### PR TITLE
Do not mutate switch case expressions

### DIFF
--- a/src/libdredd/include_private/include/libdredd/mutate_visitor.h
+++ b/src/libdredd/include_private/include/libdredd/mutate_visitor.h
@@ -35,6 +35,10 @@ class MutateVisitor : public clang::RecursiveASTVisitor<MutateVisitor> {
 
   bool TraverseDecl(clang::Decl* decl);
 
+  // Overridden in order to avoid visiting the expressions associated with case
+  // statements.
+  bool TraverseCaseStmt(clang::CaseStmt* case_stmt);
+
   bool VisitUnaryOperator(clang::UnaryOperator* unary_operator);
 
   bool VisitBinaryOperator(clang::BinaryOperator* binary_operator);

--- a/src/libdredd/src/mutate_visitor.cc
+++ b/src/libdredd/src/mutate_visitor.cc
@@ -84,6 +84,13 @@ bool MutateVisitor::TraverseDecl(clang::Decl* decl) {
   return true;
 }
 
+bool MutateVisitor::TraverseCaseStmt(clang::CaseStmt* case_stmt) {
+  // Do not traverse the expression associated with this switch case: switch
+  // case expressions need to be constant, which rules out the kinds of
+  // mutations that Dredd performs.
+  return TraverseStmt(case_stmt->getSubStmt());
+}
+
 bool MutateVisitor::VisitUnaryOperator(clang::UnaryOperator* unary_operator) {
   if (NotInFunction()) {
     // Only consider mutating unary expressions that occur inside functions.

--- a/test/single_file/negative_switch_case.cc
+++ b/test/single_file/negative_switch_case.cc
@@ -1,0 +1,8 @@
+int main() {
+  switch(0) {
+  case -1:
+    break;
+  default:
+    break;
+  }
+}

--- a/test/single_file/negative_switch_case.expected
+++ b/test/single_file/negative_switch_case.expected
@@ -1,0 +1,41 @@
+#include <cinttypes>
+#include <cstddef>
+#include <functional>
+#include <string>
+
+static bool __dredd_enabled_mutation(int local_mutation_id) {
+  static bool initialized = false;
+  static uint64_t enabled_bitset[1];
+  if (!initialized) {
+    const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
+    if (dredd_environment_variable != nullptr) {
+      std::string contents(dredd_environment_variable);
+      while (true) {
+        size_t pos = contents.find(",");
+        std::string token = (pos == std::string::npos ? contents : contents.substr(0, pos));
+        if (!token.empty()) {
+          int value = std::stoi(token);
+          int local_value = value - 0;
+          if (local_value >= 0 && local_value < 1) {
+            enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+          }
+        }
+        if (pos == std::string::npos) {
+          break;
+        }
+        contents.erase(0, pos + 1);
+      }
+    }
+    initialized = true;
+  }
+  return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
+}
+
+int main() {
+  if (!__dredd_enabled_mutation(0)) { switch(0) {
+  case -1:
+    break;
+  default:
+    break;
+  } }
+}


### PR DESCRIPTION
Switch case expressions need to be constants and so cannot easily
mutated in the Dredd style.

Fixes #68.