### PR TITLE
Correct where Dredd prelude is inserted

### DIFF
--- a/src/libdredd/include_private/include/libdredd/mutate_visitor.h
+++ b/src/libdredd/include_private/include/libdredd/mutate_visitor.h
@@ -24,6 +24,7 @@
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/Stmt.h"
 #include "clang/AST/Type.h"
+#include "clang/Basic/SourceLocation.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "libdredd/mutation.h"
 
@@ -55,16 +56,17 @@ class MutateVisitor : public clang::RecursiveASTVisitor<MutateVisitor> {
     return mutations_;
   }
 
-  [[nodiscard]] const clang::Decl* GetFirstDeclInSourceFile() const {
-    return first_decl_in_source_file_;
+  [[nodiscard]] clang::SourceLocation GetStartLocationOfFirstDeclInSourceFile()
+      const {
+    return start_location_of_first_decl_in_source_file_;
   }
 
  private:
   const clang::CompilerInstance& compiler_instance_;
 
-  // Records the very first declaration in the source file, before which
-  // directives such as includes can be placed.
-  const clang::Decl* first_decl_in_source_file_;
+  // Records the start locat of the very first declaration in the source file,
+  // before which Dredd's prelude can be placed.
+  clang::SourceLocation start_location_of_first_decl_in_source_file_;
 
   // Tracks the nest of declarations currently being traversed. Any new Dredd
   // functions will be put before the start of the current nest, which avoids

--- a/src/libdredd/src/mutate_visitor.cc
+++ b/src/libdredd/src/mutate_visitor.cc
@@ -75,7 +75,7 @@ bool MutateVisitor::TraverseDecl(clang::Decl* decl) {
     // match the order they are visited in the AST (for example, a typedef
     // declaration is visited after the associated type declaration, even though
     // the 'typedef' keyword occurs first in the AST), thus this location is
-    // updated each a declaration that appears earlier is encountered.
+    // updated each time a declaration that appears earlier is encountered.
     start_location_of_first_decl_in_source_file_ =
         source_range_in_main_file.getBegin();
   }

--- a/test/single_file/template.cc
+++ b/test/single_file/template.cc
@@ -1,0 +1,9 @@
+template<typename T>
+T foo(T a) {
+  return a + 2;
+}
+
+void foo() {
+  int x;
+  x = foo(3);
+}

--- a/test/single_file/template.expected
+++ b/test/single_file/template.expected
@@ -1,0 +1,56 @@
+#include <cinttypes>
+#include <cstddef>
+#include <functional>
+#include <string>
+
+static bool __dredd_enabled_mutation(int local_mutation_id) {
+  static bool initialized = false;
+  static uint64_t enabled_bitset[1];
+  if (!initialized) {
+    const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
+    if (dredd_environment_variable != nullptr) {
+      std::string contents(dredd_environment_variable);
+      while (true) {
+        size_t pos = contents.find(",");
+        std::string token = (pos == std::string::npos ? contents : contents.substr(0, pos));
+        if (!token.empty()) {
+          int value = std::stoi(token);
+          int local_value = value - 0;
+          if (local_value >= 0 && local_value < 12) {
+            enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+          }
+        }
+        if (pos == std::string::npos) {
+          break;
+        }
+        contents.erase(0, pos + 1);
+      }
+    }
+    initialized = true;
+  }
+  return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
+}
+
+static int& __dredd_replace_binary_operator_Assign_int_int(std::function<int&()> arg1, std::function<int()> arg2, int local_mutation_id) {
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() += arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1() &= arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1() /= arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return arg1() *= arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return arg1() |= arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 5)) return arg1() %= arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 6)) return arg1() <<= arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 7)) return arg1() >>= arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 8)) return arg1() -= arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 9)) return arg1() ^= arg2();
+  return arg1() = arg2();
+}
+
+template<typename T>
+T foo(T a) {
+  if (!__dredd_enabled_mutation(0)) { return a + 2; }
+}
+
+void foo() {
+  int x;
+  if (!__dredd_enabled_mutation(11)) { __dredd_replace_binary_operator_Assign_int_int([&]() -> int& { return static_cast<int&>(x); }, [&]() -> int { return static_cast<int>(foo(3)); }, 1); }
+}

--- a/test/single_file/typedef.cc
+++ b/test/single_file/typedef.cc
@@ -1,0 +1,7 @@
+typedef struct S {
+
+} SomeS;
+
+void foo() {
+  1 + 2;
+}

--- a/test/single_file/typedef.expected
+++ b/test/single_file/typedef.expected
@@ -1,0 +1,50 @@
+#include <cinttypes>
+#include <cstddef>
+#include <functional>
+#include <string>
+
+static bool __dredd_enabled_mutation(int local_mutation_id) {
+  static bool initialized = false;
+  static uint64_t enabled_bitset[1];
+  if (!initialized) {
+    const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
+    if (dredd_environment_variable != nullptr) {
+      std::string contents(dredd_environment_variable);
+      while (true) {
+        size_t pos = contents.find(",");
+        std::string token = (pos == std::string::npos ? contents : contents.substr(0, pos));
+        if (!token.empty()) {
+          int value = std::stoi(token);
+          int local_value = value - 0;
+          if (local_value >= 0 && local_value < 7) {
+            enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+          }
+        }
+        if (pos == std::string::npos) {
+          break;
+        }
+        contents.erase(0, pos + 1);
+      }
+    }
+    initialized = true;
+  }
+  return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
+}
+
+static int __dredd_replace_binary_operator_Add_int_int(std::function<int()> arg1, std::function<int()> arg2, int local_mutation_id) {
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() / arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1() * arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1() % arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return arg1() - arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return arg1();
+  if (__dredd_enabled_mutation(local_mutation_id + 5)) return arg2();
+  return arg1() + arg2();
+}
+
+typedef struct S {
+
+} SomeS;
+
+void foo() {
+  if (!__dredd_enabled_mutation(6)) { __dredd_replace_binary_operator_Add_int_int([&]() -> int { return static_cast<int>(1); }, [&]() -> int { return static_cast<int>(2); }, 0); }
+}

--- a/test/single_file/using.cc
+++ b/test/single_file/using.cc
@@ -1,0 +1,5 @@
+using blah = int;
+
+void foo() {
+  1 + 2;
+}

--- a/test/single_file/using.expected
+++ b/test/single_file/using.expected
@@ -1,0 +1,48 @@
+#include <cinttypes>
+#include <cstddef>
+#include <functional>
+#include <string>
+
+static bool __dredd_enabled_mutation(int local_mutation_id) {
+  static bool initialized = false;
+  static uint64_t enabled_bitset[1];
+  if (!initialized) {
+    const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
+    if (dredd_environment_variable != nullptr) {
+      std::string contents(dredd_environment_variable);
+      while (true) {
+        size_t pos = contents.find(",");
+        std::string token = (pos == std::string::npos ? contents : contents.substr(0, pos));
+        if (!token.empty()) {
+          int value = std::stoi(token);
+          int local_value = value - 0;
+          if (local_value >= 0 && local_value < 7) {
+            enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+          }
+        }
+        if (pos == std::string::npos) {
+          break;
+        }
+        contents.erase(0, pos + 1);
+      }
+    }
+    initialized = true;
+  }
+  return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
+}
+
+static int __dredd_replace_binary_operator_Add_int_int(std::function<int()> arg1, std::function<int()> arg2, int local_mutation_id) {
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() / arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1() * arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1() % arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return arg1() - arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return arg1();
+  if (__dredd_enabled_mutation(local_mutation_id + 5)) return arg2();
+  return arg1() + arg2();
+}
+
+using blah = int;
+
+void foo() {
+  if (!__dredd_enabled_mutation(6)) { __dredd_replace_binary_operator_Add_int_int([&]() -> int { return static_cast<int>(1); }, [&]() -> int { return static_cast<int>(2); }, 0); }
+}


### PR DESCRIPTION
Changes the logic for deciding where to insert the Dredd prelude to
account for the fact that the first declaration encountered when
visiting the AST may not correspond to the declaration whose start
appears syntactically earliest in the main source file.

Fixes #70.