### PR TITLE
Handle volatile in binary operator mutation

### DIFF
--- a/src/libdredd/src/mutation_replace_binary_operator.cc
+++ b/src/libdredd/src/mutation_replace_binary_operator.cc
@@ -240,6 +240,13 @@ void MutationReplaceBinaryOperator::Apply(
   if (binary_operator_.isAssignmentOp()) {
     result_type += "&";
     lhs_type += "&";
+    clang::QualType qualified_lhs_type = binary_operator_.getLHS()->getType();
+    if (qualified_lhs_type.isVolatileQualified()) {
+      assert(binary_operator_.getType().isVolatileQualified() &&
+             "Expected expression to be volatile-qualified since LHS is.");
+      result_type = "volatile " + result_type;
+      lhs_type = "volatile " + lhs_type;
+    }
   }
 
   clang::SourceRange binary_operator_source_range_in_main_file =

--- a/test/single_file/volatile.cc
+++ b/test/single_file/volatile.cc
@@ -1,0 +1,4 @@
+void foo() {
+  volatile int a;
+  a += 2;
+}

--- a/test/single_file/volatile.expected
+++ b/test/single_file/volatile.expected
@@ -1,0 +1,38 @@
+#include <cstdlib>
+#include <functional>
+
+static int __dredd_enabled_mutation() {
+  static bool initialized = false;
+  static int value;
+  if (!initialized) {
+    const char* __dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
+    if (__dredd_environment_variable == nullptr) {
+      value = -1;
+    } else {
+      value = atoi(__dredd_environment_variable);
+    }
+    initialized = true;
+  }
+  return value;
+}
+
+static volatile int& __dredd_replace_binary_operator_AddAssign_int_int(std::function<volatile int&()> arg1, std::function<int()> arg2, int mutation_id) {
+  switch (__dredd_enabled_mutation() - mutation_id) {
+    case 0: return arg1() &= arg2();
+    case 1: return arg1() = arg2();
+    case 2: return arg1() /= arg2();
+    case 3: return arg1() *= arg2();
+    case 4: return arg1() |= arg2();
+    case 5: return arg1() %= arg2();
+    case 6: return arg1() <<= arg2();
+    case 7: return arg1() >>= arg2();
+    case 8: return arg1() -= arg2();
+    case 9: return arg1() ^= arg2();
+    default: return arg1() += arg2();
+  }
+}
+
+void foo() {
+  volatile int a;
+  if (__dredd_enabled_mutation() != 10) { __dredd_replace_binary_operator_AddAssign_int_int([&]() -> volatile int& { return static_cast<volatile int&>(a); }, [&]() -> int { return static_cast<int>(2); }, 0); }
+}


### PR DESCRIPTION
Properly account for volatile when mutating binary operators.

Fixes #51.