### PR TITLE
Fix rewriting error before first declaration

### DIFF
--- a/src/libdredd/src/mutate_ast_consumer.cc
+++ b/src/libdredd/src/mutate_ast_consumer.cc
@@ -28,6 +28,7 @@
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Rewrite/Core/Rewriter.h"
 #include "libdredd/mutation.h"
+#include "libdredd/util.h"
 
 namespace dredd {
 
@@ -80,14 +81,18 @@ void MutateAstConsumer::HandleTranslationUnit(clang::ASTContext& context) {
          "There is at least one mutation, therefore there must be at least one "
          "declaration.");
 
+  auto first_decl_in_main_file =
+      GetSourceRangeInMainFile(compiler_instance_.getPreprocessor(),
+                               *visitor_->GetFirstDeclInSourceFile())
+          .getBegin();
+
   // Convert the unordered set Dredd declarations into an ordered set and add
   // them to the source file before the first declaration.
   std::set<std::string> sorted_dredd_declarations;
   sorted_dredd_declarations.insert(dredd_declarations.begin(),
                                    dredd_declarations.end());
   for (const auto& decl : sorted_dredd_declarations) {
-    bool result = rewriter_.InsertTextBefore(
-        visitor_->GetFirstDeclInSourceFile()->getBeginLoc(), decl);
+    bool result = rewriter_.InsertTextBefore(first_decl_in_main_file, decl);
     (void)result;  // Keep release-mode compilers happy.
     assert(!result && "Rewrite failed.\n");
   }
@@ -165,8 +170,8 @@ void MutateAstConsumer::HandleTranslationUnit(clang::ASTContext& context) {
                    "(local_mutation_id % 64))) != 0;\n";
   dredd_prelude << "}\n\n";
 
-  bool result = rewriter_.InsertTextBefore(
-      visitor_->GetFirstDeclInSourceFile()->getBeginLoc(), dredd_prelude.str());
+  bool result =
+      rewriter_.InsertTextBefore(first_decl_in_main_file, dredd_prelude.str());
   (void)result;  // Keep release-mode compilers happy.
   assert(!result && "Rewrite failed.\n");
 

--- a/src/libdredd/src/mutate_ast_consumer.cc
+++ b/src/libdredd/src/mutate_ast_consumer.cc
@@ -23,8 +23,8 @@
 
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Decl.h"
-#include "clang/AST/DeclBase.h"
 #include "clang/Basic/Diagnostic.h"
+#include "clang/Basic/SourceLocation.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Rewrite/Core/Rewriter.h"
 #include "libdredd/mutation.h"

--- a/test/single_file/define_in_first_decl.cc
+++ b/test/single_file/define_in_first_decl.cc
@@ -1,0 +1,5 @@
+#define TYPE int
+
+TYPE foo() {
+  return 1 + 2;
+}

--- a/test/single_file/define_in_first_decl.expected
+++ b/test/single_file/define_in_first_decl.expected
@@ -1,0 +1,48 @@
+#define TYPE int
+
+#include <cinttypes>
+#include <cstddef>
+#include <functional>
+#include <string>
+
+static bool __dredd_enabled_mutation(int local_mutation_id) {
+  static bool initialized = false;
+  static uint64_t enabled_bitset[1];
+  if (!initialized) {
+    const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
+    if (dredd_environment_variable != nullptr) {
+      std::string contents(dredd_environment_variable);
+      while (true) {
+        size_t pos = contents.find(",");
+        std::string token = (pos == std::string::npos ? contents : contents.substr(0, pos));
+        if (!token.empty()) {
+          int value = std::stoi(token);
+          int local_value = value - 0;
+          if (local_value >= 0 && local_value < 7) {
+            enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+          }
+        }
+        if (pos == std::string::npos) {
+          break;
+        }
+        contents.erase(0, pos + 1);
+      }
+    }
+    initialized = true;
+  }
+  return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
+}
+
+static int __dredd_replace_binary_operator_Add_int_int(std::function<int()> arg1, std::function<int()> arg2, int local_mutation_id) {
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() / arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1() * arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1() % arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return arg1() - arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return arg1();
+  if (__dredd_enabled_mutation(local_mutation_id + 5)) return arg2();
+  return arg1() + arg2();
+}
+
+TYPE foo() {
+  if (!__dredd_enabled_mutation(6)) { return __dredd_replace_binary_operator_Add_int_int([&]() -> int { return static_cast<int>(1); }, [&]() -> int { return static_cast<int>(2); }, 0); }
+}


### PR DESCRIPTION
Fixes Dredd so that the source range in the main file is obtained for
the first declaration occurring in that file, before inserting Dredd's
prelude. This avoids a problem where if the first declaration starts
with a macro expansion, its begin location is not valid for an
insertion.

Fixes #66.