### PR TITLE
Use bool array to track which mutants are enabled

### DIFF
--- a/src/libdredd/include/libdredd/mutation.h
+++ b/src/libdredd/include/libdredd/mutation.h
@@ -39,12 +39,18 @@ class Mutation {
 
   virtual ~Mutation();
 
+  // The |first_mutation_id_in_file| argument can be subtracted from
+  // |mutation_id| to turn it from a global mutation id (across all files) into
+  // a local mutation id with respect to the particular source file being
+  // mutated.
+  //
   // The |dredd_declarations| argument provides a set of declarations that will
   // be added to the start of the source file being mutated. This allows
   // avoiding redundant repeat declarations.
   virtual void Apply(
       clang::ASTContext& ast_context, const clang::Preprocessor& preprocessor,
-      int& mutation_id, clang::Rewriter& rewriter,
+      int first_mutation_id_in_file, int& mutation_id,
+      clang::Rewriter& rewriter,
       std::unordered_set<std::string>& dredd_declarations) const = 0;
 };
 

--- a/src/libdredd/include/libdredd/mutation_remove_statement.h
+++ b/src/libdredd/include/libdredd/mutation_remove_statement.h
@@ -32,7 +32,8 @@ class MutationRemoveStatement : public Mutation {
 
   void Apply(
       clang::ASTContext& ast_context, const clang::Preprocessor& preprocessor,
-      int& mutation_id, clang::Rewriter& rewriter,
+      int first_mutation_id_in_file, int& mutation_id,
+      clang::Rewriter& rewriter,
       std::unordered_set<std::string>& dredd_declarations) const override;
 
  private:

--- a/src/libdredd/include/libdredd/mutation_replace_binary_operator.h
+++ b/src/libdredd/include/libdredd/mutation_replace_binary_operator.h
@@ -35,7 +35,8 @@ class MutationReplaceBinaryOperator : public Mutation {
 
   void Apply(
       clang::ASTContext& ast_context, const clang::Preprocessor& preprocessor,
-      int& mutation_id, clang::Rewriter& rewriter,
+      int first_mutation_id_in_file, int& mutation_id,
+      clang::Rewriter& rewriter,
       std::unordered_set<std::string>& dredd_declarations) const override;
 
  private:

--- a/src/libdredd/src/mutation_remove_statement.cc
+++ b/src/libdredd/src/mutation_remove_statement.cc
@@ -34,7 +34,7 @@ MutationRemoveStatement::MutationRemoveStatement(const clang::Stmt& statement)
 
 void MutationRemoveStatement::Apply(
     clang::ASTContext& ast_context, const clang::Preprocessor& preprocessor,
-    int& mutation_id, clang::Rewriter& rewriter,
+    int first_mutation_id_in_file, int& mutation_id, clang::Rewriter& rewriter,
     std::unordered_set<std::string>& dredd_declarations) const {
   (void)dredd_declarations;  // Unused
   clang::CharSourceRange source_range = clang::tooling::maybeExtendRange(
@@ -43,9 +43,10 @@ void MutationRemoveStatement::Apply(
       clang::tok::TokenKind::semi, ast_context);
 
   bool result = rewriter.ReplaceText(
-      source_range, "if (!__dredd_enabled_mutation(" +
-                        std::to_string(mutation_id) + ")) { " +
-                        rewriter.getRewrittenText(source_range) + " }");
+      source_range,
+      "if (!__dredd_enabled_mutation(" +
+          std::to_string(mutation_id - first_mutation_id_in_file) + ")) { " +
+          rewriter.getRewrittenText(source_range) + " }");
   (void)result;  // Keep release-mode compilers happy.
   assert(!result && "Rewrite failed.\n");
   mutation_id++;

--- a/src/libdredd/src/mutation_remove_statement.cc
+++ b/src/libdredd/src/mutation_remove_statement.cc
@@ -42,11 +42,13 @@ void MutationRemoveStatement::Apply(
           GetSourceRangeInMainFile(preprocessor, statement_)),
       clang::tok::TokenKind::semi, ast_context);
 
+  // Subtracting |first_mutation_id_in_file| turns the global mutation id,
+  // |mutation_id|, into a file-local mutation id.
+  const int local_mutation_id = mutation_id - first_mutation_id_in_file;
   bool result = rewriter.ReplaceText(
-      source_range,
-      "if (!__dredd_enabled_mutation(" +
-          std::to_string(mutation_id - first_mutation_id_in_file) + ")) { " +
-          rewriter.getRewrittenText(source_range) + " }");
+      source_range, "if (!__dredd_enabled_mutation(" +
+                        std::to_string(local_mutation_id) + ")) { " +
+                        rewriter.getRewrittenText(source_range) + " }");
   (void)result;  // Keep release-mode compilers happy.
   assert(!result && "Rewrite failed.\n");
   mutation_id++;

--- a/src/libdredd/src/mutation_replace_binary_operator.cc
+++ b/src/libdredd/src/mutation_replace_binary_operator.cc
@@ -262,6 +262,10 @@ void MutationReplaceBinaryOperator::Apply(
 
   // Replace the binary operator expression with a call to the wrapper
   // function.
+  //
+  // Subtracting |first_mutation_id_in_file| turns the global mutation id,
+  // |mutation_id|, into a file-local mutation id.
+  const int local_mutation_id = mutation_id - first_mutation_id_in_file;
   bool result = rewriter.ReplaceText(
       binary_operator_source_range_in_main_file,
       new_function_name + "([&]() -> " + lhs_type + " { return static_cast<" +
@@ -269,8 +273,7 @@ void MutationReplaceBinaryOperator::Apply(
           rewriter.getRewrittenText(lhs_source_range_in_main_file) +
           +"); }, [&]() -> " + rhs_type + " { return static_cast<" + rhs_type +
           ">(" + rewriter.getRewrittenText(rhs_source_range_in_main_file) +
-          "); }, " + std::to_string(mutation_id - first_mutation_id_in_file) +
-          ")");
+          "); }, " + std::to_string(local_mutation_id) + ")");
   (void)result;  // Keep release-mode compilers happy.
   assert(!result && "Rewrite failed.\n");
 

--- a/src/libdredd/src/mutation_replace_binary_operator.cc
+++ b/src/libdredd/src/mutation_replace_binary_operator.cc
@@ -61,7 +61,7 @@ std::string MutationReplaceBinaryOperator::GenerateMutatorFunction(
                << " arg1, ";
 
   new_function << "std::function<" << rhs_type << "()>"
-               << " arg2, int mutation_id) {\n";
+               << " arg2, int local_mutation_id) {\n";
 
   int mutant_offset = 0;
 
@@ -72,7 +72,7 @@ std::string MutationReplaceBinaryOperator::GenerateMutatorFunction(
     if (op == binary_operator_.getOpcode()) {
       continue;
     }
-    new_function << "  if (__dredd_enabled_mutation(mutation_id + "
+    new_function << "  if (__dredd_enabled_mutation(local_mutation_id + "
                  << mutant_offset << ")) return " << arg1_evaluated << " "
                  << clang::BinaryOperator::getOpcodeStr(op).str() << " "
                  << arg2_evaluated << ";\n";
@@ -80,23 +80,23 @@ std::string MutationReplaceBinaryOperator::GenerateMutatorFunction(
   }
   if (!binary_operator_.isAssignmentOp()) {
     // LHS
-    new_function << "  if (__dredd_enabled_mutation(mutation_id + "
+    new_function << "  if (__dredd_enabled_mutation(local_mutation_id + "
                  << mutant_offset << ")) return " << arg1_evaluated << ";\n";
     mutant_offset++;
 
     // RHS
-    new_function << "  if (__dredd_enabled_mutation(mutation_id + "
+    new_function << "  if (__dredd_enabled_mutation(local_mutation_id + "
                  << mutant_offset << ")) return " << arg2_evaluated << ";\n";
     mutant_offset++;
   }
   if (binary_operator_.isLogicalOp()) {
     // true
-    new_function << "  if (__dredd_enabled_mutation(mutation_id + "
+    new_function << "  if (__dredd_enabled_mutation(local_mutation_id + "
                  << mutant_offset << ")) return true;\n";
     mutant_offset++;
 
     // false
-    new_function << "  if (__dredd_enabled_mutation(mutation_id + "
+    new_function << "  if (__dredd_enabled_mutation(local_mutation_id + "
                  << mutant_offset << ")) return false;\n";
     mutant_offset++;
   }
@@ -116,7 +116,7 @@ std::string MutationReplaceBinaryOperator::GenerateMutatorFunction(
 
 void MutationReplaceBinaryOperator::Apply(
     clang::ASTContext& ast_context, const clang::Preprocessor& preprocessor,
-    int& mutation_id, clang::Rewriter& rewriter,
+    int first_mutation_id_in_file, int& mutation_id, clang::Rewriter& rewriter,
     std::unordered_set<std::string>& dredd_declarations) const {
   std::string new_function_name = "__dredd_replace_binary_operator_";
 
@@ -269,7 +269,8 @@ void MutationReplaceBinaryOperator::Apply(
           rewriter.getRewrittenText(lhs_source_range_in_main_file) +
           +"); }, [&]() -> " + rhs_type + " { return static_cast<" + rhs_type +
           ">(" + rewriter.getRewrittenText(rhs_source_range_in_main_file) +
-          "); }, " + std::to_string(mutation_id) + ")");
+          "); }, " + std::to_string(mutation_id - first_mutation_id_in_file) +
+          ")");
   (void)result;  // Keep release-mode compilers happy.
   assert(!result && "Rewrite failed.\n");
 

--- a/src/libdreddtest/src/mutation_remove_statement_test.cc
+++ b/src/libdreddtest/src/mutation_remove_statement_test.cc
@@ -46,7 +46,7 @@ void TestRemoval(const std::string& original, const std::string& expected,
   int mutation_id = 0;
   std::unordered_set<std::string> dredd_declarations;
   mutation_supplier(ast_unit->getASTContext())
-      .Apply(ast_unit->getASTContext(), ast_unit->getPreprocessor(),
+      .Apply(ast_unit->getASTContext(), ast_unit->getPreprocessor(), 0,
              mutation_id, rewriter, dredd_declarations);
   ASSERT_EQ(1, mutation_id);
   ASSERT_EQ(0, dredd_declarations.size());

--- a/src/libdreddtest/src/mutation_replace_binary_operator_test.cc
+++ b/src/libdreddtest/src/mutation_replace_binary_operator_test.cc
@@ -56,7 +56,7 @@ void TestReplacement(const std::string& original, const std::string& expected,
                            ast_unit->getLangOpts());
   int mutation_id = 0;
   std::unordered_set<std::string> dredd_declarations;
-  mutation.Apply(ast_unit->getASTContext(), ast_unit->getPreprocessor(),
+  mutation.Apply(ast_unit->getASTContext(), ast_unit->getPreprocessor(), 0,
                  mutation_id, rewriter, dredd_declarations);
   ASSERT_EQ(num_replacements, mutation_id);
   ASSERT_EQ(1, dredd_declarations.size());
@@ -77,13 +77,13 @@ TEST(MutationReplaceBinaryOperatorTest, MutateAdd) {
       "0); "
       "}";
   std::string expected_dredd_declaration =
-      R"(static int __dredd_replace_binary_operator_Add_int_int(std::function<int()> arg1, std::function<int()> arg2, int mutation_id) {
-  if (__dredd_enabled_mutation(mutation_id + 0)) return arg1() / arg2();
-  if (__dredd_enabled_mutation(mutation_id + 1)) return arg1() * arg2();
-  if (__dredd_enabled_mutation(mutation_id + 2)) return arg1() % arg2();
-  if (__dredd_enabled_mutation(mutation_id + 3)) return arg1() - arg2();
-  if (__dredd_enabled_mutation(mutation_id + 4)) return arg1();
-  if (__dredd_enabled_mutation(mutation_id + 5)) return arg2();
+      R"(static int __dredd_replace_binary_operator_Add_int_int(std::function<int()> arg1, std::function<int()> arg2, int local_mutation_id) {
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() / arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1() * arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1() % arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return arg1() - arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return arg1();
+  if (__dredd_enabled_mutation(local_mutation_id + 5)) return arg2();
   return arg1() + arg2();
 }
 
@@ -108,12 +108,12 @@ TEST(MutationReplaceBinaryOperatorTest, MutateAnd) {
 }
 )";
   std::string expected_dredd_declaration =
-      R"(static bool __dredd_replace_binary_operator_LAnd_bool_bool(std::function<bool()> arg1, std::function<bool()> arg2, int mutation_id) {
-  if (__dredd_enabled_mutation(mutation_id + 0)) return arg1() || arg2();
-  if (__dredd_enabled_mutation(mutation_id + 1)) return arg1();
-  if (__dredd_enabled_mutation(mutation_id + 2)) return arg2();
-  if (__dredd_enabled_mutation(mutation_id + 3)) return true;
-  if (__dredd_enabled_mutation(mutation_id + 4)) return false;
+      R"(static bool __dredd_replace_binary_operator_LAnd_bool_bool(std::function<bool()> arg1, std::function<bool()> arg2, int local_mutation_id) {
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() || arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1();
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return true;
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return false;
   return arg1() && arg2();
 }
 
@@ -136,17 +136,17 @@ TEST(MutationReplaceBinaryOperatorTest, MutateAssign) {
 }
 )";
   std::string expected_dredd_declaration =
-      R"(static int& __dredd_replace_binary_operator_Assign_int_int(std::function<int&()> arg1, std::function<int()> arg2, int mutation_id) {
-  if (__dredd_enabled_mutation(mutation_id + 0)) return arg1() += arg2();
-  if (__dredd_enabled_mutation(mutation_id + 1)) return arg1() &= arg2();
-  if (__dredd_enabled_mutation(mutation_id + 2)) return arg1() /= arg2();
-  if (__dredd_enabled_mutation(mutation_id + 3)) return arg1() *= arg2();
-  if (__dredd_enabled_mutation(mutation_id + 4)) return arg1() |= arg2();
-  if (__dredd_enabled_mutation(mutation_id + 5)) return arg1() %= arg2();
-  if (__dredd_enabled_mutation(mutation_id + 6)) return arg1() <<= arg2();
-  if (__dredd_enabled_mutation(mutation_id + 7)) return arg1() >>= arg2();
-  if (__dredd_enabled_mutation(mutation_id + 8)) return arg1() -= arg2();
-  if (__dredd_enabled_mutation(mutation_id + 9)) return arg1() ^= arg2();
+      R"(static int& __dredd_replace_binary_operator_Assign_int_int(std::function<int&()> arg1, std::function<int()> arg2, int local_mutation_id) {
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() += arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1() &= arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1() /= arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return arg1() *= arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return arg1() |= arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 5)) return arg1() %= arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 6)) return arg1() <<= arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 7)) return arg1() >>= arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 8)) return arg1() -= arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 9)) return arg1() ^= arg2();
   return arg1() = arg2();
 }
 
@@ -173,17 +173,17 @@ void foo() {
 }
 )";
   std::string expected_dredd_declaration =
-      R"(static int& __dredd_replace_binary_operator_Assign_int_int(std::function<int&()> arg1, std::function<int()> arg2, int mutation_id) {
-  if (__dredd_enabled_mutation(mutation_id + 0)) return arg1() += arg2();
-  if (__dredd_enabled_mutation(mutation_id + 1)) return arg1() &= arg2();
-  if (__dredd_enabled_mutation(mutation_id + 2)) return arg1() /= arg2();
-  if (__dredd_enabled_mutation(mutation_id + 3)) return arg1() *= arg2();
-  if (__dredd_enabled_mutation(mutation_id + 4)) return arg1() |= arg2();
-  if (__dredd_enabled_mutation(mutation_id + 5)) return arg1() %= arg2();
-  if (__dredd_enabled_mutation(mutation_id + 6)) return arg1() <<= arg2();
-  if (__dredd_enabled_mutation(mutation_id + 7)) return arg1() >>= arg2();
-  if (__dredd_enabled_mutation(mutation_id + 8)) return arg1() -= arg2();
-  if (__dredd_enabled_mutation(mutation_id + 9)) return arg1() ^= arg2();
+      R"(static int& __dredd_replace_binary_operator_Assign_int_int(std::function<int&()> arg1, std::function<int()> arg2, int local_mutation_id) {
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() += arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1() &= arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1() /= arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return arg1() *= arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return arg1() |= arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 5)) return arg1() %= arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 6)) return arg1() <<= arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 7)) return arg1() >>= arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 8)) return arg1() -= arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 9)) return arg1() ^= arg2();
   return arg1() = arg2();
 }
 

--- a/test/single_file/add.expected
+++ b/test/single_file/add.expected
@@ -1,28 +1,30 @@
 #include <cstdlib>
 #include <functional>
 
-static bool __dredd_enabled_mutation(int mutation_id) {
+static bool __dredd_enabled_mutation(int local_mutation_id) {
   static bool initialized = false;
-  static int value;
+  static bool enabled[13];
   if (!initialized) {
     const char* __dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
-    if (__dredd_environment_variable == nullptr) {
-      value = -1;
-    } else {
-      value = atoi(__dredd_environment_variable);
+    if (__dredd_environment_variable != nullptr) {
+      int value = atoi(__dredd_environment_variable);
+      int local_value = value - 0;
+      if (local_value >= 0 && local_value < 13) {
+        enabled[local_value] = true;
+      }
     }
     initialized = true;
   }
-  return value == mutation_id;
+  return enabled[local_mutation_id];
 }
 
-static int __dredd_replace_binary_operator_Add_int_int(std::function<int()> arg1, std::function<int()> arg2, int mutation_id) {
-  if (__dredd_enabled_mutation(mutation_id + 0)) return arg1() / arg2();
-  if (__dredd_enabled_mutation(mutation_id + 1)) return arg1() * arg2();
-  if (__dredd_enabled_mutation(mutation_id + 2)) return arg1() % arg2();
-  if (__dredd_enabled_mutation(mutation_id + 3)) return arg1() - arg2();
-  if (__dredd_enabled_mutation(mutation_id + 4)) return arg1();
-  if (__dredd_enabled_mutation(mutation_id + 5)) return arg2();
+static int __dredd_replace_binary_operator_Add_int_int(std::function<int()> arg1, std::function<int()> arg2, int local_mutation_id) {
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() / arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1() * arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1() % arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return arg1() - arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return arg1();
+  if (__dredd_enabled_mutation(local_mutation_id + 5)) return arg2();
   return arg1() + arg2();
 }
 

--- a/test/single_file/add_mul.expected
+++ b/test/single_file/add_mul.expected
@@ -1,38 +1,40 @@
 #include <cstdlib>
 #include <functional>
 
-static bool __dredd_enabled_mutation(int mutation_id) {
+static bool __dredd_enabled_mutation(int local_mutation_id) {
   static bool initialized = false;
-  static int value;
+  static bool enabled[13];
   if (!initialized) {
     const char* __dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
-    if (__dredd_environment_variable == nullptr) {
-      value = -1;
-    } else {
-      value = atoi(__dredd_environment_variable);
+    if (__dredd_environment_variable != nullptr) {
+      int value = atoi(__dredd_environment_variable);
+      int local_value = value - 0;
+      if (local_value >= 0 && local_value < 13) {
+        enabled[local_value] = true;
+      }
     }
     initialized = true;
   }
-  return value == mutation_id;
+  return enabled[local_mutation_id];
 }
 
-static int __dredd_replace_binary_operator_Mul_int_int(std::function<int()> arg1, std::function<int()> arg2, int mutation_id) {
-  if (__dredd_enabled_mutation(mutation_id + 0)) return arg1() + arg2();
-  if (__dredd_enabled_mutation(mutation_id + 1)) return arg1() / arg2();
-  if (__dredd_enabled_mutation(mutation_id + 2)) return arg1() % arg2();
-  if (__dredd_enabled_mutation(mutation_id + 3)) return arg1() - arg2();
-  if (__dredd_enabled_mutation(mutation_id + 4)) return arg1();
-  if (__dredd_enabled_mutation(mutation_id + 5)) return arg2();
+static int __dredd_replace_binary_operator_Mul_int_int(std::function<int()> arg1, std::function<int()> arg2, int local_mutation_id) {
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() + arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1() / arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1() % arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return arg1() - arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return arg1();
+  if (__dredd_enabled_mutation(local_mutation_id + 5)) return arg2();
   return arg1() * arg2();
 }
 
-static int __dredd_replace_binary_operator_Add_int_int(std::function<int()> arg1, std::function<int()> arg2, int mutation_id) {
-  if (__dredd_enabled_mutation(mutation_id + 0)) return arg1() / arg2();
-  if (__dredd_enabled_mutation(mutation_id + 1)) return arg1() * arg2();
-  if (__dredd_enabled_mutation(mutation_id + 2)) return arg1() % arg2();
-  if (__dredd_enabled_mutation(mutation_id + 3)) return arg1() - arg2();
-  if (__dredd_enabled_mutation(mutation_id + 4)) return arg1();
-  if (__dredd_enabled_mutation(mutation_id + 5)) return arg2();
+static int __dredd_replace_binary_operator_Add_int_int(std::function<int()> arg1, std::function<int()> arg2, int local_mutation_id) {
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() / arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1() * arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1() % arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return arg1() - arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return arg1();
+  if (__dredd_enabled_mutation(local_mutation_id + 5)) return arg2();
   return arg1() + arg2();
 }
 

--- a/test/single_file/add_type_aliases.expected
+++ b/test/single_file/add_type_aliases.expected
@@ -4,58 +4,60 @@
 #include <cstdlib>
 #include <functional>
 
-static bool __dredd_enabled_mutation(int mutation_id) {
+static bool __dredd_enabled_mutation(int local_mutation_id) {
   static bool initialized = false;
-  static int value;
+  static bool enabled[63];
   if (!initialized) {
     const char* __dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
-    if (__dredd_environment_variable == nullptr) {
-      value = -1;
-    } else {
-      value = atoi(__dredd_environment_variable);
+    if (__dredd_environment_variable != nullptr) {
+      int value = atoi(__dredd_environment_variable);
+      int local_value = value - 0;
+      if (local_value >= 0 && local_value < 63) {
+        enabled[local_value] = true;
+      }
     }
     initialized = true;
   }
-  return value == mutation_id;
+  return enabled[local_mutation_id];
 }
 
-static unsigned long __dredd_replace_binary_operator_Add_unsigned_long_unsigned_long(std::function<unsigned long()> arg1, std::function<unsigned long()> arg2, int mutation_id) {
-  if (__dredd_enabled_mutation(mutation_id + 0)) return arg1() / arg2();
-  if (__dredd_enabled_mutation(mutation_id + 1)) return arg1() * arg2();
-  if (__dredd_enabled_mutation(mutation_id + 2)) return arg1() % arg2();
-  if (__dredd_enabled_mutation(mutation_id + 3)) return arg1() - arg2();
-  if (__dredd_enabled_mutation(mutation_id + 4)) return arg1();
-  if (__dredd_enabled_mutation(mutation_id + 5)) return arg2();
+static unsigned long __dredd_replace_binary_operator_Add_unsigned_long_unsigned_long(std::function<unsigned long()> arg1, std::function<unsigned long()> arg2, int local_mutation_id) {
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() / arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1() * arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1() % arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return arg1() - arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return arg1();
+  if (__dredd_enabled_mutation(local_mutation_id + 5)) return arg2();
   return arg1() + arg2();
 }
 
-static unsigned int __dredd_replace_binary_operator_Add_unsigned_int_unsigned_int(std::function<unsigned int()> arg1, std::function<unsigned int()> arg2, int mutation_id) {
-  if (__dredd_enabled_mutation(mutation_id + 0)) return arg1() / arg2();
-  if (__dredd_enabled_mutation(mutation_id + 1)) return arg1() * arg2();
-  if (__dredd_enabled_mutation(mutation_id + 2)) return arg1() % arg2();
-  if (__dredd_enabled_mutation(mutation_id + 3)) return arg1() - arg2();
-  if (__dredd_enabled_mutation(mutation_id + 4)) return arg1();
-  if (__dredd_enabled_mutation(mutation_id + 5)) return arg2();
+static unsigned int __dredd_replace_binary_operator_Add_unsigned_int_unsigned_int(std::function<unsigned int()> arg1, std::function<unsigned int()> arg2, int local_mutation_id) {
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() / arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1() * arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1() % arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return arg1() - arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return arg1();
+  if (__dredd_enabled_mutation(local_mutation_id + 5)) return arg2();
   return arg1() + arg2();
 }
 
-static long __dredd_replace_binary_operator_Add_long_long(std::function<long()> arg1, std::function<long()> arg2, int mutation_id) {
-  if (__dredd_enabled_mutation(mutation_id + 0)) return arg1() / arg2();
-  if (__dredd_enabled_mutation(mutation_id + 1)) return arg1() * arg2();
-  if (__dredd_enabled_mutation(mutation_id + 2)) return arg1() % arg2();
-  if (__dredd_enabled_mutation(mutation_id + 3)) return arg1() - arg2();
-  if (__dredd_enabled_mutation(mutation_id + 4)) return arg1();
-  if (__dredd_enabled_mutation(mutation_id + 5)) return arg2();
+static long __dredd_replace_binary_operator_Add_long_long(std::function<long()> arg1, std::function<long()> arg2, int local_mutation_id) {
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() / arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1() * arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1() % arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return arg1() - arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return arg1();
+  if (__dredd_enabled_mutation(local_mutation_id + 5)) return arg2();
   return arg1() + arg2();
 }
 
-static int __dredd_replace_binary_operator_Add_int_int(std::function<int()> arg1, std::function<int()> arg2, int mutation_id) {
-  if (__dredd_enabled_mutation(mutation_id + 0)) return arg1() / arg2();
-  if (__dredd_enabled_mutation(mutation_id + 1)) return arg1() * arg2();
-  if (__dredd_enabled_mutation(mutation_id + 2)) return arg1() % arg2();
-  if (__dredd_enabled_mutation(mutation_id + 3)) return arg1() - arg2();
-  if (__dredd_enabled_mutation(mutation_id + 4)) return arg1();
-  if (__dredd_enabled_mutation(mutation_id + 5)) return arg2();
+static int __dredd_replace_binary_operator_Add_int_int(std::function<int()> arg1, std::function<int()> arg2, int local_mutation_id) {
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() / arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1() * arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1() % arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return arg1() - arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return arg1();
+  if (__dredd_enabled_mutation(local_mutation_id + 5)) return arg2();
   return arg1() + arg2();
 }
 

--- a/test/single_file/basic.expected
+++ b/test/single_file/basic.expected
@@ -1,19 +1,21 @@
 #include <cstdlib>
 #include <functional>
 
-static bool __dredd_enabled_mutation(int mutation_id) {
+static bool __dredd_enabled_mutation(int local_mutation_id) {
   static bool initialized = false;
-  static int value;
+  static bool enabled[1];
   if (!initialized) {
     const char* __dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
-    if (__dredd_environment_variable == nullptr) {
-      value = -1;
-    } else {
-      value = atoi(__dredd_environment_variable);
+    if (__dredd_environment_variable != nullptr) {
+      int value = atoi(__dredd_environment_variable);
+      int local_value = value - 0;
+      if (local_value >= 0 && local_value < 1) {
+        enabled[local_value] = true;
+      }
     }
     initialized = true;
   }
-  return value == mutation_id;
+  return enabled[local_mutation_id];
 }
 
 int main() {

--- a/test/single_file/volatile.expected
+++ b/test/single_file/volatile.expected
@@ -1,38 +1,38 @@
 #include <cstdlib>
 #include <functional>
 
-static int __dredd_enabled_mutation() {
+static bool __dredd_enabled_mutation(int local_mutation_id) {
   static bool initialized = false;
-  static int value;
+  static bool enabled[11];
   if (!initialized) {
     const char* __dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
-    if (__dredd_environment_variable == nullptr) {
-      value = -1;
-    } else {
-      value = atoi(__dredd_environment_variable);
+    if (__dredd_environment_variable != nullptr) {
+      int value = atoi(__dredd_environment_variable);
+      int local_value = value - 0;
+      if (local_value >= 0 && local_value < 11) {
+        enabled[local_value] = true;
+      }
     }
     initialized = true;
   }
-  return value;
+  return enabled[local_mutation_id];
 }
 
-static volatile int& __dredd_replace_binary_operator_AddAssign_int_int(std::function<volatile int&()> arg1, std::function<int()> arg2, int mutation_id) {
-  switch (__dredd_enabled_mutation() - mutation_id) {
-    case 0: return arg1() &= arg2();
-    case 1: return arg1() = arg2();
-    case 2: return arg1() /= arg2();
-    case 3: return arg1() *= arg2();
-    case 4: return arg1() |= arg2();
-    case 5: return arg1() %= arg2();
-    case 6: return arg1() <<= arg2();
-    case 7: return arg1() >>= arg2();
-    case 8: return arg1() -= arg2();
-    case 9: return arg1() ^= arg2();
-    default: return arg1() += arg2();
-  }
+static volatile int& __dredd_replace_binary_operator_AddAssign_int_int(std::function<volatile int&()> arg1, std::function<int()> arg2, int local_mutation_id) {
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() &= arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1() = arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1() /= arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return arg1() *= arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return arg1() |= arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 5)) return arg1() %= arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 6)) return arg1() <<= arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 7)) return arg1() >>= arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 8)) return arg1() -= arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 9)) return arg1() ^= arg2();
+  return arg1() += arg2();
 }
 
 void foo() {
   volatile int a;
-  if (__dredd_enabled_mutation() != 10) { __dredd_replace_binary_operator_AddAssign_int_int([&]() -> volatile int& { return static_cast<volatile int&>(a); }, [&]() -> int { return static_cast<int>(2); }, 0); }
+  if (!__dredd_enabled_mutation(10)) { __dredd_replace_binary_operator_AddAssign_int_int([&]() -> volatile int& { return static_cast<volatile int&>(a); }, [&]() -> int { return static_cast<int>(2); }, 0); }
 }


### PR DESCRIPTION
Paving the way for having multiple mutants enabled, this change
introduces an array of booleans to track the mutations that are
enabled on a per file basis. At present, at most one element of this
array will be set to true. In a future change, environment variable
parsing will be updated to support multiple mutants.

Part of #55.