### PR TITLE
Do not mutate template arguments

### DIFF
--- a/src/libdredd/include_private/include/libdredd/mutate_visitor.h
+++ b/src/libdredd/include_private/include/libdredd/mutate_visitor.h
@@ -23,6 +23,7 @@
 #include "clang/AST/Expr.h"
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/Stmt.h"
+#include "clang/AST/TemplateBase.h"
 #include "clang/AST/Type.h"
 #include "clang/AST/TypeLoc.h"
 #include "clang/Basic/SourceLocation.h"
@@ -49,6 +50,11 @@ class MutateVisitor : public clang::RecursiveASTVisitor<MutateVisitor> {
   // (because lambdas cannot appear in such expressions).
   bool TraverseVariableArrayTypeLoc(
       clang::VariableArrayTypeLoc variable_array_type_loc);
+
+  // Overridden to avoid mutating template argument expressions, which typically
+  // (and perhaps always) need to be compile-time constants.
+  bool TraverseTemplateArgumentLoc(
+      clang::TemplateArgumentLoc template_argument_loc);
 
   bool VisitUnaryOperator(clang::UnaryOperator* unary_operator);
 

--- a/src/libdredd/src/mutate_visitor.cc
+++ b/src/libdredd/src/mutate_visitor.cc
@@ -24,6 +24,7 @@
 #include "clang/AST/OperationKinds.h"
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/Stmt.h"
+#include "clang/AST/TemplateBase.h"
 #include "clang/AST/Type.h"
 #include "clang/AST/TypeLoc.h"
 #include "clang/Basic/LangOptions.h"
@@ -159,6 +160,17 @@ bool MutateVisitor::TraverseVariableArrayTypeLoc(
   }
   return RecursiveASTVisitor::TraverseVariableArrayTypeLoc(
       variable_array_type_loc);
+}
+
+bool MutateVisitor::TraverseTemplateArgumentLoc(
+    clang::TemplateArgumentLoc template_argument_loc) {
+  // Prevent compilers complaining that this method could be made static, and
+  // that it ignores its parameter.
+  (void)this;
+  (void)template_argument_loc;
+  // C++ template arguments typically need to be compile-time constants, and so
+  // should not be mutated.
+  return true;
 }
 
 bool MutateVisitor::VisitUnaryOperator(clang::UnaryOperator* unary_operator) {

--- a/test/single_file/template_instantiation.cc
+++ b/test/single_file/template_instantiation.cc
@@ -1,0 +1,7 @@
+template<int N> void foo() {
+  int A[N] = {0};
+}
+
+int main() {
+  foo<1 + 2>();
+}

--- a/test/single_file/template_instantiation.cc.expected
+++ b/test/single_file/template_instantiation.cc.expected
@@ -1,0 +1,40 @@
+#include <cinttypes>
+#include <cstddef>
+#include <functional>
+#include <string>
+
+static bool __dredd_enabled_mutation(int local_mutation_id) {
+  static bool initialized = false;
+  static uint64_t enabled_bitset[1];
+  if (!initialized) {
+    const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
+    if (dredd_environment_variable != nullptr) {
+      std::string contents(dredd_environment_variable);
+      while (true) {
+        size_t pos = contents.find(",");
+        std::string token = (pos == std::string::npos ? contents : contents.substr(0, pos));
+        if (!token.empty()) {
+          int value = std::stoi(token);
+          int local_value = value - 0;
+          if (local_value >= 0 && local_value < 1) {
+            enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+          }
+        }
+        if (pos == std::string::npos) {
+          break;
+        }
+        contents.erase(0, pos + 1);
+      }
+    }
+    initialized = true;
+  }
+  return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
+}
+
+template<int N> void foo() {
+  int A[N] = {0};
+}
+
+int main() {
+  if (!__dredd_enabled_mutation(0)) { foo<1 + 2>(); }
+}


### PR DESCRIPTION
Avoids mutating template argument expressions, which normally need to
be compile-time constants.

Fixes #80.