### PR TITLE
Do not mutate operators that use bit-field l-values

### DIFF
--- a/src/libdredd/src/mutate_visitor.cc
+++ b/src/libdredd/src/mutate_visitor.cc
@@ -136,6 +136,12 @@ bool MutateVisitor::VisitUnaryOperator(clang::UnaryOperator* unary_operator) {
     return true;
   }
 
+  // As it is not possible to pass bit-fields by reference, mutation of
+  // bit-field l-values is not supported.
+  if (unary_operator->getSubExpr()->refersToBitField()) {
+    return true;
+  }
+
   mutations_.push_back(
       std::make_unique<MutationReplaceUnaryOperator>(*unary_operator));
   return true;
@@ -174,6 +180,12 @@ bool MutateVisitor::VisitBinaryOperator(
     return true;
   }
   if (IsTypeSupported(binary_operator->getRHS()->getType())) {
+    return true;
+  }
+
+  // As it is not possible to pass bit-fields by reference, mutation of
+  // bit-field l-values is not supported.
+  if (binary_operator->getLHS()->refersToBitField()) {
     return true;
   }
 

--- a/test/single_file/bitfield.cc
+++ b/test/single_file/bitfield.cc
@@ -1,0 +1,11 @@
+struct S {
+  int a : 3;
+  int b : 3;
+};
+
+void foo() {
+  S myS;
+  myS.a = myS.b;
+  myS.a++;
+  --myS.b;
+}

--- a/test/single_file/bitfield.expected
+++ b/test/single_file/bitfield.expected
@@ -1,0 +1,44 @@
+#include <cinttypes>
+#include <cstddef>
+#include <functional>
+#include <string>
+
+static bool __dredd_enabled_mutation(int local_mutation_id) {
+  static bool initialized = false;
+  static uint64_t enabled_bitset[1];
+  if (!initialized) {
+    const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
+    if (dredd_environment_variable != nullptr) {
+      std::string contents(dredd_environment_variable);
+      while (true) {
+        size_t pos = contents.find(",");
+        std::string token = (pos == std::string::npos ? contents : contents.substr(0, pos));
+        if (!token.empty()) {
+          int value = std::stoi(token);
+          int local_value = value - 0;
+          if (local_value >= 0 && local_value < 3) {
+            enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+          }
+        }
+        if (pos == std::string::npos) {
+          break;
+        }
+        contents.erase(0, pos + 1);
+      }
+    }
+    initialized = true;
+  }
+  return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
+}
+
+struct S {
+  int a : 3;
+  int b : 3;
+};
+
+void foo() {
+  S myS;
+  if (!__dredd_enabled_mutation(0)) { myS.a = myS.b; }
+  if (!__dredd_enabled_mutation(1)) { myS.a++; }
+  if (!__dredd_enabled_mutation(2)) { --myS.b; }
+}


### PR DESCRIPTION
As it is not possible to pass bit-fields by refernce, mutations cannot
be applied to bit-field l-values.

Fixes #73.