### PR TITLE
Add single-file test framework

### DIFF
--- a/scripts/check_all.sh
+++ b/scripts/check_all.sh
@@ -23,3 +23,4 @@ check_format.sh
 check_cmakelint.sh
 check_cpplint.sh
 check_clean_build.sh
+check_single_file_tests.sh

--- a/scripts/check_headers.py
+++ b/scripts/check_headers.py
@@ -35,6 +35,7 @@ def exclude_dirname(f: str):
             "__pycache__",
             ".pytest_cache",
             ".venv",
+            "single_file"
         ]
     )
 

--- a/scripts/check_single_file_tests.sh
+++ b/scripts/check_single_file_tests.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The Dredd Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -u
+set -x
+
+if [ -z "${DREDD_SKIP_CHECK_COMPILE_COMMANDS+x}" ]
+then
+  DREDD_INSTALLED_EXECUTABLE=${DREDD_REPO_ROOT}/third_party/clang+llvm-13.0.1/bin/dredd
+  # Move to the temporary directory
+  cd "${DREDD_REPO_ROOT}"
+  cd temp/
+  # Ensure that Dredd is in its installed location. This depends on a
+  # debug build being available
+  cp build-Debug/src/dredd/dredd ${DREDD_INSTALLED_EXECUTABLE}
+  # Consider each single-file test case
+  for f in `ls ${DREDD_REPO_ROOT}/test/single_file/*.cc`
+  do
+    # Copy the single-file test case to the temporary directory so
+    # that it can be mutated without affecting the original
+    cp $f .
+    copy_of_f=$(basename $f)      
+    # Mutate the test case using Dredd
+    ${DREDD_INSTALLED_EXECUTABLE} ${copy_of_f} --
+    # Check that the mutated test case is as expected
+    diff ${copy_of_f} ${f%.*}.expected
+    # Check that the mutated file compiles
+    ${CXX} -c ${copy_of_f}
+    # Clean up
+    rm ${copy_of_f}
+    rm ${copy_of_f%.*}.o
+  done
+fi

--- a/scripts/regenerate_single_file_expectations.sh
+++ b/scripts/regenerate_single_file_expectations.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The Dredd Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -u
+set -x
+
+if [ -z "${DREDD_SKIP_CHECK_COMPILE_COMMANDS+x}" ]
+then
+  DREDD_INSTALLED_EXECUTABLE=${DREDD_REPO_ROOT}/third_party/clang+llvm-13.0.1/bin/dredd
+  # Move to the temporary directory
+  cd "${DREDD_REPO_ROOT}"
+  cd temp/
+  # Ensure that Dredd is in its installed location. This depends on a
+  # debug build being available
+  cp build-Debug/src/dredd/dredd ${DREDD_INSTALLED_EXECUTABLE}
+  # Consider each single-file test case
+  for f in `ls ${DREDD_REPO_ROOT}/test/single_file/*.cc`
+  do
+    # Copy the single-file test case to the temporary directory so
+    # that it can be mutated without affecting the original
+    cp $f .
+    copy_of_f=$(basename $f)      
+    # Mutate the test case using Dredd
+    ${DREDD_INSTALLED_EXECUTABLE} ${copy_of_f} --
+    # Check that the mutated file compiles
+    ${CXX} -c ${copy_of_f}
+    # Copy the mutated file so that it becomes the new test expectation
+    cp ${copy_of_f} ${f%.*}.expected
+    # Clean up
+    rm ${copy_of_f}
+    rm ${copy_of_f%.*}.o
+  done
+fi

--- a/test/single_file/README.md
+++ b/test/single_file/README.md
@@ -1,0 +1,19 @@
+This provides a way of confirming that Dredd behaves as expected on a
+set of single-file test cases.
+
+Whenever a new feature is added to Dredd, or a defect is discovered
+when using Dredd, a test case should be added to this test set in
+response. The test case should ensure that Dredd produces the expected
+output on a given input program.
+
+A test case consists of a `.cc` file and a corresponding `.expected`
+file.
+
+The `check_single_file_tests.sh` script can be used to run Dredd on
+all single-file test cases, confirming that results are as expected
+and that every mutated file compiles.
+
+A change in Dredd may require many of the `.expected` file to be
+updated. If you are confident that the change is a good one, the
+`regenerate_single_file_expectations.sh` can be used to update all
+such files based on Dredd's current behaviour.

--- a/test/single_file/basic.cc
+++ b/test/single_file/basic.cc
@@ -1,0 +1,3 @@
+int main() {
+  return 0;
+}

--- a/test/single_file/basic.expected
+++ b/test/single_file/basic.expected
@@ -1,0 +1,3 @@
+int main() {
+  return 0;
+}

--- a/test/single_file/basic.expected
+++ b/test/single_file/basic.expected
@@ -1,3 +1,21 @@
+#include <cstdlib>
+#include <functional>
+
+static int __dredd_enabled_mutation() {
+  static bool initialized = false;
+  static int value;
+  if (!initialized) {
+    const char* __dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
+    if (__dredd_environment_variable == nullptr) {
+      value = -1;
+    } else {
+      value = atoi(__dredd_environment_variable);
+    }
+    initialized = true;
+  }
+  return value;
+}
+
 int main() {
-  return 0;
+  if (__dredd_enabled_mutation() != 0) { return 0; }
 }

--- a/test/single_file/constexpr.cc
+++ b/test/single_file/constexpr.cc
@@ -1,0 +1,4 @@
+// Checks that operator mutations are not applied to constexprs.
+namespace foo {
+constexpr int a = -2 + ~3;
+};

--- a/test/single_file/constexpr.expected
+++ b/test/single_file/constexpr.expected
@@ -1,0 +1,4 @@
+// Checks that operator mutations are not applied to constexprs.
+namepsace foo {
+constexpr int a = -2 + ~3;
+};

--- a/test/single_file/constexpr.expected
+++ b/test/single_file/constexpr.expected
@@ -1,4 +1,22 @@
 // Checks that operator mutations are not applied to constexprs.
-namepsace foo {
+#include <cstdlib>
+#include <functional>
+
+static int __dredd_enabled_mutation() {
+  static bool initialized = false;
+  static int value;
+  if (!initialized) {
+    const char* __dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
+    if (__dredd_environment_variable == nullptr) {
+      value = -1;
+    } else {
+      value = atoi(__dredd_environment_variable);
+    }
+    initialized = true;
+  }
+  return value;
+}
+
+namespace foo {
 constexpr int a = -2 + ~3;
 };


### PR DESCRIPTION
Adds a script and corresponding initial tests to allow confirming that
Dredd performs as expected on a number of single-file test cases.
    
Fixes #45.
