### PR TITLE
Avoid duplicate mutation functions

### DIFF
--- a/src/libdredd/include/libdredd/mutation.h
+++ b/src/libdredd/include/libdredd/mutation.h
@@ -15,6 +15,9 @@
 #ifndef LIBDREDD_MUTATION_H
 #define LIBDREDD_MUTATION_H
 
+#include <string>
+#include <unordered_set>
+
 #include "clang/AST/ASTContext.h"
 #include "clang/Lex/Preprocessor.h"
 #include "clang/Rewrite/Core/Rewriter.h"
@@ -36,9 +39,13 @@ class Mutation {
 
   virtual ~Mutation();
 
-  virtual void Apply(clang::ASTContext& ast_context,
-                     const clang::Preprocessor& preprocessor, int& mutation_id,
-                     clang::Rewriter& rewriter) const = 0;
+  // The |dredd_declarations| argument provides a set of declarations that will
+  // be added to the start of the source file being mutated. This allows
+  // avoiding redundant repeat declarations.
+  virtual void Apply(
+      clang::ASTContext& ast_context, const clang::Preprocessor& preprocessor,
+      int& mutation_id, clang::Rewriter& rewriter,
+      std::unordered_set<std::string>& dredd_declarations) const = 0;
 };
 
 }  // namespace dredd

--- a/src/libdredd/include/libdredd/mutation_remove_statement.h
+++ b/src/libdredd/include/libdredd/mutation_remove_statement.h
@@ -15,6 +15,9 @@
 #ifndef LIBDREDD_MUTATION_REMOVE_STATEMENT_H
 #define LIBDREDD_MUTATION_REMOVE_STATEMENT_H
 
+#include <string>
+#include <unordered_set>
+
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Stmt.h"
 #include "clang/Lex/Preprocessor.h"
@@ -27,9 +30,10 @@ class MutationRemoveStatement : public Mutation {
  public:
   explicit MutationRemoveStatement(const clang::Stmt& statement);
 
-  void Apply(clang::ASTContext& ast_context,
-             const clang::Preprocessor& preprocessor, int& mutation_id,
-             clang::Rewriter& rewriter) const override;
+  void Apply(
+      clang::ASTContext& ast_context, const clang::Preprocessor& preprocessor,
+      int& mutation_id, clang::Rewriter& rewriter,
+      std::unordered_set<std::string>& dredd_declarations) const override;
 
  private:
   const clang::Stmt& statement_;

--- a/src/libdredd/include/libdredd/mutation_replace_binary_operator.h
+++ b/src/libdredd/include/libdredd/mutation_replace_binary_operator.h
@@ -40,7 +40,7 @@ class MutationReplaceBinaryOperator : public Mutation {
 
  private:
   std::string GenerateMutatorFunction(
-      const std::string& new_function_name, const std::string& result_type,
+      const std::string& function_name, const std::string& result_type,
       const std::string& lhs_type, const std::string& rhs_type,
       const std::vector<clang::BinaryOperatorKind>& operators,
       int& mutation_id) const;

--- a/src/libdredd/include/libdredd/mutation_replace_binary_operator.h
+++ b/src/libdredd/include/libdredd/mutation_replace_binary_operator.h
@@ -16,10 +16,10 @@
 #define LIBDREDD_MUTATION_REPLACE_BINARY_OPERATOR_H
 
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 #include "clang/AST/ASTContext.h"
-#include "clang/AST/DeclBase.h"
 #include "clang/AST/Expr.h"
 #include "clang/AST/OperationKinds.h"
 #include "clang/Lex/Preprocessor.h"
@@ -30,12 +30,13 @@ namespace dredd {
 
 class MutationReplaceBinaryOperator : public Mutation {
  public:
-  MutationReplaceBinaryOperator(const clang::BinaryOperator& binary_operator,
-                                const clang::Decl& enclosing_decl);
+  explicit MutationReplaceBinaryOperator(
+      const clang::BinaryOperator& binary_operator);
 
-  void Apply(clang::ASTContext& ast_context,
-             const clang::Preprocessor& preprocessor, int& mutation_id,
-             clang::Rewriter& rewriter) const override;
+  void Apply(
+      clang::ASTContext& ast_context, const clang::Preprocessor& preprocessor,
+      int& mutation_id, clang::Rewriter& rewriter,
+      std::unordered_set<std::string>& dredd_declarations) const override;
 
  private:
   std::string GenerateMutatorFunction(
@@ -45,7 +46,6 @@ class MutationReplaceBinaryOperator : public Mutation {
       int& mutation_id) const;
 
   const clang::BinaryOperator& binary_operator_;
-  const clang::Decl& enclosing_decl_;
 };
 
 }  // namespace dredd

--- a/src/libdredd/include/libdredd/mutation_replace_binary_operator.h
+++ b/src/libdredd/include/libdredd/mutation_replace_binary_operator.h
@@ -40,7 +40,7 @@ class MutationReplaceBinaryOperator : public Mutation {
 
  private:
   std::string GenerateMutatorFunction(
-      const std::string& function_name, const std::string& result_type,
+      const std::string& new_function_name, const std::string& result_type,
       const std::string& lhs_type, const std::string& rhs_type,
       const std::vector<clang::BinaryOperatorKind>& operators,
       int& mutation_id) const;

--- a/src/libdredd/src/mutate_ast_consumer.cc
+++ b/src/libdredd/src/mutate_ast_consumer.cc
@@ -65,6 +65,17 @@ void MutateAstConsumer::HandleTranslationUnit(clang::ASTContext& context) {
   assert(visitor_->GetFirstDeclInSourceFile() != nullptr &&
          "There is at least one mutation, therefore there must be at least one "
          "declaration.");
+
+  std::set<std::string> sorted_dredd_declarations;
+  sorted_dredd_declarations.insert(dredd_declarations.begin(),
+                                   dredd_declarations.end());
+  for (const auto& decl : sorted_dredd_declarations) {
+    bool result = rewriter_.InsertTextBefore(
+        visitor_->GetFirstDeclInSourceFile()->getBeginLoc(), decl);
+    (void)result;  // Keep release-mode compilers happy.
+    assert(!result && "Rewrite failed.\n");
+  }
+
   std::stringstream dredd_prelude;
   dredd_prelude << "#include <cstdlib>\n";
   dredd_prelude << "#include <functional>\n\n";
@@ -88,16 +99,6 @@ void MutateAstConsumer::HandleTranslationUnit(clang::ASTContext& context) {
       visitor_->GetFirstDeclInSourceFile()->getBeginLoc(), dredd_prelude.str());
   (void)result;  // Keep release-mode compilers happy.
   assert(!result && "Rewrite failed.\n");
-
-  std::set<std::string> sorted_dredd_declarations;
-  sorted_dredd_declarations.insert(dredd_declarations.begin(),
-                                   dredd_declarations.end());
-  for (const auto& decl : sorted_dredd_declarations) {
-    result = rewriter_.InsertTextBefore(
-        visitor_->GetFirstDeclInSourceFile()->getBeginLoc(), decl);
-    (void)result;  // Keep release-mode compilers happy.
-    assert(!result && "Rewrite failed.\n");
-  }
 
   result = rewriter_.overwriteChangedFiles();
   (void)result;  // Keep release mode compilers happy

--- a/src/libdredd/src/mutate_ast_consumer.cc
+++ b/src/libdredd/src/mutate_ast_consumer.cc
@@ -15,7 +15,10 @@
 #include "libdredd/mutate_ast_consumer.h"
 
 #include <cassert>
+#include <set>
 #include <sstream>
+#include <string>
+#include <unordered_set>
 #include <vector>
 
 #include "clang/AST/ASTContext.h"

--- a/src/libdredd/src/mutate_ast_consumer.cc
+++ b/src/libdredd/src/mutate_ast_consumer.cc
@@ -48,7 +48,10 @@ void MutateAstConsumer::HandleTranslationUnit(clang::ASTContext& context) {
 
   // This is used to collect the various declarations that are introduced by
   // mutations in a manner that avoids duplicates, after which they can be added
-  // to the start of the source file.
+  // to the start of the source file. As lots of duplicates are expected, an
+  // unordered set is used to facilitate efficient lookup. Later, this is
+  // converted to an ordered set so that declarations can be added to the source
+  // file in a deterministic order.
   std::unordered_set<std::string> dredd_declarations;
 
   // By construction, replacements are processed in a bottom-up fashion. This
@@ -69,6 +72,8 @@ void MutateAstConsumer::HandleTranslationUnit(clang::ASTContext& context) {
          "There is at least one mutation, therefore there must be at least one "
          "declaration.");
 
+  // Convert the unordered set Dredd declarations into an ordered set and add
+  // them to the source file before the first declaration.
   std::set<std::string> sorted_dredd_declarations;
   sorted_dredd_declarations.insert(dredd_declarations.begin(),
                                    dredd_declarations.end());

--- a/src/libdredd/src/mutate_visitor.cc
+++ b/src/libdredd/src/mutate_visitor.cc
@@ -119,8 +119,8 @@ bool MutateVisitor::VisitBinaryOperator(
     return true;
   }
 
-  mutations_.push_back(std::make_unique<MutationReplaceBinaryOperator>(
-      *binary_operator, *enclosing_decls_[0]));
+  mutations_.push_back(
+      std::make_unique<MutationReplaceBinaryOperator>(*binary_operator));
   return true;
 }
 

--- a/src/libdredd/src/mutation_remove_statement.cc
+++ b/src/libdredd/src/mutation_remove_statement.cc
@@ -16,6 +16,7 @@
 
 #include <cassert>
 #include <string>
+#include <unordered_set>
 
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Stmt.h"
@@ -31,10 +32,11 @@ namespace dredd {
 MutationRemoveStatement::MutationRemoveStatement(const clang::Stmt& statement)
     : statement_(statement) {}
 
-void MutationRemoveStatement::Apply(clang::ASTContext& ast_context,
-                                    const clang::Preprocessor& preprocessor,
-                                    int& mutation_id,
-                                    clang::Rewriter& rewriter) const {
+void MutationRemoveStatement::Apply(
+    clang::ASTContext& ast_context, const clang::Preprocessor& preprocessor,
+    int& mutation_id, clang::Rewriter& rewriter,
+    std::unordered_set<std::string>& dredd_declarations) const {
+  (void)dredd_declarations;  // Unused
   clang::CharSourceRange source_range = clang::tooling::maybeExtendRange(
       clang::CharSourceRange::getTokenRange(
           GetSourceRangeInMainFile(preprocessor, statement_)),

--- a/src/libdredd/src/mutation_replace_binary_operator.cc
+++ b/src/libdredd/src/mutation_replace_binary_operator.cc
@@ -36,15 +36,11 @@ namespace dredd {
 
 namespace {
 
+// Utility method used to avoid spaces when types, such as 'unsigned int', are
+// used in mutation function names.
 std::string SpaceToUnderscore(const std::string& input) {
-  std::string result;
-  for (auto character : input) {
-    if (character == ' ') {
-      result += "_";
-    } else {
-      result += character;
-    }
-  }
+  std::string result(input);
+  std::replace(result.begin(), result.end(), ' ', '_');
   return result;
 }
 
@@ -123,6 +119,10 @@ void MutationReplaceBinaryOperator::Apply(
     int& mutation_id, clang::Rewriter& rewriter,
     std::unordered_set<std::string>& dredd_declarations) const {
   std::string new_function_name = "__dredd_replace_binary_operator_";
+
+  // A string corresponding to the binary operator forms part of the name of the
+  // mutation function, to differentiate mutation functions for different
+  // operators
   switch (binary_operator_.getOpcode()) {
     case clang::BinaryOperatorKind::BO_Add:
       new_function_name += "Add";
@@ -230,6 +230,10 @@ void MutationReplaceBinaryOperator::Apply(
                              ->getName(ast_context.getPrintingPolicy())
                              .str();
 
+  // To avoid problems of ambiguous function calls, the argument types (ignoring
+  // whether they are references or not) are baked into the mutation function
+  // name. Some type names have space in them (e.g. 'unsigned int'); such spaces
+  // are replaced with underscores.
   new_function_name +=
       "_" + SpaceToUnderscore(lhs_type) + "_" + SpaceToUnderscore(rhs_type);
 

--- a/src/libdredd/src/mutation_replace_binary_operator.cc
+++ b/src/libdredd/src/mutation_replace_binary_operator.cc
@@ -34,56 +34,74 @@
 
 namespace dredd {
 
+namespace {
+
+std::string SpaceToUnderscore(const std::string& input) {
+  std::string result;
+  for (auto character : input) {
+    if (character == ' ') {
+      result += "_";
+    } else {
+      result += character;
+    }
+  }
+  return result;
+}
+
+}  // namespace
+
 MutationReplaceBinaryOperator::MutationReplaceBinaryOperator(
     const clang::BinaryOperator& binary_operator)
     : binary_operator_(binary_operator) {}
 
 std::string MutationReplaceBinaryOperator::GenerateMutatorFunction(
-    const std::string& function_name, const std::string& result_type,
+    const std::string& new_function_name, const std::string& result_type,
     const std::string& lhs_type, const std::string& rhs_type,
     const std::vector<clang::BinaryOperatorKind>& operators,
     int& mutation_id) const {
   std::stringstream new_function;
-  new_function << "static " << result_type << " " << function_name << "(";
-
-  std::string arg1_evaluated("arg1()");
-  new_function << "std::function<" << lhs_type << "()>"
+  new_function << "static " << result_type << " " << new_function_name;
+  new_function << "(std::function<" << lhs_type << "()>"
                << " arg1, ";
 
-  std::string arg2_evaluated("arg2()");
   new_function << "std::function<" << rhs_type << "()>"
-               << " arg2) {\n";
-  new_function << "  switch (__dredd_enabled_mutation()) {\n";
+               << " arg2, int mutation_id) {\n";
+  new_function << "  switch (__dredd_enabled_mutation() - mutation_id) {\n";
+
+  int next_switch_case = 0;
 
   // Consider every operator apart from the existing operator
+  std::string arg1_evaluated("arg1()");
+  std::string arg2_evaluated("arg2()");
   for (auto op : operators) {
     if (op == binary_operator_.getOpcode()) {
       continue;
     }
-    new_function << "    case " << mutation_id << ": return " << arg1_evaluated
-                 << " " << clang::BinaryOperator::getOpcodeStr(op).str() << " "
+    new_function << "    case " << next_switch_case << ": return "
+                 << arg1_evaluated << " "
+                 << clang::BinaryOperator::getOpcodeStr(op).str() << " "
                  << arg2_evaluated << ";\n";
-    mutation_id++;
+    next_switch_case++;
   }
   if (!binary_operator_.isAssignmentOp()) {
     // LHS
-    new_function << "    case " << mutation_id << ": return " << arg1_evaluated
-                 << ";\n";
-    mutation_id++;
+    new_function << "    case " << next_switch_case << ": return "
+                 << arg1_evaluated << ";\n";
+    next_switch_case++;
 
     // RHS
-    new_function << "    case " << mutation_id << ": return " << arg2_evaluated
-                 << ";\n";
-    mutation_id++;
+    new_function << "    case " << next_switch_case << ": return "
+                 << arg2_evaluated << ";\n";
+    next_switch_case++;
   }
   if (binary_operator_.isLogicalOp()) {
     // true
-    new_function << "    case " << mutation_id << ": return true;\n";
-    mutation_id++;
+    new_function << "    case " << next_switch_case << ": return true;\n";
+    next_switch_case++;
 
     // false
-    new_function << "    case " << mutation_id << ": return false;\n";
-    mutation_id++;
+    new_function << "    case " << next_switch_case << ": return false;\n";
+    next_switch_case++;
   }
 
   new_function
@@ -92,6 +110,11 @@ std::string MutationReplaceBinaryOperator::GenerateMutatorFunction(
       << " " << arg2_evaluated << ";\n";
   new_function << "  }\n";
   new_function << "}\n\n";
+
+  // The function captures |next_switch_cases| different mutations, so bump up
+  // the mutation id accordingly.
+  mutation_id += next_switch_case;
+
   return new_function.str();
 }
 
@@ -99,10 +122,99 @@ void MutationReplaceBinaryOperator::Apply(
     clang::ASTContext& ast_context, const clang::Preprocessor& preprocessor,
     int& mutation_id, clang::Rewriter& rewriter,
     std::unordered_set<std::string>& dredd_declarations) const {
-  // The name of the mutation wrapper function to be used for this
-  // replacement.
-  std::string mutation_function_name("__dredd_replace_binary_operator_" +
-                                     std::to_string(mutation_id));
+  std::string new_function_name = "__dredd_replace_binary_operator_";
+  switch (binary_operator_.getOpcode()) {
+    case clang::BinaryOperatorKind::BO_Add:
+      new_function_name += "Add";
+      break;
+    case clang::BinaryOperatorKind::BO_Div:
+      new_function_name += "Div";
+      break;
+    case clang::BinaryOperatorKind::BO_Mul:
+      new_function_name += "Mul";
+      break;
+    case clang::BinaryOperatorKind::BO_Rem:
+      new_function_name += "Rem";
+      break;
+    case clang::BinaryOperatorKind::BO_Sub:
+      new_function_name += "Sub";
+      break;
+    case clang::BinaryOperatorKind::BO_AddAssign:
+      new_function_name += "AddAssign";
+      break;
+    case clang::BinaryOperatorKind::BO_AndAssign:
+      new_function_name += "AndAssign";
+      break;
+    case clang::BinaryOperatorKind::BO_Assign:
+      new_function_name += "Assign";
+      break;
+    case clang::BinaryOperatorKind::BO_DivAssign:
+      new_function_name += "DivAssign";
+      break;
+    case clang::BinaryOperatorKind::BO_MulAssign:
+      new_function_name += "MulAssign";
+      break;
+    case clang::BinaryOperatorKind::BO_OrAssign:
+      new_function_name += "OrAssign";
+      break;
+    case clang::BinaryOperatorKind::BO_RemAssign:
+      new_function_name += "RemAssign";
+      break;
+    case clang::BinaryOperatorKind::BO_ShlAssign:
+      new_function_name += "ShlAssign";
+      break;
+    case clang::BinaryOperatorKind::BO_ShrAssign:
+      new_function_name += "ShrAssign";
+      break;
+    case clang::BinaryOperatorKind::BO_SubAssign:
+      new_function_name += "SubAssign";
+      break;
+    case clang::BinaryOperatorKind::BO_XorAssign:
+      new_function_name += "XorAssign";
+      break;
+    case clang::BinaryOperatorKind::BO_And:
+      new_function_name += "And";
+      break;
+    case clang::BinaryOperatorKind::BO_Or:
+      new_function_name += "Or";
+      break;
+    case clang::BinaryOperatorKind::BO_Xor:
+      new_function_name += "Xor";
+      break;
+    case clang::BinaryOperatorKind::BO_LAnd:
+      new_function_name += "LAnd";
+      break;
+    case clang::BinaryOperatorKind::BO_LOr:
+      new_function_name += "LOr";
+      break;
+    case clang::BinaryOperatorKind::BO_EQ:
+      new_function_name += "EQ";
+      break;
+    case clang::BinaryOperatorKind::BO_GE:
+      new_function_name += "GE";
+      break;
+    case clang::BinaryOperatorKind::BO_GT:
+      new_function_name += "GT";
+      break;
+    case clang::BinaryOperatorKind::BO_LE:
+      new_function_name += "LE";
+      break;
+    case clang::BinaryOperatorKind::BO_LT:
+      new_function_name += "LT";
+      break;
+    case clang::BinaryOperatorKind::BO_NE:
+      new_function_name += "NE";
+      break;
+    case clang::BinaryOperatorKind::BO_Shl:
+      new_function_name += "Shl";
+      break;
+    case clang::BinaryOperatorKind::BO_Shr:
+      new_function_name += "Shr";
+      break;
+    default:
+      assert(false && "Unsupported opcode");
+  }
+
   std::string result_type = binary_operator_.getType()
                                 ->getAs<clang::BuiltinType>()
                                 ->getName(ast_context.getPrintingPolicy())
@@ -117,12 +229,38 @@ void MutationReplaceBinaryOperator::Apply(
                              ->getAs<clang::BuiltinType>()
                              ->getName(ast_context.getPrintingPolicy())
                              .str();
+
+  new_function_name +=
+      "_" + SpaceToUnderscore(lhs_type) + "_" + SpaceToUnderscore(rhs_type);
+
   if (binary_operator_.isAssignmentOp()) {
     result_type += "&";
     lhs_type += "&";
   }
 
-  std::string new_function;
+  clang::SourceRange binary_operator_source_range_in_main_file =
+      GetSourceRangeInMainFile(preprocessor, binary_operator_);
+  assert(binary_operator_source_range_in_main_file.isValid() &&
+         "Invalid source range.");
+  clang::SourceRange lhs_source_range_in_main_file =
+      GetSourceRangeInMainFile(preprocessor, *binary_operator_.getLHS());
+  assert(lhs_source_range_in_main_file.isValid() && "Invalid source range.");
+  clang::SourceRange rhs_source_range_in_main_file =
+      GetSourceRangeInMainFile(preprocessor, *binary_operator_.getRHS());
+  assert(rhs_source_range_in_main_file.isValid() && "Invalid source range.");
+
+  // Replace the binary operator expression with a call to the wrapper
+  // function.
+  bool result = rewriter.ReplaceText(
+      binary_operator_source_range_in_main_file,
+      new_function_name + "([&]() -> " + lhs_type + " { return static_cast<" +
+          lhs_type + ">(" +
+          rewriter.getRewrittenText(lhs_source_range_in_main_file) +
+          +"); }, [&]() -> " + rhs_type + " { return static_cast<" + rhs_type +
+          ">(" + rewriter.getRewrittenText(rhs_source_range_in_main_file) +
+          "); }, " + std::to_string(mutation_id) + ")");
+  (void)result;  // Keep release-mode compilers happy.
+  assert(!result && "Rewrite failed.\n");
 
   std::vector<clang::BinaryOperatorKind> arithmetic_operators = {
       clang::BinaryOperatorKind::BO_Add, clang::BinaryOperatorKind::BO_Div,
@@ -157,42 +295,19 @@ void MutationReplaceBinaryOperator::Apply(
   std::vector<clang::BinaryOperatorKind> shift_operators = {
       clang::BinaryOperatorKind::BO_Shl, clang::BinaryOperatorKind::BO_Shr};
 
+  std::string new_function;
   for (const auto& operators :
        {arithmetic_operators, assignment_operators, bitwise_operators,
         logical_operators, relational_operators, shift_operators}) {
     if (std::find(operators.begin(), operators.end(),
                   binary_operator_.getOpcode()) != operators.end()) {
       new_function =
-          GenerateMutatorFunction(mutation_function_name, result_type, lhs_type,
+          GenerateMutatorFunction(new_function_name, result_type, lhs_type,
                                   rhs_type, operators, mutation_id);
       break;
     }
   }
   assert(!new_function.empty() && "Unsupported opcode.");
-
-  clang::SourceRange binary_operator_source_range_in_main_file =
-      GetSourceRangeInMainFile(preprocessor, binary_operator_);
-  assert(binary_operator_source_range_in_main_file.isValid() &&
-         "Invalid source range.");
-  clang::SourceRange lhs_source_range_in_main_file =
-      GetSourceRangeInMainFile(preprocessor, *binary_operator_.getLHS());
-  assert(lhs_source_range_in_main_file.isValid() && "Invalid source range.");
-  clang::SourceRange rhs_source_range_in_main_file =
-      GetSourceRangeInMainFile(preprocessor, *binary_operator_.getRHS());
-  assert(rhs_source_range_in_main_file.isValid() && "Invalid source range.");
-
-  // Replace the binary operator expression with a call to the wrapper
-  // function.
-  bool result = rewriter.ReplaceText(
-      binary_operator_source_range_in_main_file,
-      mutation_function_name + "([&]() -> " + lhs_type +
-          " { return static_cast<" + lhs_type + ">(" +
-          rewriter.getRewrittenText(lhs_source_range_in_main_file) +
-          +"); }, [&]() -> " + rhs_type + " { return static_cast<" + rhs_type +
-          ">(" + rewriter.getRewrittenText(rhs_source_range_in_main_file) +
-          "); })");
-  (void)result;  // Keep release-mode compilers happy.
-  assert(!result && "Rewrite failed.\n");
 
   // Add the mutation function to the set of Dredd declarations - there may
   // already be a matching function, in which case duplication will be avoided.

--- a/src/libdredd/src/mutation_replace_binary_operator.cc
+++ b/src/libdredd/src/mutation_replace_binary_operator.cc
@@ -55,12 +55,12 @@ MutationReplaceBinaryOperator::MutationReplaceBinaryOperator(
     : binary_operator_(binary_operator) {}
 
 std::string MutationReplaceBinaryOperator::GenerateMutatorFunction(
-    const std::string& new_function_name, const std::string& result_type,
+    const std::string& function_name, const std::string& result_type,
     const std::string& lhs_type, const std::string& rhs_type,
     const std::vector<clang::BinaryOperatorKind>& operators,
     int& mutation_id) const {
   std::stringstream new_function;
-  new_function << "static " << result_type << " " << new_function_name;
+  new_function << "static " << result_type << " " << function_name;
   new_function << "(std::function<" << lhs_type << "()>"
                << " arg1, ";
 

--- a/src/libdreddtest/.clang-tidy
+++ b/src/libdreddtest/.clang-tidy
@@ -2,6 +2,7 @@
 Checks: >
   -cppcoreguidelines-owning-memory,
   -cppcoreguidelines-avoid-non-const-global-variables,
+  -readability-function-cognitive-complexity,
 
 InheritParentConfig: true
 ...

--- a/src/libdreddtest/src/mutation_remove_statement_test.cc
+++ b/src/libdreddtest/src/mutation_remove_statement_test.cc
@@ -44,10 +44,12 @@ void TestRemoval(const std::string& original, const std::string& expected,
   clang::Rewriter rewriter(ast_unit->getSourceManager(),
                            ast_unit->getLangOpts());
   int mutation_id = 0;
+  std::unordered_set<std::string> dredd_declarations;
   mutation_supplier(ast_unit->getASTContext())
       .Apply(ast_unit->getASTContext(), ast_unit->getPreprocessor(),
-             mutation_id, rewriter);
+             mutation_id, rewriter, dredd_declarations);
   ASSERT_EQ(1, mutation_id);
+  ASSERT_EQ(0, dredd_declarations.size());
   const clang::RewriteBuffer* rewrite_buffer = rewriter.getRewriteBufferFor(
       ast_unit->getSourceManager().getMainFileID());
   std::string rewritten_text(rewrite_buffer->begin(), rewrite_buffer->end());

--- a/src/libdreddtest/src/mutation_replace_binary_operator_test.cc
+++ b/src/libdreddtest/src/mutation_replace_binary_operator_test.cc
@@ -17,7 +17,6 @@
 #include <memory>
 #include <string>
 
-#include "clang/AST/Decl.h"
 #include "clang/AST/Expr.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "clang/ASTMatchers/ASTMatchers.h"

--- a/src/libdreddtest/src/mutation_replace_binary_operator_test.cc
+++ b/src/libdreddtest/src/mutation_replace_binary_operator_test.cc
@@ -72,12 +72,14 @@ void TestReplacement(const std::string& original, const std::string& expected,
 TEST(MutationReplaceBinaryOperatorTest, MutateAdd) {
   std::string original = "void foo() { 1 + 2; }";
   std::string expected =
-      "void foo() { __dredd_replace_binary_operator_0([&]() -> int { return "
-      "static_cast<int>(1); }, [&]() -> int { return static_cast<int>(2); }); "
+      "void foo() { __dredd_replace_binary_operator_Add_int_int([&]() -> int { "
+      "return "
+      "static_cast<int>(1); }, [&]() -> int { return static_cast<int>(2); }, "
+      "0); "
       "}";
   std::string expected_dredd_declaration =
-      R"(static int __dredd_replace_binary_operator_0(std::function<int()> arg1, std::function<int()> arg2) {
-  switch (__dredd_enabled_mutation()) {
+      R"(static int __dredd_replace_binary_operator_Add_int_int(std::function<int()> arg1, std::function<int()> arg2, int mutation_id) {
+  switch (__dredd_enabled_mutation() - mutation_id) {
     case 0: return arg1() / arg2();
     case 1: return arg1() * arg2();
     case 2: return arg1() % arg2();
@@ -105,12 +107,12 @@ TEST(MutationReplaceBinaryOperatorTest, MutateAnd) {
       R"(void foo() {
   int x = 1;
   int y = 2;
-  int z = __dredd_replace_binary_operator_0([&]() -> bool { return static_cast<bool>(x); }, [&]() -> bool { return static_cast<bool>(y); });
+  int z = __dredd_replace_binary_operator_LAnd_bool_bool([&]() -> bool { return static_cast<bool>(x); }, [&]() -> bool { return static_cast<bool>(y); }, 0);
 }
 )";
   std::string expected_dredd_declaration =
-      R"(static bool __dredd_replace_binary_operator_0(std::function<bool()> arg1, std::function<bool()> arg2) {
-  switch (__dredd_enabled_mutation()) {
+      R"(static bool __dredd_replace_binary_operator_LAnd_bool_bool(std::function<bool()> arg1, std::function<bool()> arg2, int mutation_id) {
+  switch (__dredd_enabled_mutation() - mutation_id) {
     case 0: return arg1() || arg2();
     case 1: return arg1();
     case 2: return arg2();
@@ -135,12 +137,12 @@ TEST(MutationReplaceBinaryOperatorTest, MutateAssign) {
   std::string expected =
       R"(void foo() {
   int x;
-  __dredd_replace_binary_operator_0([&]() -> int& { return static_cast<int&>(x); }, [&]() -> int { return static_cast<int>(1); });
+  __dredd_replace_binary_operator_Assign_int_int([&]() -> int& { return static_cast<int&>(x); }, [&]() -> int { return static_cast<int>(1); }, 0);
 }
 )";
   std::string expected_dredd_declaration =
-      R"(static int& __dredd_replace_binary_operator_0(std::function<int&()> arg1, std::function<int()> arg2) {
-  switch (__dredd_enabled_mutation()) {
+      R"(static int& __dredd_replace_binary_operator_Assign_int_int(std::function<int&()> arg1, std::function<int()> arg2, int mutation_id) {
+  switch (__dredd_enabled_mutation() - mutation_id) {
     case 0: return arg1() += arg2();
     case 1: return arg1() &= arg2();
     case 2: return arg1() /= arg2();
@@ -174,12 +176,12 @@ void foo() {
 #define BING(X, Y, Z) (X ? Y : Z)
 void foo() {
   int x;
-  __dredd_replace_binary_operator_0([&]() -> int& { return static_cast<int&>(VAR); }, [&]() -> int { return static_cast<int>(BING(1, 2, 3)); });
+  __dredd_replace_binary_operator_Assign_int_int([&]() -> int& { return static_cast<int&>(VAR); }, [&]() -> int { return static_cast<int>(BING(1, 2, 3)); }, 0);
 }
 )";
   std::string expected_dredd_declaration =
-      R"(static int& __dredd_replace_binary_operator_0(std::function<int&()> arg1, std::function<int()> arg2) {
-  switch (__dredd_enabled_mutation()) {
+      R"(static int& __dredd_replace_binary_operator_Assign_int_int(std::function<int&()> arg1, std::function<int()> arg2, int mutation_id) {
+  switch (__dredd_enabled_mutation() - mutation_id) {
     case 0: return arg1() += arg2();
     case 1: return arg1() &= arg2();
     case 2: return arg1() /= arg2();

--- a/test/single_file/add.cc
+++ b/test/single_file/add.cc
@@ -1,0 +1,5 @@
+int main() {
+  int x = 1;
+  int y = 2;
+  return x + y + x;
+}

--- a/test/single_file/add.expected
+++ b/test/single_file/add.expected
@@ -1,0 +1,35 @@
+#include <cstdlib>
+#include <functional>
+
+static int __dredd_enabled_mutation() {
+  static bool initialized = false;
+  static int value;
+  if (!initialized) {
+    const char* __dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
+    if (__dredd_environment_variable == nullptr) {
+      value = -1;
+    } else {
+      value = atoi(__dredd_environment_variable);
+    }
+    initialized = true;
+  }
+  return value;
+}
+
+static int __dredd_replace_binary_operator_Add_int_int(std::function<int()> arg1, std::function<int()> arg2, int mutation_id) {
+  switch (__dredd_enabled_mutation() - mutation_id) {
+    case 0: return arg1() / arg2();
+    case 1: return arg1() * arg2();
+    case 2: return arg1() % arg2();
+    case 3: return arg1() - arg2();
+    case 4: return arg1();
+    case 5: return arg2();
+    default: return arg1() + arg2();
+  }
+}
+
+int main() {
+  int x = 1;
+  int y = 2;
+  if (__dredd_enabled_mutation() != 12) { return __dredd_replace_binary_operator_Add_int_int([&]() -> int { return static_cast<int>(__dredd_replace_binary_operator_Add_int_int([&]() -> int { return static_cast<int>(x); }, [&]() -> int { return static_cast<int>(y); }, 0)); }, [&]() -> int { return static_cast<int>(x); }, 6); }
+}

--- a/test/single_file/add_mul.cc
+++ b/test/single_file/add_mul.cc
@@ -1,0 +1,5 @@
+int main() {
+  int x = 1;
+  int y = 2;
+  return x + y * x;
+}

--- a/test/single_file/add_mul.expected
+++ b/test/single_file/add_mul.expected
@@ -1,0 +1,47 @@
+#include <cstdlib>
+#include <functional>
+
+static int __dredd_enabled_mutation() {
+  static bool initialized = false;
+  static int value;
+  if (!initialized) {
+    const char* __dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
+    if (__dredd_environment_variable == nullptr) {
+      value = -1;
+    } else {
+      value = atoi(__dredd_environment_variable);
+    }
+    initialized = true;
+  }
+  return value;
+}
+
+static int __dredd_replace_binary_operator_Mul_int_int(std::function<int()> arg1, std::function<int()> arg2, int mutation_id) {
+  switch (__dredd_enabled_mutation() - mutation_id) {
+    case 0: return arg1() + arg2();
+    case 1: return arg1() / arg2();
+    case 2: return arg1() % arg2();
+    case 3: return arg1() - arg2();
+    case 4: return arg1();
+    case 5: return arg2();
+    default: return arg1() * arg2();
+  }
+}
+
+static int __dredd_replace_binary_operator_Add_int_int(std::function<int()> arg1, std::function<int()> arg2, int mutation_id) {
+  switch (__dredd_enabled_mutation() - mutation_id) {
+    case 0: return arg1() / arg2();
+    case 1: return arg1() * arg2();
+    case 2: return arg1() % arg2();
+    case 3: return arg1() - arg2();
+    case 4: return arg1();
+    case 5: return arg2();
+    default: return arg1() + arg2();
+  }
+}
+
+int main() {
+  int x = 1;
+  int y = 2;
+  if (__dredd_enabled_mutation() != 12) { return __dredd_replace_binary_operator_Add_int_int([&]() -> int { return static_cast<int>(x); }, [&]() -> int { return static_cast<int>(__dredd_replace_binary_operator_Mul_int_int([&]() -> int { return static_cast<int>(y); }, [&]() -> int { return static_cast<int>(x); }, 0)); }, 6); }
+}

--- a/test/single_file/add_type_aliases.cc
+++ b/test/single_file/add_type_aliases.cc
@@ -1,0 +1,25 @@
+#include <cinttypes>
+#include <cstddef>
+
+int main() {
+  unsigned a;
+  uint32_t b;
+  int c;
+  int32_t d;
+  unsigned long e;
+  size_t f;
+  long g;
+  int64_t h;
+  uint64_t i;
+
+  a + a;
+  b + b;
+  c + c;
+  d + d;
+  e + e;
+  f + f;
+  g + g;
+  h + h;
+  i + i;
+  
+}

--- a/test/single_file/add_type_aliases.cc
+++ b/test/single_file/add_type_aliases.cc
@@ -21,5 +21,4 @@ int main() {
   g + g;
   h + h;
   i + i;
-  
 }

--- a/test/single_file/add_type_aliases.expected
+++ b/test/single_file/add_type_aliases.expected
@@ -87,5 +87,4 @@ int main() {
   if (__dredd_enabled_mutation() != 60) { __dredd_replace_binary_operator_Add_long_long([&]() -> long { return static_cast<long>(g); }, [&]() -> long { return static_cast<long>(g); }, 36); }
   if (__dredd_enabled_mutation() != 61) { __dredd_replace_binary_operator_Add_long_long([&]() -> long { return static_cast<long>(h); }, [&]() -> long { return static_cast<long>(h); }, 42); }
   if (__dredd_enabled_mutation() != 62) { __dredd_replace_binary_operator_Add_unsigned_long_unsigned_long([&]() -> unsigned long { return static_cast<unsigned long>(i); }, [&]() -> unsigned long { return static_cast<unsigned long>(i); }, 48); }
-  
 }

--- a/test/single_file/add_type_aliases.expected
+++ b/test/single_file/add_type_aliases.expected
@@ -1,0 +1,91 @@
+#include <cinttypes>
+#include <cstddef>
+
+#include <cstdlib>
+#include <functional>
+
+static int __dredd_enabled_mutation() {
+  static bool initialized = false;
+  static int value;
+  if (!initialized) {
+    const char* __dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
+    if (__dredd_environment_variable == nullptr) {
+      value = -1;
+    } else {
+      value = atoi(__dredd_environment_variable);
+    }
+    initialized = true;
+  }
+  return value;
+}
+
+static unsigned long __dredd_replace_binary_operator_Add_unsigned_long_unsigned_long(std::function<unsigned long()> arg1, std::function<unsigned long()> arg2, int mutation_id) {
+  switch (__dredd_enabled_mutation() - mutation_id) {
+    case 0: return arg1() / arg2();
+    case 1: return arg1() * arg2();
+    case 2: return arg1() % arg2();
+    case 3: return arg1() - arg2();
+    case 4: return arg1();
+    case 5: return arg2();
+    default: return arg1() + arg2();
+  }
+}
+
+static unsigned int __dredd_replace_binary_operator_Add_unsigned_int_unsigned_int(std::function<unsigned int()> arg1, std::function<unsigned int()> arg2, int mutation_id) {
+  switch (__dredd_enabled_mutation() - mutation_id) {
+    case 0: return arg1() / arg2();
+    case 1: return arg1() * arg2();
+    case 2: return arg1() % arg2();
+    case 3: return arg1() - arg2();
+    case 4: return arg1();
+    case 5: return arg2();
+    default: return arg1() + arg2();
+  }
+}
+
+static long __dredd_replace_binary_operator_Add_long_long(std::function<long()> arg1, std::function<long()> arg2, int mutation_id) {
+  switch (__dredd_enabled_mutation() - mutation_id) {
+    case 0: return arg1() / arg2();
+    case 1: return arg1() * arg2();
+    case 2: return arg1() % arg2();
+    case 3: return arg1() - arg2();
+    case 4: return arg1();
+    case 5: return arg2();
+    default: return arg1() + arg2();
+  }
+}
+
+static int __dredd_replace_binary_operator_Add_int_int(std::function<int()> arg1, std::function<int()> arg2, int mutation_id) {
+  switch (__dredd_enabled_mutation() - mutation_id) {
+    case 0: return arg1() / arg2();
+    case 1: return arg1() * arg2();
+    case 2: return arg1() % arg2();
+    case 3: return arg1() - arg2();
+    case 4: return arg1();
+    case 5: return arg2();
+    default: return arg1() + arg2();
+  }
+}
+
+int main() {
+  unsigned a;
+  uint32_t b;
+  int c;
+  int32_t d;
+  unsigned long e;
+  size_t f;
+  long g;
+  int64_t h;
+  uint64_t i;
+
+  if (__dredd_enabled_mutation() != 54) { __dredd_replace_binary_operator_Add_unsigned_int_unsigned_int([&]() -> unsigned int { return static_cast<unsigned int>(a); }, [&]() -> unsigned int { return static_cast<unsigned int>(a); }, 0); }
+  if (__dredd_enabled_mutation() != 55) { __dredd_replace_binary_operator_Add_unsigned_int_unsigned_int([&]() -> unsigned int { return static_cast<unsigned int>(b); }, [&]() -> unsigned int { return static_cast<unsigned int>(b); }, 6); }
+  if (__dredd_enabled_mutation() != 56) { __dredd_replace_binary_operator_Add_int_int([&]() -> int { return static_cast<int>(c); }, [&]() -> int { return static_cast<int>(c); }, 12); }
+  if (__dredd_enabled_mutation() != 57) { __dredd_replace_binary_operator_Add_int_int([&]() -> int { return static_cast<int>(d); }, [&]() -> int { return static_cast<int>(d); }, 18); }
+  if (__dredd_enabled_mutation() != 58) { __dredd_replace_binary_operator_Add_unsigned_long_unsigned_long([&]() -> unsigned long { return static_cast<unsigned long>(e); }, [&]() -> unsigned long { return static_cast<unsigned long>(e); }, 24); }
+  if (__dredd_enabled_mutation() != 59) { __dredd_replace_binary_operator_Add_unsigned_long_unsigned_long([&]() -> unsigned long { return static_cast<unsigned long>(f); }, [&]() -> unsigned long { return static_cast<unsigned long>(f); }, 30); }
+  if (__dredd_enabled_mutation() != 60) { __dredd_replace_binary_operator_Add_long_long([&]() -> long { return static_cast<long>(g); }, [&]() -> long { return static_cast<long>(g); }, 36); }
+  if (__dredd_enabled_mutation() != 61) { __dredd_replace_binary_operator_Add_long_long([&]() -> long { return static_cast<long>(h); }, [&]() -> long { return static_cast<long>(h); }, 42); }
+  if (__dredd_enabled_mutation() != 62) { __dredd_replace_binary_operator_Add_unsigned_long_unsigned_long([&]() -> unsigned long { return static_cast<unsigned long>(i); }, [&]() -> unsigned long { return static_cast<unsigned long>(i); }, 48); }
+  
+}

--- a/test/single_file/constexpr.expected
+++ b/test/single_file/constexpr.expected
@@ -1,22 +1,4 @@
 // Checks that operator mutations are not applied to constexprs.
-#include <cstdlib>
-#include <functional>
-
-static int __dredd_enabled_mutation() {
-  static bool initialized = false;
-  static int value;
-  if (!initialized) {
-    const char* __dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
-    if (__dredd_environment_variable == nullptr) {
-      value = -1;
-    } else {
-      value = atoi(__dredd_environment_variable);
-    }
-    initialized = true;
-  }
-  return value;
-}
-
 namespace foo {
 constexpr int a = -2 + ~3;
 };


### PR DESCRIPTION
Reworks binary operator mutation to avoid producing a separate
function for every single operator that is considered. Instead,operators with common argument types share the same mutation function (if in the same source file).
    
Fixes #48.
