### PR TITLE
Check formatting of examples

### DIFF
--- a/examples/simple/pi.cc
+++ b/examples/simple/pi.cc
@@ -26,6 +26,4 @@ static double CalculatePi() {
   return sum * 4;
 }
 
-int main() {
-  std::cout << CalculatePi() << std::endl;
-}
+int main() { std::cout << CalculatePi() << std::endl; }

--- a/scripts/check_format.sh
+++ b/scripts/check_format.sh
@@ -25,3 +25,9 @@ for f in `dredd_cmake_files.sh`
 do
     cmake-format --first-comment-is-literal TRUE --check $f
 done
+
+examples_source_files.sh | xargs -t clang-format --dry-run --Werror
+for f in `examples_cmake_files.sh`
+do
+    cmake-format --first-comment-is-literal TRUE --check $f
+done

--- a/scripts/examples_cmake_files.sh
+++ b/scripts/examples_cmake_files.sh
@@ -18,16 +18,7 @@ set -e
 set -u
 set -x
 
-cd "${DREDD_REPO_ROOT}"
+test -d examples/
 
-dredd_source_files.sh | xargs clang-format -i --verbose
-for f in `dredd_cmake_files.sh`
-do
-    cmake-format --first-comment-is-literal TRUE -i $f
-done
-
-examples_source_files.sh | xargs clang-format -i --verbose
-for f in `examples_cmake_files.sh`
-do
-    cmake-format --first-comment-is-literal TRUE -i $f
-done
+find ./examples/ -iname 'CMakeLists.txt' -print
+echo ./CMakeLists.txt

--- a/scripts/examples_source_files.sh
+++ b/scripts/examples_source_files.sh
@@ -18,16 +18,6 @@ set -e
 set -u
 set -x
 
-cd "${DREDD_REPO_ROOT}"
+test -d examples/
 
-dredd_source_files.sh | xargs clang-format -i --verbose
-for f in `dredd_cmake_files.sh`
-do
-    cmake-format --first-comment-is-literal TRUE -i $f
-done
-
-examples_source_files.sh | xargs clang-format -i --verbose
-for f in `examples_cmake_files.sh`
-do
-    cmake-format --first-comment-is-literal TRUE -i $f
-done
+find ./examples/ '(' -iname '*.cc' -o -iname '*.h' ')' -print


### PR DESCRIPTION
Extends the Dredd format checking and fixing scripts to consider code
under the 'examples' directory.