### PR TITLE
Allow mutations in certain macro contexts

### DIFF
--- a/src/libdredd/CMakeLists.txt
+++ b/src/libdredd/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(
   include/libdredd/new_mutate_frontend_action_factory.h
   include_private/include/libdredd/mutate_ast_consumer.h
   include_private/include/libdredd/mutate_visitor.h
+  include_private/include/libdredd/util.h
   src/mutate_ast_consumer.cc
   src/mutate_visitor.cc
   src/mutation.cc

--- a/src/libdredd/include/libdredd/mutation.h
+++ b/src/libdredd/include/libdredd/mutation.h
@@ -16,6 +16,7 @@
 #define LIBDREDD_MUTATION_H
 
 #include "clang/AST/ASTContext.h"
+#include "clang/Lex/Preprocessor.h"
 #include "clang/Rewrite/Core/Rewriter.h"
 
 namespace dredd {
@@ -35,7 +36,8 @@ class Mutation {
 
   virtual ~Mutation();
 
-  virtual void Apply(clang::ASTContext& ast_context, int& mutation_id,
+  virtual void Apply(clang::ASTContext& ast_context,
+                     const clang::Preprocessor& preprocessor, int& mutation_id,
                      clang::Rewriter& rewriter) const = 0;
 };
 

--- a/src/libdredd/include/libdredd/mutation_remove_statement.h
+++ b/src/libdredd/include/libdredd/mutation_remove_statement.h
@@ -17,6 +17,7 @@
 
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Stmt.h"
+#include "clang/Lex/Preprocessor.h"
 #include "clang/Rewrite/Core/Rewriter.h"
 #include "libdredd/mutation.h"
 
@@ -26,7 +27,8 @@ class MutationRemoveStatement : public Mutation {
  public:
   explicit MutationRemoveStatement(const clang::Stmt& statement);
 
-  void Apply(clang::ASTContext& ast_context, int& mutation_id,
+  void Apply(clang::ASTContext& ast_context,
+             const clang::Preprocessor& preprocessor, int& mutation_id,
              clang::Rewriter& rewriter) const override;
 
  private:

--- a/src/libdredd/include/libdredd/mutation_replace_binary_operator.h
+++ b/src/libdredd/include/libdredd/mutation_replace_binary_operator.h
@@ -22,6 +22,7 @@
 #include "clang/AST/DeclBase.h"
 #include "clang/AST/Expr.h"
 #include "clang/AST/OperationKinds.h"
+#include "clang/Lex/Preprocessor.h"
 #include "clang/Rewrite/Core/Rewriter.h"
 #include "libdredd/mutation.h"
 
@@ -32,7 +33,8 @@ class MutationReplaceBinaryOperator : public Mutation {
   MutationReplaceBinaryOperator(const clang::BinaryOperator& binary_operator,
                                 const clang::Decl& enclosing_decl);
 
-  void Apply(clang::ASTContext& ast_context, int& mutation_id,
+  void Apply(clang::ASTContext& ast_context,
+             const clang::Preprocessor& preprocessor, int& mutation_id,
              clang::Rewriter& rewriter) const override;
 
  private:

--- a/src/libdredd/include_private/include/libdredd/mutate_ast_consumer.h
+++ b/src/libdredd/include_private/include/libdredd/mutate_ast_consumer.h
@@ -30,8 +30,7 @@ class MutateAstConsumer : public clang::ASTConsumer {
   MutateAstConsumer(const clang::CompilerInstance& compiler_instance,
                     int& mutation_id)
       : compiler_instance_(compiler_instance),
-        visitor_(
-            std::make_unique<MutateVisitor>(compiler_instance.getASTContext())),
+        visitor_(std::make_unique<MutateVisitor>(compiler_instance)),
         mutation_id_(mutation_id) {}
 
   void HandleTranslationUnit(clang::ASTContext& context) override;

--- a/src/libdredd/include_private/include/libdredd/mutate_visitor.h
+++ b/src/libdredd/include_private/include/libdredd/mutate_visitor.h
@@ -19,18 +19,18 @@
 #include <unordered_set>
 #include <vector>
 
-#include "clang/AST/ASTContext.h"
 #include "clang/AST/DeclBase.h"
 #include "clang/AST/Expr.h"
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/Stmt.h"
+#include "clang/Frontend/CompilerInstance.h"
 #include "libdredd/mutation.h"
 
 namespace dredd {
 
 class MutateVisitor : public clang::RecursiveASTVisitor<MutateVisitor> {
  public:
-  explicit MutateVisitor(const clang::ASTContext& ast_context);
+  explicit MutateVisitor(const clang::CompilerInstance& compiler_instance);
 
   bool TraverseDecl(clang::Decl* decl);
 
@@ -51,11 +51,7 @@ class MutateVisitor : public clang::RecursiveASTVisitor<MutateVisitor> {
   }
 
  private:
-  template <typename HasSourceRange>
-  [[nodiscard]] bool StartsAndEndsInMainSourceFile(
-      const HasSourceRange& ast_node) const;
-
-  const clang::ASTContext& ast_context_;
+  const clang::CompilerInstance& compiler_instance_;
 
   // Records the very first declaration in the source file, before which
   // directives such as includes can be placed.

--- a/src/libdredd/include_private/include/libdredd/util.h
+++ b/src/libdredd/include_private/include/libdredd/util.h
@@ -1,0 +1,70 @@
+// Copyright 2022 The Dredd Project Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LIBDREDD_UTIL_H
+#define LIBDREDD_UTIL_H
+
+#include "clang/Lex/Preprocessor.h"
+
+namespace dredd {
+
+template <typename HasSourceRange>
+[[nodiscard]] clang::SourceRange GetSourceRangeInMainFile(
+    const clang::Preprocessor& preprocessor, const HasSourceRange& ast_node) {
+  const clang::SourceManager& source_manager = preprocessor.getSourceManager();
+  auto main_file_id = source_manager.getMainFileID();
+
+  clang::SourceLocation begin_loc_in_main_file;
+  clang::SourceLocation end_loc_in_main_file;
+  clang::SourceLocation macro_expansion_location;
+  {
+    clang::SourceLocation begin_loc = ast_node.getSourceRange().getBegin();
+    auto begin_file_id = source_manager.getFileID(begin_loc);
+    if (begin_file_id == main_file_id) {
+      begin_loc_in_main_file = begin_loc;
+    } else if (begin_loc.isMacroID() &&
+               preprocessor.isAtStartOfMacroExpansion(
+                   begin_loc, &macro_expansion_location) &&
+               source_manager.getFileID(macro_expansion_location) ==
+                   main_file_id) {
+      begin_loc_in_main_file = macro_expansion_location;
+    } else {
+      // There is no location in the main file corresponding to the start of the
+      // AST node.
+      return {};
+    }
+  }
+  {
+    clang::SourceLocation end_loc = ast_node.getSourceRange().getEnd();
+    auto end_file_id = source_manager.getFileID(end_loc);
+    if (end_file_id == main_file_id) {
+      end_loc_in_main_file = end_loc;
+    } else if (end_loc.isMacroID() &&
+               preprocessor.isAtEndOfMacroExpansion(
+                   end_loc, &macro_expansion_location) &&
+               source_manager.getFileID(macro_expansion_location) ==
+                   main_file_id) {
+      end_loc_in_main_file = macro_expansion_location;
+    } else {
+      // There is no location in the main file corresponding to the end of the
+      // AST node.
+      return {};
+    }
+  }
+  return {begin_loc_in_main_file, end_loc_in_main_file};
+}
+
+}  // namespace dredd
+
+#endif  // LIBDREDD_UTIL_H

--- a/src/libdredd/src/mutate_ast_consumer.cc
+++ b/src/libdredd/src/mutate_ast_consumer.cc
@@ -45,7 +45,8 @@ void MutateAstConsumer::HandleTranslationUnit(clang::ASTContext& context) {
   // parent has been rewritten.
   for (const auto& replacement : visitor_->GetMutations()) {
     int mutation_id_old = mutation_id_;
-    replacement->Apply(context, mutation_id_, rewriter_);
+    replacement->Apply(context, compiler_instance_.getPreprocessor(),
+                       mutation_id_, rewriter_);
     assert(mutation_id_ > mutation_id_old &&
            "Every mutation should lead to the mutation id increasing by at "
            "least 1.");

--- a/src/libdredd/src/mutation_remove_statement.cc
+++ b/src/libdredd/src/mutation_remove_statement.cc
@@ -21,8 +21,10 @@
 #include "clang/AST/Stmt.h"
 #include "clang/Basic/SourceLocation.h"
 #include "clang/Basic/TokenKinds.h"
+#include "clang/Lex/Preprocessor.h"
 #include "clang/Rewrite/Core/Rewriter.h"
 #include "clang/Tooling/Transformer/SourceCode.h"
+#include "libdredd/util.h"
 
 namespace dredd {
 
@@ -30,12 +32,13 @@ MutationRemoveStatement::MutationRemoveStatement(const clang::Stmt& statement)
     : statement_(statement) {}
 
 void MutationRemoveStatement::Apply(clang::ASTContext& ast_context,
+                                    const clang::Preprocessor& preprocessor,
                                     int& mutation_id,
                                     clang::Rewriter& rewriter) const {
-  clang::SourceRange source_range =
-      clang::tooling::getExtendedRange(statement_, clang::tok::TokenKind::semi,
-                                       ast_context)
-          .getAsRange();
+  clang::CharSourceRange source_range = clang::tooling::maybeExtendRange(
+      clang::CharSourceRange::getTokenRange(
+          GetSourceRangeInMainFile(preprocessor, statement_)),
+      clang::tok::TokenKind::semi, ast_context);
 
   bool result = rewriter.ReplaceText(
       source_range,


### PR DESCRIPTION
Refines the machinery for checking whether AST nodes start and end in
the main file, to support macros.

Fixes #23.