### PR TITLE
Account for comments when removing return statements

### DIFF
--- a/test/single_file/comment.cc
+++ b/test/single_file/comment.cc
@@ -1,0 +1,16 @@
+void g();
+
+int f()
+{
+  g() /* something */ ;
+  g() // something
+;
+
+  if(true) {
+
+  }
+  // something
+  if(true) {
+
+  } /* something */
+}

--- a/test/single_file/comment.expected
+++ b/test/single_file/comment.expected
@@ -1,0 +1,51 @@
+#include <cinttypes>
+#include <cstddef>
+#include <functional>
+#include <string>
+
+static bool __dredd_enabled_mutation(int local_mutation_id) {
+  static bool initialized = false;
+  static uint64_t enabled_bitset[1];
+  if (!initialized) {
+    const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
+    if (dredd_environment_variable != nullptr) {
+      std::string contents(dredd_environment_variable);
+      while (true) {
+        size_t pos = contents.find(",");
+        std::string token = (pos == std::string::npos ? contents : contents.substr(0, pos));
+        if (!token.empty()) {
+          int value = std::stoi(token);
+          int local_value = value - 0;
+          if (local_value >= 0 && local_value < 4) {
+            enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+          }
+        }
+        if (pos == std::string::npos) {
+          break;
+        }
+        contents.erase(0, pos + 1);
+      }
+    }
+    initialized = true;
+  }
+  return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
+}
+
+void g();
+
+int f()
+{
+  if (!__dredd_enabled_mutation(0)) { g() /* something */ ; }
+  if (!__dredd_enabled_mutation(1)) { g() // something
+; }
+
+  if (!__dredd_enabled_mutation(2)) { if(true) {
+
+  }
+  // something
+}
+  if (!__dredd_enabled_mutation(3)) { if(true) {
+
+  } /* something */
+}
+}


### PR DESCRIPTION
Ensures that comments are accounted for when extending statement
source ranges to include trailing semi-colons during statement
deletion.

Fixes #72.