### PR TITLE
Check enabled mutation using predicate

### DIFF
--- a/src/libdredd/src/mutate_ast_consumer.cc
+++ b/src/libdredd/src/mutate_ast_consumer.cc
@@ -87,7 +87,7 @@ void MutateAstConsumer::HandleTranslationUnit(clang::ASTContext& context) {
   std::stringstream dredd_prelude;
   dredd_prelude << "#include <cstdlib>\n";
   dredd_prelude << "#include <functional>\n\n";
-  dredd_prelude << "static int __dredd_enabled_mutation() {\n";
+  dredd_prelude << "static bool __dredd_enabled_mutation(int mutation_id) {\n";
   dredd_prelude << "  static bool initialized = false;\n";
   dredd_prelude << "  static int value;\n";
   dredd_prelude << "  if (!initialized) {\n";
@@ -100,7 +100,7 @@ void MutateAstConsumer::HandleTranslationUnit(clang::ASTContext& context) {
   dredd_prelude << "    }\n";
   dredd_prelude << "    initialized = true;\n";
   dredd_prelude << "  }\n";
-  dredd_prelude << "  return value;\n";
+  dredd_prelude << "  return value == mutation_id;\n";
   dredd_prelude << "}\n\n";
 
   bool result = rewriter_.InsertTextBefore(

--- a/src/libdredd/src/mutation_remove_statement.cc
+++ b/src/libdredd/src/mutation_remove_statement.cc
@@ -43,9 +43,9 @@ void MutationRemoveStatement::Apply(
       clang::tok::TokenKind::semi, ast_context);
 
   bool result = rewriter.ReplaceText(
-      source_range,
-      "if (__dredd_enabled_mutation() != " + std::to_string(mutation_id) +
-          ") { " + rewriter.getRewrittenText(source_range) + " }");
+      source_range, "if (!__dredd_enabled_mutation(" +
+                        std::to_string(mutation_id) + ")) { " +
+                        rewriter.getRewrittenText(source_range) + " }");
   (void)result;  // Keep release-mode compilers happy.
   assert(!result && "Rewrite failed.\n");
   mutation_id++;

--- a/src/libdreddtest/src/mutation_remove_statement_test.cc
+++ b/src/libdreddtest/src/mutation_remove_statement_test.cc
@@ -59,7 +59,7 @@ void TestRemoval(const std::string& original, const std::string& expected,
 TEST(MutationRemoveStatementTest, BasicTest) {
   std::string original = "void foo() { 1 + 2; }";
   std::string expected =
-      R"(void foo() { if (__dredd_enabled_mutation() != 0) { 1 + 2; } })";
+      R"(void foo() { if (!__dredd_enabled_mutation(0)) { 1 + 2; } })";
   std::function<MutationRemoveStatement(clang::ASTContext&)> mutation_supplier =
       [](clang::ASTContext& ast_context) -> MutationRemoveStatement {
     auto statement = clang::ast_matchers::match(
@@ -74,7 +74,7 @@ TEST(MutationRemoveStatementTest, BasicTest) {
 TEST(MutationRemoveStatementTest, RemoveIfStatement) {
   std::string original = "void foo() { if (true) { } }";
   std::string expected =
-      R"(void foo() { if (__dredd_enabled_mutation() != 0) { if (true) { } } })";
+      R"(void foo() { if (!__dredd_enabled_mutation(0)) { if (true) { } } })";
   std::function<MutationRemoveStatement(clang::ASTContext&)> mutation_supplier =
       [](clang::ASTContext& ast_context) -> MutationRemoveStatement {
     auto statement = clang::ast_matchers::match(
@@ -89,7 +89,7 @@ TEST(MutationRemoveStatementTest, RemoveIfStatement) {
 TEST(MutationRemoveStatementTest, RemoveIfStatementWithTrailingSemi) {
   std::string original = "void foo() { if (true) { }; }";
   std::string expected =
-      R"(void foo() { if (__dredd_enabled_mutation() != 0) { if (true) { }; } })";
+      R"(void foo() { if (!__dredd_enabled_mutation(0)) { if (true) { }; } })";
   std::function<MutationRemoveStatement(clang::ASTContext&)> mutation_supplier =
       [](clang::ASTContext& ast_context) -> MutationRemoveStatement {
     auto statement = clang::ast_matchers::match(
@@ -104,7 +104,7 @@ TEST(MutationRemoveStatementTest, RemoveIfStatementWithTrailingSemi) {
 TEST(MutationRemoveStatementTest, RemoveIfStatementWithTrailingSemis) {
   std::string original = "void foo() { if (true) { };; }";
   std::string expected =
-      R"(void foo() { if (__dredd_enabled_mutation() != 0) { if (true) { }; }; })";
+      R"(void foo() { if (!__dredd_enabled_mutation(0)) { if (true) { }; }; })";
   std::function<MutationRemoveStatement(clang::ASTContext&)> mutation_supplier =
       [](clang::ASTContext& ast_context) -> MutationRemoveStatement {
     auto statement = clang::ast_matchers::match(
@@ -119,7 +119,7 @@ TEST(MutationRemoveStatementTest, RemoveIfStatementWithTrailingSemis) {
 TEST(MutationRemoveStatementTest, RemoveIfStatementWithoutBraces) {
   std::string original = "void foo() { if (true) return; }";
   std::string expected =
-      R"(void foo() { if (__dredd_enabled_mutation() != 0) { if (true) return; } })";
+      R"(void foo() { if (!__dredd_enabled_mutation(0)) { if (true) return; } })";
   std::function<MutationRemoveStatement(clang::ASTContext&)> mutation_supplier =
       [](clang::ASTContext& ast_context) -> MutationRemoveStatement {
     auto statement = clang::ast_matchers::match(
@@ -134,7 +134,7 @@ TEST(MutationRemoveStatementTest, RemoveIfStatementWithoutBraces) {
 TEST(MutationRemoveStatementTest, RemoveReturnStmt) {
   std::string original = "void foo() { return; }";
   std::string expected =
-      R"(void foo() { if (__dredd_enabled_mutation() != 0) { return; } })";
+      R"(void foo() { if (!__dredd_enabled_mutation(0)) { return; } })";
   std::function<MutationRemoveStatement(clang::ASTContext&)> mutation_supplier =
       [](clang::ASTContext& ast_context) -> MutationRemoveStatement {
     auto statement = clang::ast_matchers::match(
@@ -149,7 +149,7 @@ TEST(MutationRemoveStatementTest, RemoveReturnStmt) {
 TEST(MutationRemoveStatementTest, RemoveBreakStmt) {
   std::string original = "void foo() { while (true) { break; } }";
   std::string expected =
-      R"(void foo() { while (true) { if (__dredd_enabled_mutation() != 0) { break; } } })";
+      R"(void foo() { while (true) { if (!__dredd_enabled_mutation(0)) { break; } } })";
   std::function<MutationRemoveStatement(clang::ASTContext&)> mutation_supplier =
       [](clang::ASTContext& ast_context) -> MutationRemoveStatement {
     auto statement = clang::ast_matchers::match(
@@ -167,7 +167,7 @@ TEST(MutationRemoveStatementTest, RemoveMacroStmt) {
       "void foo() { int x; ASSIGN(x, 1); }";
   std::string expected =
       R"(#define ASSIGN(A, B) A = B
-void foo() { int x; if (__dredd_enabled_mutation() != 0) { ASSIGN(x, 1); } })";
+void foo() { int x; if (!__dredd_enabled_mutation(0)) { ASSIGN(x, 1); } })";
   std::function<MutationRemoveStatement(clang::ASTContext&)> mutation_supplier =
       [](clang::ASTContext& ast_context) -> MutationRemoveStatement {
     auto statement = clang::ast_matchers::match(

--- a/src/libdreddtest/src/mutation_replace_binary_operator_test.cc
+++ b/src/libdreddtest/src/mutation_replace_binary_operator_test.cc
@@ -78,15 +78,13 @@ TEST(MutationReplaceBinaryOperatorTest, MutateAdd) {
       "}";
   std::string expected_dredd_declaration =
       R"(static int __dredd_replace_binary_operator_Add_int_int(std::function<int()> arg1, std::function<int()> arg2, int mutation_id) {
-  switch (__dredd_enabled_mutation() - mutation_id) {
-    case 0: return arg1() / arg2();
-    case 1: return arg1() * arg2();
-    case 2: return arg1() % arg2();
-    case 3: return arg1() - arg2();
-    case 4: return arg1();
-    case 5: return arg2();
-    default: return arg1() + arg2();
-  }
+  if (__dredd_enabled_mutation(mutation_id + 0)) return arg1() / arg2();
+  if (__dredd_enabled_mutation(mutation_id + 1)) return arg1() * arg2();
+  if (__dredd_enabled_mutation(mutation_id + 2)) return arg1() % arg2();
+  if (__dredd_enabled_mutation(mutation_id + 3)) return arg1() - arg2();
+  if (__dredd_enabled_mutation(mutation_id + 4)) return arg1();
+  if (__dredd_enabled_mutation(mutation_id + 5)) return arg2();
+  return arg1() + arg2();
 }
 
 )";
@@ -111,14 +109,12 @@ TEST(MutationReplaceBinaryOperatorTest, MutateAnd) {
 )";
   std::string expected_dredd_declaration =
       R"(static bool __dredd_replace_binary_operator_LAnd_bool_bool(std::function<bool()> arg1, std::function<bool()> arg2, int mutation_id) {
-  switch (__dredd_enabled_mutation() - mutation_id) {
-    case 0: return arg1() || arg2();
-    case 1: return arg1();
-    case 2: return arg2();
-    case 3: return true;
-    case 4: return false;
-    default: return arg1() && arg2();
-  }
+  if (__dredd_enabled_mutation(mutation_id + 0)) return arg1() || arg2();
+  if (__dredd_enabled_mutation(mutation_id + 1)) return arg1();
+  if (__dredd_enabled_mutation(mutation_id + 2)) return arg2();
+  if (__dredd_enabled_mutation(mutation_id + 3)) return true;
+  if (__dredd_enabled_mutation(mutation_id + 4)) return false;
+  return arg1() && arg2();
 }
 
 )";
@@ -141,19 +137,17 @@ TEST(MutationReplaceBinaryOperatorTest, MutateAssign) {
 )";
   std::string expected_dredd_declaration =
       R"(static int& __dredd_replace_binary_operator_Assign_int_int(std::function<int&()> arg1, std::function<int()> arg2, int mutation_id) {
-  switch (__dredd_enabled_mutation() - mutation_id) {
-    case 0: return arg1() += arg2();
-    case 1: return arg1() &= arg2();
-    case 2: return arg1() /= arg2();
-    case 3: return arg1() *= arg2();
-    case 4: return arg1() |= arg2();
-    case 5: return arg1() %= arg2();
-    case 6: return arg1() <<= arg2();
-    case 7: return arg1() >>= arg2();
-    case 8: return arg1() -= arg2();
-    case 9: return arg1() ^= arg2();
-    default: return arg1() = arg2();
-  }
+  if (__dredd_enabled_mutation(mutation_id + 0)) return arg1() += arg2();
+  if (__dredd_enabled_mutation(mutation_id + 1)) return arg1() &= arg2();
+  if (__dredd_enabled_mutation(mutation_id + 2)) return arg1() /= arg2();
+  if (__dredd_enabled_mutation(mutation_id + 3)) return arg1() *= arg2();
+  if (__dredd_enabled_mutation(mutation_id + 4)) return arg1() |= arg2();
+  if (__dredd_enabled_mutation(mutation_id + 5)) return arg1() %= arg2();
+  if (__dredd_enabled_mutation(mutation_id + 6)) return arg1() <<= arg2();
+  if (__dredd_enabled_mutation(mutation_id + 7)) return arg1() >>= arg2();
+  if (__dredd_enabled_mutation(mutation_id + 8)) return arg1() -= arg2();
+  if (__dredd_enabled_mutation(mutation_id + 9)) return arg1() ^= arg2();
+  return arg1() = arg2();
 }
 
 )";
@@ -180,19 +174,17 @@ void foo() {
 )";
   std::string expected_dredd_declaration =
       R"(static int& __dredd_replace_binary_operator_Assign_int_int(std::function<int&()> arg1, std::function<int()> arg2, int mutation_id) {
-  switch (__dredd_enabled_mutation() - mutation_id) {
-    case 0: return arg1() += arg2();
-    case 1: return arg1() &= arg2();
-    case 2: return arg1() /= arg2();
-    case 3: return arg1() *= arg2();
-    case 4: return arg1() |= arg2();
-    case 5: return arg1() %= arg2();
-    case 6: return arg1() <<= arg2();
-    case 7: return arg1() >>= arg2();
-    case 8: return arg1() -= arg2();
-    case 9: return arg1() ^= arg2();
-    default: return arg1() = arg2();
-  }
+  if (__dredd_enabled_mutation(mutation_id + 0)) return arg1() += arg2();
+  if (__dredd_enabled_mutation(mutation_id + 1)) return arg1() &= arg2();
+  if (__dredd_enabled_mutation(mutation_id + 2)) return arg1() /= arg2();
+  if (__dredd_enabled_mutation(mutation_id + 3)) return arg1() *= arg2();
+  if (__dredd_enabled_mutation(mutation_id + 4)) return arg1() |= arg2();
+  if (__dredd_enabled_mutation(mutation_id + 5)) return arg1() %= arg2();
+  if (__dredd_enabled_mutation(mutation_id + 6)) return arg1() <<= arg2();
+  if (__dredd_enabled_mutation(mutation_id + 7)) return arg1() >>= arg2();
+  if (__dredd_enabled_mutation(mutation_id + 8)) return arg1() -= arg2();
+  if (__dredd_enabled_mutation(mutation_id + 9)) return arg1() ^= arg2();
+  return arg1() = arg2();
 }
 
 )";

--- a/test/single_file/add.expected
+++ b/test/single_file/add.expected
@@ -1,7 +1,7 @@
 #include <cstdlib>
 #include <functional>
 
-static int __dredd_enabled_mutation() {
+static bool __dredd_enabled_mutation(int mutation_id) {
   static bool initialized = false;
   static int value;
   if (!initialized) {
@@ -13,23 +13,21 @@ static int __dredd_enabled_mutation() {
     }
     initialized = true;
   }
-  return value;
+  return value == mutation_id;
 }
 
 static int __dredd_replace_binary_operator_Add_int_int(std::function<int()> arg1, std::function<int()> arg2, int mutation_id) {
-  switch (__dredd_enabled_mutation() - mutation_id) {
-    case 0: return arg1() / arg2();
-    case 1: return arg1() * arg2();
-    case 2: return arg1() % arg2();
-    case 3: return arg1() - arg2();
-    case 4: return arg1();
-    case 5: return arg2();
-    default: return arg1() + arg2();
-  }
+  if (__dredd_enabled_mutation(mutation_id + 0)) return arg1() / arg2();
+  if (__dredd_enabled_mutation(mutation_id + 1)) return arg1() * arg2();
+  if (__dredd_enabled_mutation(mutation_id + 2)) return arg1() % arg2();
+  if (__dredd_enabled_mutation(mutation_id + 3)) return arg1() - arg2();
+  if (__dredd_enabled_mutation(mutation_id + 4)) return arg1();
+  if (__dredd_enabled_mutation(mutation_id + 5)) return arg2();
+  return arg1() + arg2();
 }
 
 int main() {
   int x = 1;
   int y = 2;
-  if (__dredd_enabled_mutation() != 12) { return __dredd_replace_binary_operator_Add_int_int([&]() -> int { return static_cast<int>(__dredd_replace_binary_operator_Add_int_int([&]() -> int { return static_cast<int>(x); }, [&]() -> int { return static_cast<int>(y); }, 0)); }, [&]() -> int { return static_cast<int>(x); }, 6); }
+  if (!__dredd_enabled_mutation(12)) { return __dredd_replace_binary_operator_Add_int_int([&]() -> int { return static_cast<int>(__dredd_replace_binary_operator_Add_int_int([&]() -> int { return static_cast<int>(x); }, [&]() -> int { return static_cast<int>(y); }, 0)); }, [&]() -> int { return static_cast<int>(x); }, 6); }
 }

--- a/test/single_file/add_mul.expected
+++ b/test/single_file/add_mul.expected
@@ -1,7 +1,7 @@
 #include <cstdlib>
 #include <functional>
 
-static int __dredd_enabled_mutation() {
+static bool __dredd_enabled_mutation(int mutation_id) {
   static bool initialized = false;
   static int value;
   if (!initialized) {
@@ -13,35 +13,31 @@ static int __dredd_enabled_mutation() {
     }
     initialized = true;
   }
-  return value;
+  return value == mutation_id;
 }
 
 static int __dredd_replace_binary_operator_Mul_int_int(std::function<int()> arg1, std::function<int()> arg2, int mutation_id) {
-  switch (__dredd_enabled_mutation() - mutation_id) {
-    case 0: return arg1() + arg2();
-    case 1: return arg1() / arg2();
-    case 2: return arg1() % arg2();
-    case 3: return arg1() - arg2();
-    case 4: return arg1();
-    case 5: return arg2();
-    default: return arg1() * arg2();
-  }
+  if (__dredd_enabled_mutation(mutation_id + 0)) return arg1() + arg2();
+  if (__dredd_enabled_mutation(mutation_id + 1)) return arg1() / arg2();
+  if (__dredd_enabled_mutation(mutation_id + 2)) return arg1() % arg2();
+  if (__dredd_enabled_mutation(mutation_id + 3)) return arg1() - arg2();
+  if (__dredd_enabled_mutation(mutation_id + 4)) return arg1();
+  if (__dredd_enabled_mutation(mutation_id + 5)) return arg2();
+  return arg1() * arg2();
 }
 
 static int __dredd_replace_binary_operator_Add_int_int(std::function<int()> arg1, std::function<int()> arg2, int mutation_id) {
-  switch (__dredd_enabled_mutation() - mutation_id) {
-    case 0: return arg1() / arg2();
-    case 1: return arg1() * arg2();
-    case 2: return arg1() % arg2();
-    case 3: return arg1() - arg2();
-    case 4: return arg1();
-    case 5: return arg2();
-    default: return arg1() + arg2();
-  }
+  if (__dredd_enabled_mutation(mutation_id + 0)) return arg1() / arg2();
+  if (__dredd_enabled_mutation(mutation_id + 1)) return arg1() * arg2();
+  if (__dredd_enabled_mutation(mutation_id + 2)) return arg1() % arg2();
+  if (__dredd_enabled_mutation(mutation_id + 3)) return arg1() - arg2();
+  if (__dredd_enabled_mutation(mutation_id + 4)) return arg1();
+  if (__dredd_enabled_mutation(mutation_id + 5)) return arg2();
+  return arg1() + arg2();
 }
 
 int main() {
   int x = 1;
   int y = 2;
-  if (__dredd_enabled_mutation() != 12) { return __dredd_replace_binary_operator_Add_int_int([&]() -> int { return static_cast<int>(x); }, [&]() -> int { return static_cast<int>(__dredd_replace_binary_operator_Mul_int_int([&]() -> int { return static_cast<int>(y); }, [&]() -> int { return static_cast<int>(x); }, 0)); }, 6); }
+  if (!__dredd_enabled_mutation(12)) { return __dredd_replace_binary_operator_Add_int_int([&]() -> int { return static_cast<int>(x); }, [&]() -> int { return static_cast<int>(__dredd_replace_binary_operator_Mul_int_int([&]() -> int { return static_cast<int>(y); }, [&]() -> int { return static_cast<int>(x); }, 0)); }, 6); }
 }

--- a/test/single_file/add_type_aliases.expected
+++ b/test/single_file/add_type_aliases.expected
@@ -4,7 +4,7 @@
 #include <cstdlib>
 #include <functional>
 
-static int __dredd_enabled_mutation() {
+static bool __dredd_enabled_mutation(int mutation_id) {
   static bool initialized = false;
   static int value;
   if (!initialized) {
@@ -16,55 +16,47 @@ static int __dredd_enabled_mutation() {
     }
     initialized = true;
   }
-  return value;
+  return value == mutation_id;
 }
 
 static unsigned long __dredd_replace_binary_operator_Add_unsigned_long_unsigned_long(std::function<unsigned long()> arg1, std::function<unsigned long()> arg2, int mutation_id) {
-  switch (__dredd_enabled_mutation() - mutation_id) {
-    case 0: return arg1() / arg2();
-    case 1: return arg1() * arg2();
-    case 2: return arg1() % arg2();
-    case 3: return arg1() - arg2();
-    case 4: return arg1();
-    case 5: return arg2();
-    default: return arg1() + arg2();
-  }
+  if (__dredd_enabled_mutation(mutation_id + 0)) return arg1() / arg2();
+  if (__dredd_enabled_mutation(mutation_id + 1)) return arg1() * arg2();
+  if (__dredd_enabled_mutation(mutation_id + 2)) return arg1() % arg2();
+  if (__dredd_enabled_mutation(mutation_id + 3)) return arg1() - arg2();
+  if (__dredd_enabled_mutation(mutation_id + 4)) return arg1();
+  if (__dredd_enabled_mutation(mutation_id + 5)) return arg2();
+  return arg1() + arg2();
 }
 
 static unsigned int __dredd_replace_binary_operator_Add_unsigned_int_unsigned_int(std::function<unsigned int()> arg1, std::function<unsigned int()> arg2, int mutation_id) {
-  switch (__dredd_enabled_mutation() - mutation_id) {
-    case 0: return arg1() / arg2();
-    case 1: return arg1() * arg2();
-    case 2: return arg1() % arg2();
-    case 3: return arg1() - arg2();
-    case 4: return arg1();
-    case 5: return arg2();
-    default: return arg1() + arg2();
-  }
+  if (__dredd_enabled_mutation(mutation_id + 0)) return arg1() / arg2();
+  if (__dredd_enabled_mutation(mutation_id + 1)) return arg1() * arg2();
+  if (__dredd_enabled_mutation(mutation_id + 2)) return arg1() % arg2();
+  if (__dredd_enabled_mutation(mutation_id + 3)) return arg1() - arg2();
+  if (__dredd_enabled_mutation(mutation_id + 4)) return arg1();
+  if (__dredd_enabled_mutation(mutation_id + 5)) return arg2();
+  return arg1() + arg2();
 }
 
 static long __dredd_replace_binary_operator_Add_long_long(std::function<long()> arg1, std::function<long()> arg2, int mutation_id) {
-  switch (__dredd_enabled_mutation() - mutation_id) {
-    case 0: return arg1() / arg2();
-    case 1: return arg1() * arg2();
-    case 2: return arg1() % arg2();
-    case 3: return arg1() - arg2();
-    case 4: return arg1();
-    case 5: return arg2();
-    default: return arg1() + arg2();
-  }
+  if (__dredd_enabled_mutation(mutation_id + 0)) return arg1() / arg2();
+  if (__dredd_enabled_mutation(mutation_id + 1)) return arg1() * arg2();
+  if (__dredd_enabled_mutation(mutation_id + 2)) return arg1() % arg2();
+  if (__dredd_enabled_mutation(mutation_id + 3)) return arg1() - arg2();
+  if (__dredd_enabled_mutation(mutation_id + 4)) return arg1();
+  if (__dredd_enabled_mutation(mutation_id + 5)) return arg2();
+  return arg1() + arg2();
 }
 
 static int __dredd_replace_binary_operator_Add_int_int(std::function<int()> arg1, std::function<int()> arg2, int mutation_id) {
-  switch (__dredd_enabled_mutation() - mutation_id) {
-    case 0: return arg1() / arg2();
-    case 1: return arg1() * arg2();
-    case 2: return arg1() % arg2();
-    case 3: return arg1() - arg2();
-    case 4: return arg1();
-    case 5: return arg2();
-    default: return arg1() + arg2();
-  }
+  if (__dredd_enabled_mutation(mutation_id + 0)) return arg1() / arg2();
+  if (__dredd_enabled_mutation(mutation_id + 1)) return arg1() * arg2();
+  if (__dredd_enabled_mutation(mutation_id + 2)) return arg1() % arg2();
+  if (__dredd_enabled_mutation(mutation_id + 3)) return arg1() - arg2();
+  if (__dredd_enabled_mutation(mutation_id + 4)) return arg1();
+  if (__dredd_enabled_mutation(mutation_id + 5)) return arg2();
+  return arg1() + arg2();
 }
 
 int main() {
@@ -78,13 +70,13 @@ int main() {
   int64_t h;
   uint64_t i;
 
-  if (__dredd_enabled_mutation() != 54) { __dredd_replace_binary_operator_Add_unsigned_int_unsigned_int([&]() -> unsigned int { return static_cast<unsigned int>(a); }, [&]() -> unsigned int { return static_cast<unsigned int>(a); }, 0); }
-  if (__dredd_enabled_mutation() != 55) { __dredd_replace_binary_operator_Add_unsigned_int_unsigned_int([&]() -> unsigned int { return static_cast<unsigned int>(b); }, [&]() -> unsigned int { return static_cast<unsigned int>(b); }, 6); }
-  if (__dredd_enabled_mutation() != 56) { __dredd_replace_binary_operator_Add_int_int([&]() -> int { return static_cast<int>(c); }, [&]() -> int { return static_cast<int>(c); }, 12); }
-  if (__dredd_enabled_mutation() != 57) { __dredd_replace_binary_operator_Add_int_int([&]() -> int { return static_cast<int>(d); }, [&]() -> int { return static_cast<int>(d); }, 18); }
-  if (__dredd_enabled_mutation() != 58) { __dredd_replace_binary_operator_Add_unsigned_long_unsigned_long([&]() -> unsigned long { return static_cast<unsigned long>(e); }, [&]() -> unsigned long { return static_cast<unsigned long>(e); }, 24); }
-  if (__dredd_enabled_mutation() != 59) { __dredd_replace_binary_operator_Add_unsigned_long_unsigned_long([&]() -> unsigned long { return static_cast<unsigned long>(f); }, [&]() -> unsigned long { return static_cast<unsigned long>(f); }, 30); }
-  if (__dredd_enabled_mutation() != 60) { __dredd_replace_binary_operator_Add_long_long([&]() -> long { return static_cast<long>(g); }, [&]() -> long { return static_cast<long>(g); }, 36); }
-  if (__dredd_enabled_mutation() != 61) { __dredd_replace_binary_operator_Add_long_long([&]() -> long { return static_cast<long>(h); }, [&]() -> long { return static_cast<long>(h); }, 42); }
-  if (__dredd_enabled_mutation() != 62) { __dredd_replace_binary_operator_Add_unsigned_long_unsigned_long([&]() -> unsigned long { return static_cast<unsigned long>(i); }, [&]() -> unsigned long { return static_cast<unsigned long>(i); }, 48); }
+  if (!__dredd_enabled_mutation(54)) { __dredd_replace_binary_operator_Add_unsigned_int_unsigned_int([&]() -> unsigned int { return static_cast<unsigned int>(a); }, [&]() -> unsigned int { return static_cast<unsigned int>(a); }, 0); }
+  if (!__dredd_enabled_mutation(55)) { __dredd_replace_binary_operator_Add_unsigned_int_unsigned_int([&]() -> unsigned int { return static_cast<unsigned int>(b); }, [&]() -> unsigned int { return static_cast<unsigned int>(b); }, 6); }
+  if (!__dredd_enabled_mutation(56)) { __dredd_replace_binary_operator_Add_int_int([&]() -> int { return static_cast<int>(c); }, [&]() -> int { return static_cast<int>(c); }, 12); }
+  if (!__dredd_enabled_mutation(57)) { __dredd_replace_binary_operator_Add_int_int([&]() -> int { return static_cast<int>(d); }, [&]() -> int { return static_cast<int>(d); }, 18); }
+  if (!__dredd_enabled_mutation(58)) { __dredd_replace_binary_operator_Add_unsigned_long_unsigned_long([&]() -> unsigned long { return static_cast<unsigned long>(e); }, [&]() -> unsigned long { return static_cast<unsigned long>(e); }, 24); }
+  if (!__dredd_enabled_mutation(59)) { __dredd_replace_binary_operator_Add_unsigned_long_unsigned_long([&]() -> unsigned long { return static_cast<unsigned long>(f); }, [&]() -> unsigned long { return static_cast<unsigned long>(f); }, 30); }
+  if (!__dredd_enabled_mutation(60)) { __dredd_replace_binary_operator_Add_long_long([&]() -> long { return static_cast<long>(g); }, [&]() -> long { return static_cast<long>(g); }, 36); }
+  if (!__dredd_enabled_mutation(61)) { __dredd_replace_binary_operator_Add_long_long([&]() -> long { return static_cast<long>(h); }, [&]() -> long { return static_cast<long>(h); }, 42); }
+  if (!__dredd_enabled_mutation(62)) { __dredd_replace_binary_operator_Add_unsigned_long_unsigned_long([&]() -> unsigned long { return static_cast<unsigned long>(i); }, [&]() -> unsigned long { return static_cast<unsigned long>(i); }, 48); }
 }

--- a/test/single_file/basic.expected
+++ b/test/single_file/basic.expected
@@ -1,7 +1,7 @@
 #include <cstdlib>
 #include <functional>
 
-static int __dredd_enabled_mutation() {
+static bool __dredd_enabled_mutation(int mutation_id) {
   static bool initialized = false;
   static int value;
   if (!initialized) {
@@ -13,9 +13,9 @@ static int __dredd_enabled_mutation() {
     }
     initialized = true;
   }
-  return value;
+  return value == mutation_id;
 }
 
 int main() {
-  if (__dredd_enabled_mutation() != 0) { return 0; }
+  if (!__dredd_enabled_mutation(0)) { return 0; }
 }


### PR DESCRIPTION
Paves the way for enabling multiple mutants, by using a predicate to
check whether a mutation is enabled, rather than asking which
particualr mutant is enabled.

Part of #55.