### PR TITLE
Configure clang-tidy and various improvements

### DIFF
--- a/.github/workflows/dev_build.sh
+++ b/.github/workflows/dev_build.sh
@@ -67,7 +67,3 @@ export DREDD_SKIP_BASH=1
 source ./dev_shell.sh.template
 
 check_all.sh
-
-# Run the unit tests
-./temp/build-Debug/src/libdreddtest/libdreddtest
-./temp/build-Release/src/libdreddtest/libdreddtest

--- a/scripts/check_build.sh
+++ b/scripts/check_build.sh
@@ -32,9 +32,8 @@ for CONFIG in Debug Release; do
 
     cmake --build . --config "${CONFIG}"
 
-    # TODO(afd): Enable once tests are in place
     # Run the unit tests
-    #./src/libdreddtest/libdreddtest
+    ./src/libdreddtest/libdreddtest
 
     check_compile_commands.sh compile_commands.json
 

--- a/scripts/check_compile_commands.sh
+++ b/scripts/check_compile_commands.sh
@@ -20,7 +20,7 @@ set -x
 
 if [ -z "${DREDD_SKIP_CHECK_COMPILE_COMMANDS+x}" ]
 then
-  check_clang_tidy.sh "${1}"
   check_cppcheck.sh "${1}"
   check_iwyu.sh "${1}"
+  check_clang_tidy.sh "${1}"
 fi

--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -1,0 +1,40 @@
+---
+Checks: >
+  -*,
+  llvm-header-guard,
+  cppcoreguidelines-*,
+  clang-analyser-*,
+  google-*,
+  modernize-*,
+  portability-*,
+  readability-*,
+  misc-*,
+  -google-objc-*,
+  -modernize-use-trailing-return-type,
+  -cppcoreguidelines-init-variables,
+  -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+  -cppcoreguidelines-pro-bounds-pointer-arithmetic,
+  -cppcoreguidelines-pro-type-vararg,
+  -readability-simplify-boolean-expr,
+  -readability-use-anyofallof,
+  -misc-no-recursion,
+
+  # It is quite common to implement a method as a series of checks
+  # with returns, with a final return true at the end.  This check
+  # forces the final "if(c) { return false} return true;" to be
+  # turned into "return !c", which isn't always clearer.
+  #-readability-simplify-boolean-expr,
+
+  # In this project we often think that using a good old for loop is
+  # more readable than using a lambda, especially if you want to be
+  # able to early-exit from the loop.
+  #-readability-use-anyofallof,
+
+  # Recursion is used a lot by design
+  #-misc-no-recursion,
+
+WarningsAsErrors: '*'
+HeaderFilterRegex: '.*dredd.*'
+AnalyzeTemporaryDtors: false
+FormatStyle:     file
+...

--- a/src/dredd/src/main.cc
+++ b/src/dredd/src/main.cc
@@ -20,6 +20,7 @@
 
 #include "clang/Tooling/CommonOptionsParser.h"
 #include "clang/Tooling/Tooling.h"
+#include "libdredd/mersenne_random_generator.h"
 #include "libdredd/new_mutate_frontend_action_factory.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
@@ -39,15 +40,20 @@
 #endif
 
 // Set up the command line options
+// NOLINTNEXTLINE
 static llvm::cl::extrahelp common_help(
     clang::tooling::CommonOptionsParser::HelpMessage);
+// NOLINTNEXTLINE
 static llvm::cl::OptionCategory mutate_category("mutate options");
+// NOLINTNEXTLINE
 static llvm::cl::opt<std::string> output_filename(
     "o", llvm::cl::desc("Specify output filename"),
     llvm::cl::value_desc("filename"));
+// NOLINTNEXTLINE
 static llvm::cl::opt<std::string> seed(
     "seed", llvm::cl::desc("Specify seed for random number generation"),
     llvm::cl::value_desc("seed"));
+// NOLINTNEXTLINE
 static llvm::cl::opt<std::string> num_mutations(
     "num_mutations", llvm::cl::desc("Specify number of mutations to apply"),
     llvm::cl::value_desc("num_mutations"));
@@ -89,7 +95,8 @@ int main(int argc, const char** argv) {
                           ? static_cast<size_t>(std::random_device()())
                           : static_cast<size_t>(std::stoi(seed.getValue()));
 
-  std::mt19937 generator(seed_value);
+  std::mt19937 twister(seed_value);
+  dredd::MersenneRandomGenerator generator(twister);
 
   std::unique_ptr<clang::tooling::FrontendActionFactory> factory =
       dredd::NewMutateFrontendActionFactory(

--- a/src/libdredd/CMakeLists.txt
+++ b/src/libdredd/CMakeLists.txt
@@ -16,16 +16,20 @@ cmake_minimum_required(VERSION 3.13)
 
 add_library(
   libdredd STATIC
+  include/libdredd/mersenne_random_generator.h
   include/libdredd/mutation.h
   include/libdredd/mutation_replace_eager_binary_operator.h
   include/libdredd/new_mutate_frontend_action_factory.h
+  include/libdredd/random_generator.h
   include_private/include/libdredd/mutate_ast_consumer.h
   include_private/include/libdredd/mutate_visitor.h
+  src/mersenne_random_generator.cc
   src/mutate_ast_consumer.cc
   src/mutate_visitor.cc
   src/mutation.cc
   src/mutation_replace_eager_binary_operator.cc
-  src/new_mutate_frontend_action_factory.cc)
+  src/new_mutate_frontend_action_factory.cc
+  src/random_generator.cc)
 
 target_include_directories(
   libdredd

--- a/src/libdredd/include/libdredd/mersenne_random_generator.h
+++ b/src/libdredd/include/libdredd/mersenne_random_generator.h
@@ -12,33 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBDREDD_MUTATION_H
-#define LIBDREDD_MUTATION_H
+#ifndef LIBDREDD_MERSENNE_RANDOM_GENERATOR_H_
+#define LIBDREDD_MERSENNE_RANDOM_GENERATOR_H_
 
-#include "clang/AST/PrettyPrinter.h"
-#include "clang/Rewrite/Core/Rewriter.h"
+#include <cstddef>
+#include <random>
+
+#include "libdredd/random_generator.h"
 
 namespace dredd {
 
-// Interface that source code mutations should implement.
-class Mutation {
+class MersenneRandomGenerator : public RandomGenerator {
  public:
-  Mutation() = default;
+  explicit MersenneRandomGenerator(std::mt19937& twister);
 
-  Mutation(const Mutation&) = delete;
+  size_t GetSize(size_t bound) override;
 
-  Mutation& operator=(const Mutation&) = delete;
-
-  Mutation(Mutation&&) = delete;
-
-  Mutation& operator=(Mutation&&) = delete;
-
-  virtual ~Mutation();
-
-  virtual void Apply(int mutation_id, clang::Rewriter& rewriter,
-                     clang::PrintingPolicy& printing_policy) const = 0;
+ private:
+  std::mt19937& twister_;
 };
 
 }  // namespace dredd
 
-#endif  // LIBDREDD_MUTATION_H
+#endif  // LIBDREDD_MERSENNE_RANDOM_GENERATOR_H_

--- a/src/libdredd/include/libdredd/mutation_replace_eager_binary_operator.h
+++ b/src/libdredd/include/libdredd/mutation_replace_eager_binary_operator.h
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef DREDD_MUTATION_REPLACE_EAGER_BINARY_OPERATOR_H
-#define DREDD_MUTATION_REPLACE_EAGER_BINARY_OPERATOR_H
+#ifndef LIBDREDD_MUTATION_REPLACE_EAGER_BINARY_OPERATOR_H
+#define LIBDREDD_MUTATION_REPLACE_EAGER_BINARY_OPERATOR_H
 
 #include "clang/AST/Decl.h"
 #include "clang/AST/Expr.h"
+#include "clang/AST/OperationKinds.h"
 #include "clang/AST/PrettyPrinter.h"
 #include "clang/Rewrite/Core/Rewriter.h"
 #include "libdredd/mutation.h"
@@ -27,7 +28,8 @@ class MutationReplaceEagerBinaryOperator : public Mutation {
  public:
   MutationReplaceEagerBinaryOperator(
       const clang::BinaryOperator& binary_operator,
-      const clang::FunctionDecl& enclosing_function);
+      const clang::FunctionDecl& enclosing_function,
+      clang::BinaryOperatorKind new_operator);
 
   void Apply(int mutation_id, clang::Rewriter& rewriter,
              clang::PrintingPolicy& printing_policy) const override;
@@ -35,8 +37,9 @@ class MutationReplaceEagerBinaryOperator : public Mutation {
  private:
   const clang::BinaryOperator& binary_operator_;
   const clang::FunctionDecl& enclosing_function_;
+  clang::BinaryOperatorKind new_operator_;
 };
 
 }  // namespace dredd
 
-#endif  // DREDD_MUTATION_REPLACE_EAGER_BINARY_OPERATOR_H
+#endif  // LIBDREDD_MUTATION_REPLACE_EAGER_BINARY_OPERATOR_H

--- a/src/libdredd/include/libdredd/new_mutate_frontend_action_factory.h
+++ b/src/libdredd/include/libdredd/new_mutate_frontend_action_factory.h
@@ -12,23 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef DREDD_NEW_MUTATE_FRONTEND_ACTION_FACTORY_H
-#define DREDD_NEW_MUTATE_FRONTEND_ACTION_FACTORY_H
+#ifndef LIBDREDD_NEW_MUTATE_FRONTEND_ACTION_FACTORY_H
+#define LIBDREDD_NEW_MUTATE_FRONTEND_ACTION_FACTORY_H
 
 #include <cstddef>
 #include <memory>
-#include <random>
 #include <string>
 
 #include "clang/Tooling/Tooling.h"
+#include "libdredd/random_generator.h"
 
 namespace dredd {
 
 std::unique_ptr<clang::tooling::FrontendActionFactory>
 NewMutateFrontendActionFactory(size_t num_mutations,
                                const std::string& output_filename,
-                               std::mt19937& generator);
+                               RandomGenerator& generator);
 
 }
 
-#endif  // DREDD_NEW_MUTATE_FRONTEND_ACTION_FACTORY_H
+#endif  // LIBDREDD_NEW_MUTATE_FRONTEND_ACTION_FACTORY_H

--- a/src/libdredd/include/libdredd/random_generator.h
+++ b/src/libdredd/include/libdredd/random_generator.h
@@ -1,0 +1,48 @@
+// Copyright 2022 The Dredd Project Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LIBDREDD_RANDOM_GENERATOR_H_
+#define LIBDREDD_RANDOM_GENERATOR_H_
+
+#include <cstddef>
+#include <vector>
+
+namespace dredd {
+
+class RandomGenerator {
+ public:
+  RandomGenerator() = default;
+
+  virtual ~RandomGenerator();
+
+  RandomGenerator(RandomGenerator&&) = delete;
+
+  RandomGenerator(const RandomGenerator&) = delete;
+
+  RandomGenerator& operator=(const RandomGenerator&) = delete;
+
+  RandomGenerator& operator=(RandomGenerator&&) = delete;
+
+  // Returns a size in the range [0, bound)
+  virtual size_t GetSize(size_t bound) = 0;
+
+  template <typename T>
+  inline T GetRandomElement(const std::vector<T>& vec) {
+    return vec[GetSize(vec.size())];
+  }
+};
+
+}  // namespace dredd
+
+#endif  // LIBDREDD_RANDOM_GENERATOR_H_

--- a/src/libdredd/include_private/include/libdredd/mutate_ast_consumer.h
+++ b/src/libdredd/include_private/include/libdredd/mutate_ast_consumer.h
@@ -12,12 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef DREDD_MUTATE_AST_CONSUMER_H
-#define DREDD_MUTATE_AST_CONSUMER_H
+#ifndef LIBDREDD_MUTATE_AST_CONSUMER_H
+#define LIBDREDD_MUTATE_AST_CONSUMER_H
 
 #include <cstddef>
 #include <memory>
-#include <random>
 #include <string>
 
 #include "clang/AST/ASTConsumer.h"
@@ -25,6 +24,7 @@
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Rewrite/Core/Rewriter.h"
 #include "libdredd/mutate_visitor.h"
+#include "libdredd/random_generator.h"
 
 namespace dredd {
 
@@ -32,12 +32,13 @@ class MutateAstConsumer : public clang::ASTConsumer {
  public:
   MutateAstConsumer(const clang::CompilerInstance& compiler_instance,
                     size_t num_mutations, const std::string& output_file,
-                    std::mt19937& generator)
+                    RandomGenerator& generator)
       : compiler_instance_(compiler_instance),
         num_mutations_(num_mutations),
         output_file_(output_file),
         generator_(generator),
-        visitor_(std::make_unique<MutateVisitor>(compiler_instance)) {}
+        visitor_(std::make_unique<MutateVisitor>(
+            compiler_instance.getASTContext(), generator)) {}
 
   void HandleTranslationUnit(clang::ASTContext& context) override;
 
@@ -45,11 +46,11 @@ class MutateAstConsumer : public clang::ASTConsumer {
   const clang::CompilerInstance& compiler_instance_;
   const size_t num_mutations_;
   const std::string& output_file_;
-  std::mt19937& generator_;
+  RandomGenerator& generator_;
   std::unique_ptr<MutateVisitor> visitor_;
   clang::Rewriter rewriter_;
 };
 
 }  // namespace dredd
 
-#endif  // DREDD_MUTATE_AST_CONSUMER_H
+#endif  // LIBDREDD_MUTATE_AST_CONSUMER_H

--- a/src/libdredd/include_private/include/libdredd/mutate_visitor.h
+++ b/src/libdredd/include_private/include/libdredd/mutate_visitor.h
@@ -12,117 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef DREDD_MUTATE_VISITOR_H
-#define DREDD_MUTATE_VISITOR_H
+#ifndef LIBDREDD_MUTATE_VISITOR_H
+#define LIBDREDD_MUTATE_VISITOR_H
 
-#include <cassert>
 #include <memory>
 #include <vector>
 
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Decl.h"
-#include "clang/AST/DeclBase.h"
-#include "clang/AST/DeclCXX.h"
-#include "clang/AST/DeclObjC.h"
-#include "clang/AST/DeclOpenMP.h"
-#include "clang/AST/DeclTemplate.h"
 #include "clang/AST/Expr.h"
-#include "clang/AST/OpenMPClause.h"
-#include "clang/AST/OperationKinds.h"
 #include "clang/AST/RecursiveASTVisitor.h"
-#include "clang/AST/Redeclarable.h"
-#include "clang/AST/Stmt.h"
-#include "clang/AST/StmtIterator.h"
-#include "clang/AST/Type.h"
-#include "clang/Basic/SourceLocation.h"
-#include "clang/Basic/SourceManager.h"
-#include "clang/Frontend/CompilerInstance.h"
 #include "libdredd/mutation.h"
-#include "libdredd/mutation_replace_eager_binary_operator.h"
-#include "llvm/ADT/ArrayRef.h"
+#include "libdredd/random_generator.h"
 
 namespace dredd {
 
 class MutateVisitor : public clang::RecursiveASTVisitor<MutateVisitor> {
  public:
-  explicit MutateVisitor(const clang::CompilerInstance& compiler_instance);
+  MutateVisitor(const clang::ASTContext& ast_context,
+                RandomGenerator& generator);
 
-  bool TraverseFunctionDecl(clang::FunctionDecl* function_decl) {
-    // Check whether this function declaration is in the main source file. If it
-    // is not, do not traverse it. If it is, record that it is the enclosing
-    // function while traversing it, so that declarations arising from mutations
-    // inside the function can be inserted directly before it.
+  bool TraverseFunctionDecl(clang::FunctionDecl* function_decl);
 
-    const clang::SourceManager& source_manager =
-        ast_context_.getSourceManager();
-    auto begin_file_id =
-        source_manager.getFileID(function_decl->getSourceRange().getBegin());
-    auto end_file_id =
-        source_manager.getFileID(function_decl->getSourceRange().getEnd());
-    auto main_file_id = source_manager.getMainFileID();
-    if (begin_file_id != main_file_id || end_file_id != main_file_id) {
-      // This indicates either that the function is not in the main file, or
-      // that it is inside a macro. Either way, skip it.
-      return true;
-    }
-    // Traverse the function, recording that it is the enclosing function during
-    // traversal.
-    assert(enclosing_function_ == nullptr);
-    enclosing_function_ = function_decl;
-    RecursiveASTVisitor::TraverseFunctionDecl(function_decl);
-    assert(enclosing_function_ == function_decl);
-    enclosing_function_ = nullptr;
-    return true;
-  }
-
-  bool TraverseBinaryOperator(clang::BinaryOperator* binary_operator) {
-    // As a proof of concept, this records opportunities to turn a + node into a
-    // - node.
-
-    // In order to ensure that mutation opportunities are presented bottom-up,
-    // traverse the AST node before processing it.
-    RecursiveASTVisitor<MutateVisitor>::TraverseBinaryOperator(binary_operator);
-
-    // First, check that the binary expression and its arguments have source
-    // ranges that are part of the main file. In particular, this avoids
-    // mutating expressions that directly involve the use of macros (though it
-    // is OK if sub-expressions of arguments use macros).
-    const clang::SourceManager& source_manager =
-        ast_context_.getSourceManager();
-    auto begin_file_id =
-        source_manager.getFileID(binary_operator->getSourceRange().getBegin());
-    auto end_file_id =
-        source_manager.getFileID(binary_operator->getSourceRange().getEnd());
-
-    auto lhs_begin_file_id = source_manager.getFileID(
-        binary_operator->getLHS()->getSourceRange().getBegin());
-    auto lhs_end_file_id = source_manager.getFileID(
-        binary_operator->getLHS()->getSourceRange().getEnd());
-
-    auto rhs_begin_file_id = source_manager.getFileID(
-        binary_operator->getRHS()->getSourceRange().getBegin());
-    auto rhs_end_file_id = source_manager.getFileID(
-        binary_operator->getRHS()->getSourceRange().getEnd());
-
-    auto main_file_id = source_manager.getMainFileID();
-
-    // TODO(afd): It is likely that a lot of checks such as this will be
-    // required throughout the code-base, so a helper function would make sense.
-    if (!(main_file_id == begin_file_id && main_file_id == end_file_id &&
-          main_file_id == lhs_begin_file_id &&
-          main_file_id == lhs_end_file_id &&
-          main_file_id == rhs_begin_file_id &&
-          main_file_id == rhs_end_file_id)) {
-      return true;
-    }
-    // At the moment, restrict attention to +
-    if (binary_operator->getOpcode() != clang::BinaryOperatorKind::BO_Add) {
-      return true;
-    }
-    mutations_.push_back(std::make_unique<MutationReplaceEagerBinaryOperator>(
-        *binary_operator, *enclosing_function_));
-    return true;
-  }
+  bool TraverseBinaryOperator(clang::BinaryOperator* binary_operator);
 
   [[nodiscard]] const std::vector<std::unique_ptr<Mutation>>& GetMutations()
       const {
@@ -131,6 +43,9 @@ class MutateVisitor : public clang::RecursiveASTVisitor<MutateVisitor> {
 
  private:
   const clang::ASTContext& ast_context_;
+
+  // Used to randomize the creation of mutations.
+  RandomGenerator& generator_;
 
   // Tracks the function currently being traversed; nullptr if there is no such
   // function.
@@ -143,4 +58,4 @@ class MutateVisitor : public clang::RecursiveASTVisitor<MutateVisitor> {
 
 }  // namespace dredd
 
-#endif  // DREDD_MUTATE_VISITOR_H
+#endif  // LIBDREDD_MUTATE_VISITOR_H

--- a/src/libdredd/src/mersenne_random_generator.cc
+++ b/src/libdredd/src/mersenne_random_generator.cc
@@ -12,33 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBDREDD_MUTATION_H
-#define LIBDREDD_MUTATION_H
+#include "libdredd/mersenne_random_generator.h"
 
-#include "clang/AST/PrettyPrinter.h"
-#include "clang/Rewrite/Core/Rewriter.h"
+#include <cassert>
 
 namespace dredd {
 
-// Interface that source code mutations should implement.
-class Mutation {
- public:
-  Mutation() = default;
+MersenneRandomGenerator::MersenneRandomGenerator(std::mt19937& twister)
+    : twister_(twister) {}
 
-  Mutation(const Mutation&) = delete;
-
-  Mutation& operator=(const Mutation&) = delete;
-
-  Mutation(Mutation&&) = delete;
-
-  Mutation& operator=(Mutation&&) = delete;
-
-  virtual ~Mutation();
-
-  virtual void Apply(int mutation_id, clang::Rewriter& rewriter,
-                     clang::PrintingPolicy& printing_policy) const = 0;
-};
+size_t MersenneRandomGenerator::GetSize(size_t bound) {
+  assert(bound > 0 && "Bound must be positive");
+  return std::uniform_int_distribution<size_t>(0, bound - 1)(twister_);
+}
 
 }  // namespace dredd
-
-#endif  // LIBDREDD_MUTATION_H

--- a/src/libdredd/src/mutate_ast_consumer.cc
+++ b/src/libdredd/src/mutate_ast_consumer.cc
@@ -51,7 +51,7 @@ void MutateAstConsumer::HandleTranslationUnit(clang::ASTContext& context) {
   // fashion. This property should be preserved when the specific replacements
   // are made at random, to avoid attempts to rewrite a child node after its
   // parent has been rewritten.
-  for (auto& replacement : visitor_->GetMutations()) {
+  for (const auto& replacement : visitor_->GetMutations()) {
     replacement->Apply(count, rewriter_, printing_policy);
     count++;
   }

--- a/src/libdredd/src/mutate_visitor.cc
+++ b/src/libdredd/src/mutate_visitor.cc
@@ -14,12 +14,152 @@
 
 #include "libdredd/mutate_visitor.h"
 
-#include "clang/Frontend/CompilerInstance.h"
+#include <algorithm>
+#include <cassert>
+
+#include "clang/AST/ASTContext.h"
+#include "clang/AST/Decl.h"
+#include "clang/AST/DeclBase.h"
+#include "clang/AST/DeclCXX.h"
+#include "clang/AST/DeclObjC.h"
+#include "clang/AST/DeclOpenMP.h"
+#include "clang/AST/DeclTemplate.h"
+#include "clang/AST/Expr.h"
+#include "clang/AST/OpenMPClause.h"
+#include "clang/AST/OperationKinds.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/AST/Redeclarable.h"
+#include "clang/AST/Stmt.h"
+#include "clang/AST/StmtIterator.h"
+#include "clang/AST/Type.h"
+#include "clang/Basic/SourceLocation.h"
+#include "clang/Basic/SourceManager.h"
+#include "libdredd/mutation_replace_eager_binary_operator.h"
+#include "llvm/ADT/ArrayRef.h"
 
 namespace dredd {
 
-MutateVisitor::MutateVisitor(const clang::CompilerInstance& compiler_instance)
-    : ast_context_(compiler_instance.getASTContext()),
+MutateVisitor::MutateVisitor(const clang::ASTContext& ast_context,
+                             RandomGenerator& generator)
+    : ast_context_(ast_context),
+      generator_(generator),
       enclosing_function_(nullptr) {}
+
+bool MutateVisitor::TraverseFunctionDecl(clang::FunctionDecl* function_decl) {
+  // Check whether this function declaration is in the main source file. If it
+  // is not, do not traverse it. If it is, record that it is the enclosing
+  // function while traversing it, so that declarations arising from mutations
+  // inside the function can be inserted directly before it.
+
+  const clang::SourceManager& source_manager = ast_context_.getSourceManager();
+  auto begin_file_id =
+      source_manager.getFileID(function_decl->getSourceRange().getBegin());
+  auto end_file_id =
+      source_manager.getFileID(function_decl->getSourceRange().getEnd());
+  auto main_file_id = source_manager.getMainFileID();
+  if (begin_file_id != main_file_id || end_file_id != main_file_id) {
+    // This indicates either that the function is not in the main file, or
+    // that it is inside a macro. Either way, skip it.
+    return true;
+  }
+  // Traverse the function, recording that it is the enclosing function during
+  // traversal.
+  assert(enclosing_function_ == nullptr);
+  enclosing_function_ = function_decl;
+  RecursiveASTVisitor::TraverseFunctionDecl(function_decl);
+  assert(enclosing_function_ == function_decl);
+  enclosing_function_ = nullptr;
+  return true;
+}
+
+bool MutateVisitor::TraverseBinaryOperator(
+    clang::BinaryOperator* binary_operator) {
+  // As a proof of concept, this records opportunities to turn a + node into a
+  // - node.
+
+  // In order to ensure that mutation opportunities are presented bottom-up,
+  // traverse the AST node before processing it.
+  RecursiveASTVisitor<MutateVisitor>::TraverseBinaryOperator(binary_operator);
+
+  // Check that the binary expression and its arguments have source
+  // ranges that are part of the main file. In particular, this avoids
+  // mutating expressions that directly involve the use of macros (though it
+  // is OK if sub-expressions of arguments use macros).
+  const clang::SourceManager& source_manager = ast_context_.getSourceManager();
+  auto begin_file_id =
+      source_manager.getFileID(binary_operator->getSourceRange().getBegin());
+  auto end_file_id =
+      source_manager.getFileID(binary_operator->getSourceRange().getEnd());
+
+  auto lhs_begin_file_id = source_manager.getFileID(
+      binary_operator->getLHS()->getSourceRange().getBegin());
+  auto lhs_end_file_id = source_manager.getFileID(
+      binary_operator->getLHS()->getSourceRange().getEnd());
+
+  auto rhs_begin_file_id = source_manager.getFileID(
+      binary_operator->getRHS()->getSourceRange().getBegin());
+  auto rhs_end_file_id = source_manager.getFileID(
+      binary_operator->getRHS()->getSourceRange().getEnd());
+
+  auto main_file_id = source_manager.getMainFileID();
+
+  // TODO(afd): It is likely that a lot of checks such as this will be
+  // required throughout the code-base, so a helper function would make sense.
+  if (!(main_file_id == begin_file_id && main_file_id == end_file_id &&
+        main_file_id == lhs_begin_file_id && main_file_id == lhs_end_file_id &&
+        main_file_id == rhs_begin_file_id && main_file_id == rhs_end_file_id)) {
+    return true;
+  }
+
+  // We only want to change operators for binary operations on basic types.
+  // In particular, we do not want to mess with pointer arithmetic.
+  const auto* result_type =
+      binary_operator->getType()->getAs<clang::BuiltinType>();
+  if (result_type == nullptr || !result_type->isInteger()) {
+    return true;
+  }
+  const auto* lhs_type =
+      binary_operator->getLHS()->getType()->getAs<clang::BuiltinType>();
+  if (lhs_type == nullptr || !lhs_type->isInteger()) {
+    return true;
+  }
+  const auto* rhs_type =
+      binary_operator->getRHS()->getType()->getAs<clang::BuiltinType>();
+  if (rhs_type == nullptr || !rhs_type->isInteger()) {
+    return true;
+  }
+
+  std::vector<clang::BinaryOperatorKind> available_operators = {
+      clang::BinaryOperatorKind::BO_Mul,  clang::BinaryOperatorKind::BO_Div,
+      clang::BinaryOperatorKind::BO_Rem,  clang::BinaryOperatorKind::BO_Add,
+      clang::BinaryOperatorKind::BO_Sub,  clang::BinaryOperatorKind::BO_Shl,
+      clang::BinaryOperatorKind::BO_Shr,  clang::BinaryOperatorKind::BO_LT,
+      clang::BinaryOperatorKind::BO_GT,   clang::BinaryOperatorKind::BO_LE,
+      clang::BinaryOperatorKind::BO_GE,   clang::BinaryOperatorKind::BO_EQ,
+      clang::BinaryOperatorKind::BO_NE,   clang::BinaryOperatorKind::BO_And,
+      clang::BinaryOperatorKind::BO_Xor,  clang::BinaryOperatorKind::BO_Or,
+      clang::BinaryOperatorKind::BO_LAnd, clang::BinaryOperatorKind::BO_LOr};
+  if (binary_operator->getLHS()->isLValue()) {
+    available_operators.push_back(clang::BinaryOperatorKind::BO_Assign);
+    available_operators.push_back(clang::BinaryOperatorKind::BO_MulAssign);
+    available_operators.push_back(clang::BinaryOperatorKind::BO_DivAssign);
+    available_operators.push_back(clang::BinaryOperatorKind::BO_RemAssign);
+    available_operators.push_back(clang::BinaryOperatorKind::BO_AddAssign);
+    available_operators.push_back(clang::BinaryOperatorKind::BO_SubAssign);
+    available_operators.push_back(clang::BinaryOperatorKind::BO_ShlAssign);
+    available_operators.push_back(clang::BinaryOperatorKind::BO_ShrAssign);
+    available_operators.push_back(clang::BinaryOperatorKind::BO_AndAssign);
+    available_operators.push_back(clang::BinaryOperatorKind::BO_XorAssign);
+    available_operators.push_back(clang::BinaryOperatorKind::BO_OrAssign);
+  }
+  available_operators.erase(std::find(available_operators.begin(),
+                                      available_operators.end(),
+                                      binary_operator->getOpcode()));
+
+  mutations_.push_back(std::make_unique<MutationReplaceEagerBinaryOperator>(
+      *binary_operator, *enclosing_function_,
+      generator_.GetRandomElement(available_operators)));
+  return true;
+}
 
 }  // namespace dredd

--- a/src/libdredd/src/new_mutate_frontend_action_factory.cc
+++ b/src/libdredd/src/new_mutate_frontend_action_factory.cc
@@ -26,7 +26,7 @@ namespace dredd {
 class MutateFrontendAction : public clang::ASTFrontendAction {
  public:
   MutateFrontendAction(size_t num_mutations, const std::string& output_file,
-                       std::mt19937& generator)
+                       RandomGenerator& generator)
       : num_mutations_(num_mutations),
         output_file_(output_file),
         generator_(generator) {}
@@ -37,19 +37,19 @@ class MutateFrontendAction : public clang::ASTFrontendAction {
  private:
   const size_t num_mutations_;
   const std::string& output_file_;
-  std::mt19937& generator_;
+  RandomGenerator& generator_;
 };
 
 std::unique_ptr<clang::tooling::FrontendActionFactory>
 NewMutateFrontendActionFactory(size_t num_mutations,
                                const std::string& output_filename,
-                               std::mt19937& generator) {
+                               RandomGenerator& generator) {
   class MutateFrontendActionFactory
       : public clang::tooling::FrontendActionFactory {
    public:
     MutateFrontendActionFactory(size_t num_mutations,
                                 const std::string& output_filename,
-                                std::mt19937& generator)
+                                RandomGenerator& generator)
         : num_mutations_(num_mutations),
           output_filename_(output_filename),
           generator_(generator) {}
@@ -62,7 +62,7 @@ NewMutateFrontendActionFactory(size_t num_mutations,
    private:
     size_t num_mutations_;
     const std::string& output_filename_;
-    std::mt19937& generator_;
+    RandomGenerator& generator_;
   };
 
   return std::make_unique<MutateFrontendActionFactory>(

--- a/src/libdredd/src/random_generator.cc
+++ b/src/libdredd/src/random_generator.cc
@@ -12,33 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBDREDD_MUTATION_H
-#define LIBDREDD_MUTATION_H
-
-#include "clang/AST/PrettyPrinter.h"
-#include "clang/Rewrite/Core/Rewriter.h"
+#include "libdredd/random_generator.h"
 
 namespace dredd {
 
-// Interface that source code mutations should implement.
-class Mutation {
- public:
-  Mutation() = default;
-
-  Mutation(const Mutation&) = delete;
-
-  Mutation& operator=(const Mutation&) = delete;
-
-  Mutation(Mutation&&) = delete;
-
-  Mutation& operator=(Mutation&&) = delete;
-
-  virtual ~Mutation();
-
-  virtual void Apply(int mutation_id, clang::Rewriter& rewriter,
-                     clang::PrintingPolicy& printing_policy) const = 0;
-};
+RandomGenerator::~RandomGenerator() = default;
 
 }  // namespace dredd
-
-#endif  // LIBDREDD_MUTATION_H

--- a/src/libdreddtest/.clang-tidy
+++ b/src/libdreddtest/.clang-tidy
@@ -1,0 +1,7 @@
+---
+Checks: >
+  -cppcoreguidelines-owning-memory,
+  -cppcoreguidelines-avoid-non-const-global-variables,
+
+InheritParentConfig: true
+...

--- a/src/libdreddtest/src/mutation_replace_eager_binary_operator_test.cc
+++ b/src/libdreddtest/src/mutation_replace_eager_binary_operator_test.cc
@@ -19,6 +19,7 @@
 
 #include "clang/AST/Decl.h"
 #include "clang/AST/Expr.h"
+#include "clang/AST/OperationKinds.h"
 #include "clang/AST/PrettyPrinter.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "clang/ASTMatchers/ASTMatchers.h"
@@ -38,11 +39,11 @@ namespace {
 TEST(MutationReplaceEagerBinaryOperatorTest, BasicTest) {
   std::string original = "void foo() { 1 + 2; }";
   std::string expected = R"(
-int __dredd_add_to_sub_0(int arg1, int arg2) {
+int __dredd_replace_eager_binary_operator_0(int arg1, int arg2) {
   return arg1 - arg2;
 }
 
-void foo() { __dredd_add_to_sub_0(1, 2); })";
+void foo() { __dredd_replace_eager_binary_operator_0(1, 2); })";
   auto ast_unit = clang::tooling::buildASTFromCodeWithArgs(original, {"-w"});
   ASSERT_FALSE(ast_unit->getDiagnostics().hasErrorOccurred());
   auto function_decl = clang::ast_matchers::match(
@@ -58,7 +59,8 @@ void foo() { __dredd_add_to_sub_0(1, 2); })";
 
   MutationReplaceEagerBinaryOperator mutation(
       *binary_operator[0].getNodeAs<clang::BinaryOperator>("op"),
-      *function_decl[0].getNodeAs<clang::FunctionDecl>("fn"));
+      *function_decl[0].getNodeAs<clang::FunctionDecl>("fn"),
+      clang::BinaryOperatorKind::BO_Sub);
 
   clang::Rewriter rewriter(ast_unit->getSourceManager(),
                            ast_unit->getLangOpts());


### PR DESCRIPTION
Properly configures clang-tidy, fixing many associated warnings.

Adds a random number generation interface and uses it to make
operator replacement randomized.

Fixes #7.