### PR TITLE
Use bitset for enabled mutants

### DIFF
--- a/test/single_file/add.expected
+++ b/test/single_file/add.expected
@@ -1,21 +1,22 @@
+#include <cinttypes>
 #include <cstdlib>
 #include <functional>
 
 static bool __dredd_enabled_mutation(int local_mutation_id) {
   static bool initialized = false;
-  static bool enabled[13];
+  static uint64_t enabled_bitset[1];
   if (!initialized) {
     const char* __dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
     if (__dredd_environment_variable != nullptr) {
       int value = atoi(__dredd_environment_variable);
       int local_value = value - 0;
       if (local_value >= 0 && local_value < 13) {
-        enabled[local_value] = true;
+        enabled_bitset[local_value / 64] |= (1 << (local_value & 63));
       }
     }
     initialized = true;
   }
-  return enabled[local_mutation_id];
+  return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id & 63))) != 0;
 }
 
 static int __dredd_replace_binary_operator_Add_int_int(std::function<int()> arg1, std::function<int()> arg2, int local_mutation_id) {

--- a/test/single_file/add.expected
+++ b/test/single_file/add.expected
@@ -11,12 +11,12 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
       int value = atoi(__dredd_environment_variable);
       int local_value = value - 0;
       if (local_value >= 0 && local_value < 13) {
-        enabled_bitset[local_value / 64] |= (1 << (local_value & 63));
+        enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
       }
     }
     initialized = true;
   }
-  return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id & 63))) != 0;
+  return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }
 
 static int __dredd_replace_binary_operator_Add_int_int(std::function<int()> arg1, std::function<int()> arg2, int local_mutation_id) {

--- a/test/single_file/add_mul.expected
+++ b/test/single_file/add_mul.expected
@@ -1,21 +1,22 @@
+#include <cinttypes>
 #include <cstdlib>
 #include <functional>
 
 static bool __dredd_enabled_mutation(int local_mutation_id) {
   static bool initialized = false;
-  static bool enabled[13];
+  static uint64_t enabled_bitset[1];
   if (!initialized) {
     const char* __dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
     if (__dredd_environment_variable != nullptr) {
       int value = atoi(__dredd_environment_variable);
       int local_value = value - 0;
       if (local_value >= 0 && local_value < 13) {
-        enabled[local_value] = true;
+        enabled_bitset[local_value / 64] |= (1 << (local_value & 63));
       }
     }
     initialized = true;
   }
-  return enabled[local_mutation_id];
+  return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id & 63))) != 0;
 }
 
 static int __dredd_replace_binary_operator_Mul_int_int(std::function<int()> arg1, std::function<int()> arg2, int local_mutation_id) {

--- a/test/single_file/add_mul.expected
+++ b/test/single_file/add_mul.expected
@@ -11,12 +11,12 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
       int value = atoi(__dredd_environment_variable);
       int local_value = value - 0;
       if (local_value >= 0 && local_value < 13) {
-        enabled_bitset[local_value / 64] |= (1 << (local_value & 63));
+        enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
       }
     }
     initialized = true;
   }
-  return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id & 63))) != 0;
+  return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }
 
 static int __dredd_replace_binary_operator_Mul_int_int(std::function<int()> arg1, std::function<int()> arg2, int local_mutation_id) {

--- a/test/single_file/add_type_aliases.expected
+++ b/test/single_file/add_type_aliases.expected
@@ -14,12 +14,12 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
       int value = atoi(__dredd_environment_variable);
       int local_value = value - 0;
       if (local_value >= 0 && local_value < 63) {
-        enabled_bitset[local_value / 64] |= (1 << (local_value & 63));
+        enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
       }
     }
     initialized = true;
   }
-  return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id & 63))) != 0;
+  return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }
 
 static unsigned long __dredd_replace_binary_operator_Add_unsigned_long_unsigned_long(std::function<unsigned long()> arg1, std::function<unsigned long()> arg2, int local_mutation_id) {

--- a/test/single_file/add_type_aliases.expected
+++ b/test/single_file/add_type_aliases.expected
@@ -1,24 +1,25 @@
 #include <cinttypes>
 #include <cstddef>
 
+#include <cinttypes>
 #include <cstdlib>
 #include <functional>
 
 static bool __dredd_enabled_mutation(int local_mutation_id) {
   static bool initialized = false;
-  static bool enabled[63];
+  static uint64_t enabled_bitset[1];
   if (!initialized) {
     const char* __dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
     if (__dredd_environment_variable != nullptr) {
       int value = atoi(__dredd_environment_variable);
       int local_value = value - 0;
       if (local_value >= 0 && local_value < 63) {
-        enabled[local_value] = true;
+        enabled_bitset[local_value / 64] |= (1 << (local_value & 63));
       }
     }
     initialized = true;
   }
-  return enabled[local_mutation_id];
+  return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id & 63))) != 0;
 }
 
 static unsigned long __dredd_replace_binary_operator_Add_unsigned_long_unsigned_long(std::function<unsigned long()> arg1, std::function<unsigned long()> arg2, int local_mutation_id) {

--- a/test/single_file/basic.expected
+++ b/test/single_file/basic.expected
@@ -11,12 +11,12 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
       int value = atoi(__dredd_environment_variable);
       int local_value = value - 0;
       if (local_value >= 0 && local_value < 1) {
-        enabled_bitset[local_value / 64] |= (1 << (local_value & 63));
+        enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
       }
     }
     initialized = true;
   }
-  return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id & 63))) != 0;
+  return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }
 
 int main() {

--- a/test/single_file/basic.expected
+++ b/test/single_file/basic.expected
@@ -1,21 +1,22 @@
+#include <cinttypes>
 #include <cstdlib>
 #include <functional>
 
 static bool __dredd_enabled_mutation(int local_mutation_id) {
   static bool initialized = false;
-  static bool enabled[1];
+  static uint64_t enabled_bitset[1];
   if (!initialized) {
     const char* __dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
     if (__dredd_environment_variable != nullptr) {
       int value = atoi(__dredd_environment_variable);
       int local_value = value - 0;
       if (local_value >= 0 && local_value < 1) {
-        enabled[local_value] = true;
+        enabled_bitset[local_value / 64] |= (1 << (local_value & 63));
       }
     }
     initialized = true;
   }
-  return enabled[local_mutation_id];
+  return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id & 63))) != 0;
 }
 
 int main() {

--- a/test/single_file/volatile.expected
+++ b/test/single_file/volatile.expected
@@ -1,21 +1,22 @@
+#include <cinttypes>
 #include <cstdlib>
 #include <functional>
 
 static bool __dredd_enabled_mutation(int local_mutation_id) {
   static bool initialized = false;
-  static bool enabled[11];
+  static uint64_t enabled_bitset[1];
   if (!initialized) {
     const char* __dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
     if (__dredd_environment_variable != nullptr) {
       int value = atoi(__dredd_environment_variable);
       int local_value = value - 0;
       if (local_value >= 0 && local_value < 11) {
-        enabled[local_value] = true;
+        enabled_bitset[local_value / 64] |= (1 << (local_value & 63));
       }
     }
     initialized = true;
   }
-  return enabled[local_mutation_id];
+  return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id & 63))) != 0;
 }
 
 static volatile int& __dredd_replace_binary_operator_AddAssign_int_int(std::function<volatile int&()> arg1, std::function<int()> arg2, int local_mutation_id) {

--- a/test/single_file/volatile.expected
+++ b/test/single_file/volatile.expected
@@ -11,12 +11,12 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
       int value = atoi(__dredd_environment_variable);
       int local_value = value - 0;
       if (local_value >= 0 && local_value < 11) {
-        enabled_bitset[local_value / 64] |= (1 << (local_value & 63));
+        enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
       }
     }
     initialized = true;
   }
-  return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id & 63))) != 0;
+  return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }
 
 static volatile int& __dredd_replace_binary_operator_AddAssign_int_int(std::function<volatile int&()> arg1, std::function<int()> arg2, int local_mutation_id) {


### PR DESCRIPTION
Replaces array of booleans with bitset for tracking of enabled
mutants, which is more space-efficient.
    
Part of #55.