### PR TITLE
Optimization for the case when no mutants are enabled

### DIFF
--- a/src/libdredd/src/mutation_replace_binary_operator.cc
+++ b/src/libdredd/src/mutation_replace_binary_operator.cc
@@ -224,6 +224,14 @@ std::string MutationReplaceBinaryOperator::GenerateMutatorFunction(
     }
   }
 
+  // Quickly apply the original operator if no mutant is enabled (which will be
+  // the common case).
+  new_function
+      << "  if (!__dredd_some_mutation_enabled) return " << arg1_evaluated
+      << " "
+      << clang::BinaryOperator::getOpcodeStr(binary_operator_.getOpcode()).str()
+      << " " << arg2_evaluated << ";\n";
+
   for (auto op : operators) {
     if (op == binary_operator_.getOpcode() || !IsValidReplacementOperator(op)) {
       continue;

--- a/src/libdredd/src/mutation_replace_unary_operator.cc
+++ b/src/libdredd/src/mutation_replace_unary_operator.cc
@@ -162,6 +162,20 @@ std::string MutationReplaceUnaryOperator::GenerateMutatorFunction(
     }
   }
 
+  // Quickly apply the original operator if no mutant is enabled (which will be
+  // the common case).
+  new_function << "  if (!__dredd_some_mutation_enabled) return ";
+  if (IsPrefix(unary_operator_.getOpcode())) {
+    new_function
+        << clang::UnaryOperator::getOpcodeStr(unary_operator_.getOpcode()).str()
+        << arg_evaluated + ";\n";
+  } else {
+    new_function
+        << arg_evaluated
+        << clang::UnaryOperator::getOpcodeStr(unary_operator_.getOpcode()).str()
+        << ";\n";
+  }
+
   int mutant_offset = 0;
   std::vector<clang::UnaryOperatorKind> operators = {
       clang::UnaryOperatorKind::UO_PreInc, clang::UnaryOperatorKind::UO_PostInc,

--- a/src/libdreddtest/src/mutation_replace_binary_operator_test.cc
+++ b/src/libdreddtest/src/mutation_replace_binary_operator_test.cc
@@ -78,6 +78,7 @@ TEST(MutationReplaceBinaryOperatorTest, MutateAdd) {
       "}";
   std::string expected_dredd_declaration =
       R"(static int __dredd_replace_binary_operator_Add_int_int(std::function<int()> arg1, std::function<int()> arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1() + arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() / arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1() * arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1() % arg2();
@@ -109,6 +110,7 @@ TEST(MutationReplaceBinaryOperatorTest, MutateAnd) {
 )";
   std::string expected_dredd_declaration =
       R"(static bool __dredd_replace_binary_operator_LAnd_bool_bool(std::function<bool()> arg1, std::function<bool()> arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1() && arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() || arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1();
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg2();
@@ -137,6 +139,7 @@ TEST(MutationReplaceBinaryOperatorTest, MutateAssign) {
 )";
   std::string expected_dredd_declaration =
       R"(static int& __dredd_replace_binary_operator_Assign_int_int(std::function<int&()> arg1, std::function<int()> arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1() = arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() += arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1() &= arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1() /= arg2();
@@ -174,6 +177,7 @@ void foo() {
 )";
   std::string expected_dredd_declaration =
       R"(static int& __dredd_replace_binary_operator_Assign_int_int(std::function<int&()> arg1, std::function<int()> arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1() = arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() += arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1() &= arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1() /= arg2();
@@ -209,6 +213,7 @@ TEST(MutationReplaceBinaryOperatorTest, MutateFloatDiv) {
 )";
   std::string expected_dredd_declaration =
       R"(static float __dredd_replace_binary_operator_Div_float_float(std::function<float()> arg1, std::function<float()> arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1() / arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() + arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1() * arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1() - arg2();
@@ -239,6 +244,7 @@ TEST(MutationReplaceBinaryOperatorTest, MutateFloatSubAssign) {
 )";
   std::string expected_dredd_declaration =
       R"(static double& __dredd_replace_binary_operator_SubAssign_double_double(std::function<double&()> arg1, std::function<double()> arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1() -= arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() += arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1() = arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1() /= arg2();

--- a/src/libdreddtest/src/mutation_replace_unary_operator_test.cc
+++ b/src/libdreddtest/src/mutation_replace_unary_operator_test.cc
@@ -75,6 +75,7 @@ TEST(MutationReplaceUnaryOperatorTest, MutateMinus) {
       "return 2; }, 0); }";
   std::string expected_dredd_declaration =
       R"(static int __dredd_replace_unary_operator_Minus_int(std::function<int()> arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return -arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~arg();
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return !arg();
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg();
@@ -101,6 +102,7 @@ TEST(MutationReplaceUnaryOperatorTest, MutateNot) {
 )";
   std::string expected_dredd_declaration =
       R"(static bool __dredd_replace_unary_operator_LNot_bool(std::function<bool()> arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return !arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~arg();
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return -arg();
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg();
@@ -129,6 +131,7 @@ TEST(MutationReplaceUnaryOperatorTest, MutateIncrement) {
 )";
   std::string expected_dredd_declaration =
       R"(static double& __dredd_replace_unary_operator_PreInc_double(std::function<double&()> arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return ++arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return --arg();
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg();
   return ++arg();
@@ -154,6 +157,7 @@ TEST(MutationReplaceUnaryOperatorTest, MutateDecrement) {
 )";
   std::string expected_dredd_declaration =
       R"(static int __dredd_replace_unary_operator_PostDec_int(std::function<int&()> arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg()--;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg()++;
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~arg();
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return -arg();
@@ -182,6 +186,7 @@ TEST(MutationReplaceUnaryOperatorTest, MutateDecrementAssign) {
 )";
   std::string expected_dredd_declaration =
       R"(static int& __dredd_replace_unary_operator_PreDec_int(std::function<int&()> arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return --arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ++arg();
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg();
   return --arg();

--- a/test/single_file/add.c.expected
+++ b/test/single_file/add.c.expected
@@ -1,10 +1,12 @@
 #include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
+static int __dredd_some_mutation_enabled = 1;
 static int __dredd_enabled_mutation(int local_mutation_id) {
   static int initialized = 0;
   static uint64_t enabled_bitset[1];
   if (!initialized) {
+    int some_mutation_enabled = 0;
     const char* dredd_environment_variable = getenv("DREDD_ENABLED_MUTATION");
     if (dredd_environment_variable) {
       char* temp = malloc(strlen(dredd_environment_variable) + 1);
@@ -16,17 +18,20 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
         int local_value = value - 0;
         if (local_value >= 0 && local_value < 13) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+          some_mutation_enabled = 1;
         }
         token = strtok(NULL, ",");
       }
       free(temp);
     }
     initialized = 1;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64));
 }
 
 static int __dredd_replace_binary_operator_Add_int_int(int arg1, int arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1 + arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1 / arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1 * arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1 % arg2;

--- a/test/single_file/add.cc.expected
+++ b/test/single_file/add.cc.expected
@@ -3,10 +3,12 @@
 #include <functional>
 #include <string>
 
+static bool __dredd_some_mutation_enabled = true;
 static bool __dredd_enabled_mutation(int local_mutation_id) {
   static bool initialized = false;
   static uint64_t enabled_bitset[1];
   if (!initialized) {
+    bool some_mutation_enabled = false;
     const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
     if (dredd_environment_variable != nullptr) {
       std::string contents(dredd_environment_variable);
@@ -18,6 +20,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
           int local_value = value - 0;
           if (local_value >= 0 && local_value < 13) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+            some_mutation_enabled = true;
           }
         }
         if (pos == std::string::npos) {
@@ -27,11 +30,13 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
       }
     }
     initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }
 
 static int __dredd_replace_binary_operator_Add_int_int(std::function<int()> arg1, std::function<int()> arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1() + arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() / arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1() * arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1() % arg2();

--- a/test/single_file/add_float.c.expected
+++ b/test/single_file/add_float.c.expected
@@ -1,10 +1,12 @@
 #include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
+static int __dredd_some_mutation_enabled = 1;
 static int __dredd_enabled_mutation(int local_mutation_id) {
   static int initialized = 0;
   static uint64_t enabled_bitset[1];
   if (!initialized) {
+    int some_mutation_enabled = 0;
     const char* dredd_environment_variable = getenv("DREDD_ENABLED_MUTATION");
     if (dredd_environment_variable) {
       char* temp = malloc(strlen(dredd_environment_variable) + 1);
@@ -16,17 +18,20 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
         int local_value = value - 0;
         if (local_value >= 0 && local_value < 11) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+          some_mutation_enabled = 1;
         }
         token = strtok(NULL, ",");
       }
       free(temp);
     }
     initialized = 1;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64));
 }
 
 static float __dredd_replace_binary_operator_Assign_float_float(float* arg1, float arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return (*arg1) = arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return (*arg1) += arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return (*arg1) /= arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return (*arg1) *= arg2;
@@ -35,6 +40,7 @@ static float __dredd_replace_binary_operator_Assign_float_float(float* arg1, flo
 }
 
 static float __dredd_replace_binary_operator_Add_float_float(float arg1, float arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1 + arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1 / arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1 * arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1 - arg2;

--- a/test/single_file/add_float.cc.expected
+++ b/test/single_file/add_float.cc.expected
@@ -3,10 +3,12 @@
 #include <functional>
 #include <string>
 
+static bool __dredd_some_mutation_enabled = true;
 static bool __dredd_enabled_mutation(int local_mutation_id) {
   static bool initialized = false;
   static uint64_t enabled_bitset[1];
   if (!initialized) {
+    bool some_mutation_enabled = false;
     const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
     if (dredd_environment_variable != nullptr) {
       std::string contents(dredd_environment_variable);
@@ -18,6 +20,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
           int local_value = value - 0;
           if (local_value >= 0 && local_value < 11) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+            some_mutation_enabled = true;
           }
         }
         if (pos == std::string::npos) {
@@ -27,11 +30,13 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
       }
     }
     initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }
 
 static float& __dredd_replace_binary_operator_Assign_float_float(std::function<float&()> arg1, std::function<float()> arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1() = arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() += arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1() /= arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1() *= arg2();
@@ -40,6 +45,7 @@ static float& __dredd_replace_binary_operator_Assign_float_float(std::function<f
 }
 
 static float __dredd_replace_binary_operator_Add_float_float(std::function<float()> arg1, std::function<float()> arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1() + arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() / arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1() * arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1() - arg2();

--- a/test/single_file/add_mul.c.expected
+++ b/test/single_file/add_mul.c.expected
@@ -1,10 +1,12 @@
 #include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
+static int __dredd_some_mutation_enabled = 1;
 static int __dredd_enabled_mutation(int local_mutation_id) {
   static int initialized = 0;
   static uint64_t enabled_bitset[1];
   if (!initialized) {
+    int some_mutation_enabled = 0;
     const char* dredd_environment_variable = getenv("DREDD_ENABLED_MUTATION");
     if (dredd_environment_variable) {
       char* temp = malloc(strlen(dredd_environment_variable) + 1);
@@ -16,17 +18,20 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
         int local_value = value - 0;
         if (local_value >= 0 && local_value < 13) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+          some_mutation_enabled = 1;
         }
         token = strtok(NULL, ",");
       }
       free(temp);
     }
     initialized = 1;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64));
 }
 
 static int __dredd_replace_binary_operator_Mul_int_int(int arg1, int arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1 * arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1 + arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1 / arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1 % arg2;
@@ -37,6 +42,7 @@ static int __dredd_replace_binary_operator_Mul_int_int(int arg1, int arg2, int l
 }
 
 static int __dredd_replace_binary_operator_Add_int_int(int arg1, int arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1 + arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1 / arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1 * arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1 % arg2;

--- a/test/single_file/add_mul.cc.expected
+++ b/test/single_file/add_mul.cc.expected
@@ -3,10 +3,12 @@
 #include <functional>
 #include <string>
 
+static bool __dredd_some_mutation_enabled = true;
 static bool __dredd_enabled_mutation(int local_mutation_id) {
   static bool initialized = false;
   static uint64_t enabled_bitset[1];
   if (!initialized) {
+    bool some_mutation_enabled = false;
     const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
     if (dredd_environment_variable != nullptr) {
       std::string contents(dredd_environment_variable);
@@ -18,6 +20,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
           int local_value = value - 0;
           if (local_value >= 0 && local_value < 13) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+            some_mutation_enabled = true;
           }
         }
         if (pos == std::string::npos) {
@@ -27,11 +30,13 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
       }
     }
     initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }
 
 static int __dredd_replace_binary_operator_Mul_int_int(std::function<int()> arg1, std::function<int()> arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1() * arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() + arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1() / arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1() % arg2();
@@ -42,6 +47,7 @@ static int __dredd_replace_binary_operator_Mul_int_int(std::function<int()> arg1
 }
 
 static int __dredd_replace_binary_operator_Add_int_int(std::function<int()> arg1, std::function<int()> arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1() + arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() / arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1() * arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1() % arg2();

--- a/test/single_file/add_type_aliases.c.expected
+++ b/test/single_file/add_type_aliases.c.expected
@@ -4,10 +4,12 @@
 #include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
+static int __dredd_some_mutation_enabled = 1;
 static int __dredd_enabled_mutation(int local_mutation_id) {
   static int initialized = 0;
   static uint64_t enabled_bitset[1];
   if (!initialized) {
+    int some_mutation_enabled = 0;
     const char* dredd_environment_variable = getenv("DREDD_ENABLED_MUTATION");
     if (dredd_environment_variable) {
       char* temp = malloc(strlen(dredd_environment_variable) + 1);
@@ -19,17 +21,20 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
         int local_value = value - 0;
         if (local_value >= 0 && local_value < 63) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+          some_mutation_enabled = 1;
         }
         token = strtok(NULL, ",");
       }
       free(temp);
     }
     initialized = 1;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64));
 }
 
 static unsigned long __dredd_replace_binary_operator_Add_unsigned_long_unsigned_long(unsigned long arg1, unsigned long arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1 + arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1 / arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1 * arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1 % arg2;
@@ -40,6 +45,7 @@ static unsigned long __dredd_replace_binary_operator_Add_unsigned_long_unsigned_
 }
 
 static unsigned int __dredd_replace_binary_operator_Add_unsigned_int_unsigned_int(unsigned int arg1, unsigned int arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1 + arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1 / arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1 * arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1 % arg2;
@@ -50,6 +56,7 @@ static unsigned int __dredd_replace_binary_operator_Add_unsigned_int_unsigned_in
 }
 
 static long __dredd_replace_binary_operator_Add_long_long(long arg1, long arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1 + arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1 / arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1 * arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1 % arg2;
@@ -60,6 +67,7 @@ static long __dredd_replace_binary_operator_Add_long_long(long arg1, long arg2, 
 }
 
 static int __dredd_replace_binary_operator_Add_int_int(int arg1, int arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1 + arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1 / arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1 * arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1 % arg2;

--- a/test/single_file/add_type_aliases.cc.expected
+++ b/test/single_file/add_type_aliases.cc.expected
@@ -6,10 +6,12 @@
 #include <functional>
 #include <string>
 
+static bool __dredd_some_mutation_enabled = true;
 static bool __dredd_enabled_mutation(int local_mutation_id) {
   static bool initialized = false;
   static uint64_t enabled_bitset[1];
   if (!initialized) {
+    bool some_mutation_enabled = false;
     const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
     if (dredd_environment_variable != nullptr) {
       std::string contents(dredd_environment_variable);
@@ -21,6 +23,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
           int local_value = value - 0;
           if (local_value >= 0 && local_value < 63) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+            some_mutation_enabled = true;
           }
         }
         if (pos == std::string::npos) {
@@ -30,11 +33,13 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
       }
     }
     initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }
 
 static unsigned long __dredd_replace_binary_operator_Add_unsigned_long_unsigned_long(std::function<unsigned long()> arg1, std::function<unsigned long()> arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1() + arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() / arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1() * arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1() % arg2();
@@ -45,6 +50,7 @@ static unsigned long __dredd_replace_binary_operator_Add_unsigned_long_unsigned_
 }
 
 static unsigned int __dredd_replace_binary_operator_Add_unsigned_int_unsigned_int(std::function<unsigned int()> arg1, std::function<unsigned int()> arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1() + arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() / arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1() * arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1() % arg2();
@@ -55,6 +61,7 @@ static unsigned int __dredd_replace_binary_operator_Add_unsigned_int_unsigned_in
 }
 
 static long __dredd_replace_binary_operator_Add_long_long(std::function<long()> arg1, std::function<long()> arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1() + arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() / arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1() * arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1() % arg2();
@@ -65,6 +72,7 @@ static long __dredd_replace_binary_operator_Add_long_long(std::function<long()> 
 }
 
 static int __dredd_replace_binary_operator_Add_int_int(std::function<int()> arg1, std::function<int()> arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1() + arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() / arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1() * arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1() % arg2();

--- a/test/single_file/assign.c.expected
+++ b/test/single_file/assign.c.expected
@@ -1,10 +1,12 @@
 #include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
+static int __dredd_some_mutation_enabled = 1;
 static int __dredd_enabled_mutation(int local_mutation_id) {
   static int initialized = 0;
   static uint64_t enabled_bitset[1];
   if (!initialized) {
+    int some_mutation_enabled = 0;
     const char* dredd_environment_variable = getenv("DREDD_ENABLED_MUTATION");
     if (dredd_environment_variable) {
       char* temp = malloc(strlen(dredd_environment_variable) + 1);
@@ -16,17 +18,20 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
         int local_value = value - 0;
         if (local_value >= 0 && local_value < 22) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+          some_mutation_enabled = 1;
         }
         token = strtok(NULL, ",");
       }
       free(temp);
     }
     initialized = 1;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64));
 }
 
 static int __dredd_replace_binary_operator_Assign_volatile_int_int(volatile int* arg1, int arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return (*arg1) = arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return (*arg1) += arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return (*arg1) &= arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return (*arg1) /= arg2;
@@ -41,6 +46,7 @@ static int __dredd_replace_binary_operator_Assign_volatile_int_int(volatile int*
 }
 
 static int __dredd_replace_binary_operator_Assign_int_int(int* arg1, int arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return (*arg1) = arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return (*arg1) += arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return (*arg1) &= arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return (*arg1) /= arg2;

--- a/test/single_file/assign.cc.expected
+++ b/test/single_file/assign.cc.expected
@@ -3,10 +3,12 @@
 #include <functional>
 #include <string>
 
+static bool __dredd_some_mutation_enabled = true;
 static bool __dredd_enabled_mutation(int local_mutation_id) {
   static bool initialized = false;
   static uint64_t enabled_bitset[1];
   if (!initialized) {
+    bool some_mutation_enabled = false;
     const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
     if (dredd_environment_variable != nullptr) {
       std::string contents(dredd_environment_variable);
@@ -18,6 +20,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
           int local_value = value - 0;
           if (local_value >= 0 && local_value < 22) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+            some_mutation_enabled = true;
           }
         }
         if (pos == std::string::npos) {
@@ -27,11 +30,13 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
       }
     }
     initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }
 
 static volatile int& __dredd_replace_binary_operator_Assign_volatile_int_int(std::function<volatile int&()> arg1, std::function<int()> arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1() = arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() += arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1() &= arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1() /= arg2();
@@ -46,6 +51,7 @@ static volatile int& __dredd_replace_binary_operator_Assign_volatile_int_int(std
 }
 
 static int& __dredd_replace_binary_operator_Assign_int_int(std::function<int&()> arg1, std::function<int()> arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1() = arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() += arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1() &= arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1() /= arg2();

--- a/test/single_file/basic.c.expected
+++ b/test/single_file/basic.c.expected
@@ -1,10 +1,12 @@
 #include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
+static int __dredd_some_mutation_enabled = 1;
 static int __dredd_enabled_mutation(int local_mutation_id) {
   static int initialized = 0;
   static uint64_t enabled_bitset[1];
   if (!initialized) {
+    int some_mutation_enabled = 0;
     const char* dredd_environment_variable = getenv("DREDD_ENABLED_MUTATION");
     if (dredd_environment_variable) {
       char* temp = malloc(strlen(dredd_environment_variable) + 1);
@@ -16,12 +18,14 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
         int local_value = value - 0;
         if (local_value >= 0 && local_value < 1) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+          some_mutation_enabled = 1;
         }
         token = strtok(NULL, ",");
       }
       free(temp);
     }
     initialized = 1;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64));
 }

--- a/test/single_file/basic.cc.expected
+++ b/test/single_file/basic.cc.expected
@@ -3,10 +3,12 @@
 #include <functional>
 #include <string>
 
+static bool __dredd_some_mutation_enabled = true;
 static bool __dredd_enabled_mutation(int local_mutation_id) {
   static bool initialized = false;
   static uint64_t enabled_bitset[1];
   if (!initialized) {
+    bool some_mutation_enabled = false;
     const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
     if (dredd_environment_variable != nullptr) {
       std::string contents(dredd_environment_variable);
@@ -18,6 +20,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
           int local_value = value - 0;
           if (local_value >= 0 && local_value < 1) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+            some_mutation_enabled = true;
           }
         }
         if (pos == std::string::npos) {
@@ -27,6 +30,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
       }
     }
     initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }

--- a/test/single_file/bitfield.c.expected
+++ b/test/single_file/bitfield.c.expected
@@ -1,10 +1,12 @@
 #include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
+static int __dredd_some_mutation_enabled = 1;
 static int __dredd_enabled_mutation(int local_mutation_id) {
   static int initialized = 0;
   static uint64_t enabled_bitset[1];
   if (!initialized) {
+    int some_mutation_enabled = 0;
     const char* dredd_environment_variable = getenv("DREDD_ENABLED_MUTATION");
     if (dredd_environment_variable) {
       char* temp = malloc(strlen(dredd_environment_variable) + 1);
@@ -16,12 +18,14 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
         int local_value = value - 0;
         if (local_value >= 0 && local_value < 3) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+          some_mutation_enabled = 1;
         }
         token = strtok(NULL, ",");
       }
       free(temp);
     }
     initialized = 1;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64));
 }

--- a/test/single_file/bitfield.cc.expected
+++ b/test/single_file/bitfield.cc.expected
@@ -3,10 +3,12 @@
 #include <functional>
 #include <string>
 
+static bool __dredd_some_mutation_enabled = true;
 static bool __dredd_enabled_mutation(int local_mutation_id) {
   static bool initialized = false;
   static uint64_t enabled_bitset[1];
   if (!initialized) {
+    bool some_mutation_enabled = false;
     const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
     if (dredd_environment_variable != nullptr) {
       std::string contents(dredd_environment_variable);
@@ -18,6 +20,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
           int local_value = value - 0;
           if (local_value >= 0 && local_value < 3) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+            some_mutation_enabled = true;
           }
         }
         if (pos == std::string::npos) {
@@ -27,6 +30,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
       }
     }
     initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }

--- a/test/single_file/comment.cc.expected
+++ b/test/single_file/comment.cc.expected
@@ -3,10 +3,12 @@
 #include <functional>
 #include <string>
 
+static bool __dredd_some_mutation_enabled = true;
 static bool __dredd_enabled_mutation(int local_mutation_id) {
   static bool initialized = false;
   static uint64_t enabled_bitset[1];
   if (!initialized) {
+    bool some_mutation_enabled = false;
     const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
     if (dredd_environment_variable != nullptr) {
       std::string contents(dredd_environment_variable);
@@ -18,6 +20,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
           int local_value = value - 0;
           if (local_value >= 0 && local_value < 4) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+            some_mutation_enabled = true;
           }
         }
         if (pos == std::string::npos) {
@@ -27,6 +30,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
       }
     }
     initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }

--- a/test/single_file/define_in_first_decl.c.expected
+++ b/test/single_file/define_in_first_decl.c.expected
@@ -3,10 +3,12 @@
 #include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
+static int __dredd_some_mutation_enabled = 1;
 static int __dredd_enabled_mutation(int local_mutation_id) {
   static int initialized = 0;
   static uint64_t enabled_bitset[1];
   if (!initialized) {
+    int some_mutation_enabled = 0;
     const char* dredd_environment_variable = getenv("DREDD_ENABLED_MUTATION");
     if (dredd_environment_variable) {
       char* temp = malloc(strlen(dredd_environment_variable) + 1);
@@ -18,17 +20,20 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
         int local_value = value - 0;
         if (local_value >= 0 && local_value < 7) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+          some_mutation_enabled = 1;
         }
         token = strtok(NULL, ",");
       }
       free(temp);
     }
     initialized = 1;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64));
 }
 
 static int __dredd_replace_binary_operator_Add_int_int(int arg1, int arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1 + arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1 / arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1 * arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1 % arg2;

--- a/test/single_file/define_in_first_decl.cc.expected
+++ b/test/single_file/define_in_first_decl.cc.expected
@@ -5,10 +5,12 @@
 #include <functional>
 #include <string>
 
+static bool __dredd_some_mutation_enabled = true;
 static bool __dredd_enabled_mutation(int local_mutation_id) {
   static bool initialized = false;
   static uint64_t enabled_bitset[1];
   if (!initialized) {
+    bool some_mutation_enabled = false;
     const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
     if (dredd_environment_variable != nullptr) {
       std::string contents(dredd_environment_variable);
@@ -20,6 +22,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
           int local_value = value - 0;
           if (local_value >= 0 && local_value < 7) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+            some_mutation_enabled = true;
           }
         }
         if (pos == std::string::npos) {
@@ -29,11 +32,13 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
       }
     }
     initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }
 
 static int __dredd_replace_binary_operator_Add_int_int(std::function<int()> arg1, std::function<int()> arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1() + arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() / arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1() * arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1() % arg2();

--- a/test/single_file/floats.c.expected
+++ b/test/single_file/floats.c.expected
@@ -1,10 +1,12 @@
 #include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
+static int __dredd_some_mutation_enabled = 1;
 static int __dredd_enabled_mutation(int local_mutation_id) {
   static int initialized = 0;
   static uint64_t enabled_bitset[1];
   if (!initialized) {
+    int some_mutation_enabled = 0;
     const char* dredd_environment_variable = getenv("DREDD_ENABLED_MUTATION");
     if (dredd_environment_variable) {
       char* temp = malloc(strlen(dredd_environment_variable) + 1);
@@ -16,17 +18,20 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
         int local_value = value - 0;
         if (local_value >= 0 && local_value < 21) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+          some_mutation_enabled = 1;
         }
         token = strtok(NULL, ",");
       }
       free(temp);
     }
     initialized = 1;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64));
 }
 
 static float __dredd_replace_binary_operator_SubAssign_float_double(float* arg1, double arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return (*arg1) -= arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return (*arg1) += arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return (*arg1) = arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return (*arg1) /= arg2;
@@ -35,6 +40,7 @@ static float __dredd_replace_binary_operator_SubAssign_float_double(float* arg1,
 }
 
 static double __dredd_replace_binary_operator_Mul_double_double(double arg1, double arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1 * arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1 + arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1 / arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1 - arg2;
@@ -44,6 +50,7 @@ static double __dredd_replace_binary_operator_Mul_double_double(double arg1, dou
 }
 
 static double __dredd_replace_binary_operator_Add_double_double(double arg1, double arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1 + arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1 / arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1 * arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1 - arg2;
@@ -53,6 +60,7 @@ static double __dredd_replace_binary_operator_Add_double_double(double arg1, dou
 }
 
 static double __dredd_replace_binary_operator_AddAssign_double_double(double* arg1, double arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return (*arg1) += arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return (*arg1) = arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return (*arg1) /= arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return (*arg1) *= arg2;

--- a/test/single_file/floats.cc.expected
+++ b/test/single_file/floats.cc.expected
@@ -3,10 +3,12 @@
 #include <functional>
 #include <string>
 
+static bool __dredd_some_mutation_enabled = true;
 static bool __dredd_enabled_mutation(int local_mutation_id) {
   static bool initialized = false;
   static uint64_t enabled_bitset[1];
   if (!initialized) {
+    bool some_mutation_enabled = false;
     const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
     if (dredd_environment_variable != nullptr) {
       std::string contents(dredd_environment_variable);
@@ -18,6 +20,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
           int local_value = value - 0;
           if (local_value >= 0 && local_value < 21) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+            some_mutation_enabled = true;
           }
         }
         if (pos == std::string::npos) {
@@ -27,11 +30,13 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
       }
     }
     initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }
 
 static float& __dredd_replace_binary_operator_SubAssign_float_double(std::function<float&()> arg1, std::function<double()> arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1() -= arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() += arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1() = arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1() /= arg2();
@@ -40,6 +45,7 @@ static float& __dredd_replace_binary_operator_SubAssign_float_double(std::functi
 }
 
 static double& __dredd_replace_binary_operator_AddAssign_double_double(std::function<double&()> arg1, std::function<double()> arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1() += arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() = arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1() /= arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1() *= arg2();
@@ -48,6 +54,7 @@ static double& __dredd_replace_binary_operator_AddAssign_double_double(std::func
 }
 
 static double __dredd_replace_binary_operator_Mul_double_double(std::function<double()> arg1, std::function<double()> arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1() * arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() + arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1() / arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1() - arg2();
@@ -57,6 +64,7 @@ static double __dredd_replace_binary_operator_Mul_double_double(std::function<do
 }
 
 static double __dredd_replace_binary_operator_Add_double_double(std::function<double()> arg1, std::function<double()> arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1() + arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() / arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1() * arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1() - arg2();

--- a/test/single_file/initializer.c.expected
+++ b/test/single_file/initializer.c.expected
@@ -1,10 +1,12 @@
 #include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
+static int __dredd_some_mutation_enabled = 1;
 static int __dredd_enabled_mutation(int local_mutation_id) {
   static int initialized = 0;
   static uint64_t enabled_bitset[1];
   if (!initialized) {
+    int some_mutation_enabled = 0;
     const char* dredd_environment_variable = getenv("DREDD_ENABLED_MUTATION");
     if (dredd_environment_variable) {
       char* temp = malloc(strlen(dredd_environment_variable) + 1);
@@ -16,17 +18,20 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
         int local_value = value - 0;
         if (local_value >= 0 && local_value < 6) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+          some_mutation_enabled = 1;
         }
         token = strtok(NULL, ",");
       }
       free(temp);
     }
     initialized = 1;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64));
 }
 
 static int __dredd_replace_binary_operator_Add_int_int(int arg1, int arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1 + arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1 / arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1 * arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1 % arg2;

--- a/test/single_file/initializer.cc.expected
+++ b/test/single_file/initializer.cc.expected
@@ -3,10 +3,12 @@
 #include <functional>
 #include <string>
 
+static bool __dredd_some_mutation_enabled = true;
 static bool __dredd_enabled_mutation(int local_mutation_id) {
   static bool initialized = false;
   static uint64_t enabled_bitset[1];
   if (!initialized) {
+    bool some_mutation_enabled = false;
     const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
     if (dredd_environment_variable != nullptr) {
       std::string contents(dredd_environment_variable);
@@ -18,6 +20,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
           int local_value = value - 0;
           if (local_value >= 0 && local_value < 6) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+            some_mutation_enabled = true;
           }
         }
         if (pos == std::string::npos) {
@@ -27,11 +30,13 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
       }
     }
     initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }
 
 static int __dredd_replace_binary_operator_Add_int_int(std::function<int()> arg1, std::function<int()> arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1() + arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() / arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1() * arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1() % arg2();

--- a/test/single_file/negative_switch_case.c.expected
+++ b/test/single_file/negative_switch_case.c.expected
@@ -1,10 +1,12 @@
 #include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
+static int __dredd_some_mutation_enabled = 1;
 static int __dredd_enabled_mutation(int local_mutation_id) {
   static int initialized = 0;
   static uint64_t enabled_bitset[1];
   if (!initialized) {
+    int some_mutation_enabled = 0;
     const char* dredd_environment_variable = getenv("DREDD_ENABLED_MUTATION");
     if (dredd_environment_variable) {
       char* temp = malloc(strlen(dredd_environment_variable) + 1);
@@ -16,12 +18,14 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
         int local_value = value - 0;
         if (local_value >= 0 && local_value < 1) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+          some_mutation_enabled = 1;
         }
         token = strtok(NULL, ",");
       }
       free(temp);
     }
     initialized = 1;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64));
 }

--- a/test/single_file/negative_switch_case.cc.expected
+++ b/test/single_file/negative_switch_case.cc.expected
@@ -3,10 +3,12 @@
 #include <functional>
 #include <string>
 
+static bool __dredd_some_mutation_enabled = true;
 static bool __dredd_enabled_mutation(int local_mutation_id) {
   static bool initialized = false;
   static uint64_t enabled_bitset[1];
   if (!initialized) {
+    bool some_mutation_enabled = false;
     const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
     if (dredd_environment_variable != nullptr) {
       std::string contents(dredd_environment_variable);
@@ -18,6 +20,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
           int local_value = value - 0;
           if (local_value >= 0 && local_value < 1) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+            some_mutation_enabled = true;
           }
         }
         if (pos == std::string::npos) {
@@ -27,6 +30,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
       }
     }
     initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }

--- a/test/single_file/non_const_sized_array.c.expected
+++ b/test/single_file/non_const_sized_array.c.expected
@@ -1,10 +1,12 @@
 #include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
+static int __dredd_some_mutation_enabled = 1;
 static int __dredd_enabled_mutation(int local_mutation_id) {
   static int initialized = 0;
   static uint64_t enabled_bitset[1];
   if (!initialized) {
+    int some_mutation_enabled = 0;
     const char* dredd_environment_variable = getenv("DREDD_ENABLED_MUTATION");
     if (dredd_environment_variable) {
       char* temp = malloc(strlen(dredd_environment_variable) + 1);
@@ -16,17 +18,20 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
         int local_value = value - 0;
         if (local_value >= 0 && local_value < 6) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+          some_mutation_enabled = 1;
         }
         token = strtok(NULL, ",");
       }
       free(temp);
     }
     initialized = 1;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64));
 }
 
 static int __dredd_replace_binary_operator_Add_int_int(int arg1, int arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1 + arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1 / arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1 * arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1 % arg2;

--- a/test/single_file/post_inc_volatile.c.expected
+++ b/test/single_file/post_inc_volatile.c.expected
@@ -1,10 +1,12 @@
 #include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
+static int __dredd_some_mutation_enabled = 1;
 static int __dredd_enabled_mutation(int local_mutation_id) {
   static int initialized = 0;
   static uint64_t enabled_bitset[1];
   if (!initialized) {
+    int some_mutation_enabled = 0;
     const char* dredd_environment_variable = getenv("DREDD_ENABLED_MUTATION");
     if (dredd_environment_variable) {
       char* temp = malloc(strlen(dredd_environment_variable) + 1);
@@ -16,17 +18,20 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
         int local_value = value - 0;
         if (local_value >= 0 && local_value < 28) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+          some_mutation_enabled = 1;
         }
         token = strtok(NULL, ",");
       }
       free(temp);
     }
     initialized = 1;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64));
 }
 
 static int __dredd_replace_unary_operator_PostInc_volatile_int(volatile int* arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return (*arg)++;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return (*arg)--;
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~(*arg);
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return -(*arg);
@@ -36,6 +41,7 @@ static int __dredd_replace_unary_operator_PostInc_volatile_int(volatile int* arg
 }
 
 static int __dredd_replace_binary_operator_Assign_int_int(int* arg1, int arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return (*arg1) = arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return (*arg1) += arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return (*arg1) &= arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return (*arg1) /= arg2;
@@ -50,6 +56,7 @@ static int __dredd_replace_binary_operator_Assign_int_int(int* arg1, int arg2, i
 }
 
 static int __dredd_replace_binary_operator_Add_int_int(int arg1, int arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1 + arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1 / arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1 * arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1 % arg2;

--- a/test/single_file/post_inc_volatile.cc.expected
+++ b/test/single_file/post_inc_volatile.cc.expected
@@ -3,10 +3,12 @@
 #include <functional>
 #include <string>
 
+static bool __dredd_some_mutation_enabled = true;
 static bool __dredd_enabled_mutation(int local_mutation_id) {
   static bool initialized = false;
   static uint64_t enabled_bitset[1];
   if (!initialized) {
+    bool some_mutation_enabled = false;
     const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
     if (dredd_environment_variable != nullptr) {
       std::string contents(dredd_environment_variable);
@@ -18,6 +20,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
           int local_value = value - 0;
           if (local_value >= 0 && local_value < 28) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+            some_mutation_enabled = true;
           }
         }
         if (pos == std::string::npos) {
@@ -27,11 +30,13 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
       }
     }
     initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }
 
 static int& __dredd_replace_binary_operator_Assign_int_int(std::function<int&()> arg1, std::function<int()> arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1() = arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() += arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1() &= arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1() /= arg2();
@@ -46,6 +51,7 @@ static int& __dredd_replace_binary_operator_Assign_int_int(std::function<int&()>
 }
 
 static int __dredd_replace_unary_operator_PostInc_volatile_int(std::function<volatile int&()> arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg()++;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg()--;
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~arg();
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return -arg();
@@ -55,6 +61,7 @@ static int __dredd_replace_unary_operator_PostInc_volatile_int(std::function<vol
 }
 
 static int __dredd_replace_binary_operator_Add_int_int(std::function<int()> arg1, std::function<int()> arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1() + arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() / arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1() * arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1() % arg2();

--- a/test/single_file/pre_dec_assign.cc.expected
+++ b/test/single_file/pre_dec_assign.cc.expected
@@ -3,10 +3,12 @@
 #include <functional>
 #include <string>
 
+static bool __dredd_some_mutation_enabled = true;
 static bool __dredd_enabled_mutation(int local_mutation_id) {
   static bool initialized = false;
   static uint64_t enabled_bitset[1];
   if (!initialized) {
+    bool some_mutation_enabled = false;
     const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
     if (dredd_environment_variable != nullptr) {
       std::string contents(dredd_environment_variable);
@@ -18,6 +20,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
           int local_value = value - 0;
           if (local_value >= 0 && local_value < 27) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+            some_mutation_enabled = true;
           }
         }
         if (pos == std::string::npos) {
@@ -27,17 +30,20 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
       }
     }
     initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }
 
 static volatile int& __dredd_replace_unary_operator_PreDec_volatile_int(std::function<volatile int&()> arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return --arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ++arg();
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg();
   return --arg();
 }
 
 static volatile int& __dredd_replace_binary_operator_Assign_volatile_int_int(std::function<volatile int&()> arg1, std::function<int()> arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1() = arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() += arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1() &= arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1() /= arg2();
@@ -52,12 +58,14 @@ static volatile int& __dredd_replace_binary_operator_Assign_volatile_int_int(std
 }
 
 static int& __dredd_replace_unary_operator_PreDec_int(std::function<int&()> arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return --arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ++arg();
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg();
   return --arg();
 }
 
 static int& __dredd_replace_binary_operator_Assign_int_int(std::function<int&()> arg1, std::function<int()> arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1() = arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() += arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1() &= arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1() /= arg2();

--- a/test/single_file/printing.c.expected
+++ b/test/single_file/printing.c.expected
@@ -3,10 +3,12 @@
 #include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
+static int __dredd_some_mutation_enabled = 1;
 static int __dredd_enabled_mutation(int local_mutation_id) {
   static int initialized = 0;
   static uint64_t enabled_bitset[1];
   if (!initialized) {
+    int some_mutation_enabled = 0;
     const char* dredd_environment_variable = getenv("DREDD_ENABLED_MUTATION");
     if (dredd_environment_variable) {
       char* temp = malloc(strlen(dredd_environment_variable) + 1);
@@ -18,12 +20,14 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
         int local_value = value - 0;
         if (local_value >= 0 && local_value < 7) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+          some_mutation_enabled = 1;
         }
         token = strtok(NULL, ",");
       }
       free(temp);
     }
     initialized = 1;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64));
 }

--- a/test/single_file/printing.cc.expected
+++ b/test/single_file/printing.cc.expected
@@ -5,10 +5,12 @@
 #include <functional>
 #include <string>
 
+static bool __dredd_some_mutation_enabled = true;
 static bool __dredd_enabled_mutation(int local_mutation_id) {
   static bool initialized = false;
   static uint64_t enabled_bitset[1];
   if (!initialized) {
+    bool some_mutation_enabled = false;
     const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
     if (dredd_environment_variable != nullptr) {
       std::string contents(dredd_environment_variable);
@@ -20,6 +22,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
           int local_value = value - 0;
           if (local_value >= 0 && local_value < 7) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+            some_mutation_enabled = true;
           }
         }
         if (pos == std::string::npos) {
@@ -29,6 +32,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
       }
     }
     initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }

--- a/test/single_file/static_initializer.cc.expected
+++ b/test/single_file/static_initializer.cc.expected
@@ -3,10 +3,12 @@
 #include <functional>
 #include <string>
 
+static bool __dredd_some_mutation_enabled = true;
 static bool __dredd_enabled_mutation(int local_mutation_id) {
   static bool initialized = false;
   static uint64_t enabled_bitset[1];
   if (!initialized) {
+    bool some_mutation_enabled = false;
     const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
     if (dredd_environment_variable != nullptr) {
       std::string contents(dredd_environment_variable);
@@ -18,6 +20,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
           int local_value = value - 0;
           if (local_value >= 0 && local_value < 6) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+            some_mutation_enabled = true;
           }
         }
         if (pos == std::string::npos) {
@@ -27,11 +30,13 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
       }
     }
     initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }
 
 static int __dredd_replace_binary_operator_Add_int_int(std::function<int()> arg1, std::function<int()> arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1() + arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() / arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1() * arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1() % arg2();

--- a/test/single_file/template.cc.expected
+++ b/test/single_file/template.cc.expected
@@ -3,10 +3,12 @@
 #include <functional>
 #include <string>
 
+static bool __dredd_some_mutation_enabled = true;
 static bool __dredd_enabled_mutation(int local_mutation_id) {
   static bool initialized = false;
   static uint64_t enabled_bitset[1];
   if (!initialized) {
+    bool some_mutation_enabled = false;
     const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
     if (dredd_environment_variable != nullptr) {
       std::string contents(dredd_environment_variable);
@@ -18,6 +20,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
           int local_value = value - 0;
           if (local_value >= 0 && local_value < 12) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+            some_mutation_enabled = true;
           }
         }
         if (pos == std::string::npos) {
@@ -27,11 +30,13 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
       }
     }
     initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }
 
 static int& __dredd_replace_binary_operator_Assign_int_int(std::function<int&()> arg1, std::function<int()> arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1() = arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() += arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1() &= arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1() /= arg2();

--- a/test/single_file/template_instantiation.cc.expected
+++ b/test/single_file/template_instantiation.cc.expected
@@ -3,10 +3,12 @@
 #include <functional>
 #include <string>
 
+static bool __dredd_some_mutation_enabled = true;
 static bool __dredd_enabled_mutation(int local_mutation_id) {
   static bool initialized = false;
   static uint64_t enabled_bitset[1];
   if (!initialized) {
+    bool some_mutation_enabled = false;
     const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
     if (dredd_environment_variable != nullptr) {
       std::string contents(dredd_environment_variable);
@@ -18,6 +20,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
           int local_value = value - 0;
           if (local_value >= 0 && local_value < 1) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+            some_mutation_enabled = true;
           }
         }
         if (pos == std::string::npos) {
@@ -27,6 +30,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
       }
     }
     initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }

--- a/test/single_file/typedef.c.expected
+++ b/test/single_file/typedef.c.expected
@@ -1,10 +1,12 @@
 #include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
+static int __dredd_some_mutation_enabled = 1;
 static int __dredd_enabled_mutation(int local_mutation_id) {
   static int initialized = 0;
   static uint64_t enabled_bitset[1];
   if (!initialized) {
+    int some_mutation_enabled = 0;
     const char* dredd_environment_variable = getenv("DREDD_ENABLED_MUTATION");
     if (dredd_environment_variable) {
       char* temp = malloc(strlen(dredd_environment_variable) + 1);
@@ -16,17 +18,20 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
         int local_value = value - 0;
         if (local_value >= 0 && local_value < 7) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+          some_mutation_enabled = 1;
         }
         token = strtok(NULL, ",");
       }
       free(temp);
     }
     initialized = 1;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64));
 }
 
 static int __dredd_replace_binary_operator_Add_int_int(int arg1, int arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1 + arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1 / arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1 * arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1 % arg2;

--- a/test/single_file/typedef.cc.expected
+++ b/test/single_file/typedef.cc.expected
@@ -3,10 +3,12 @@
 #include <functional>
 #include <string>
 
+static bool __dredd_some_mutation_enabled = true;
 static bool __dredd_enabled_mutation(int local_mutation_id) {
   static bool initialized = false;
   static uint64_t enabled_bitset[1];
   if (!initialized) {
+    bool some_mutation_enabled = false;
     const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
     if (dredd_environment_variable != nullptr) {
       std::string contents(dredd_environment_variable);
@@ -18,6 +20,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
           int local_value = value - 0;
           if (local_value >= 0 && local_value < 7) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+            some_mutation_enabled = true;
           }
         }
         if (pos == std::string::npos) {
@@ -27,11 +30,13 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
       }
     }
     initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }
 
 static int __dredd_replace_binary_operator_Add_int_int(std::function<int()> arg1, std::function<int()> arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1() + arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() / arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1() * arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1() % arg2();

--- a/test/single_file/unary.c.expected
+++ b/test/single_file/unary.c.expected
@@ -1,10 +1,12 @@
 #include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
+static int __dredd_some_mutation_enabled = 1;
 static int __dredd_enabled_mutation(int local_mutation_id) {
   static int initialized = 0;
   static uint64_t enabled_bitset[1];
   if (!initialized) {
+    int some_mutation_enabled = 0;
     const char* dredd_environment_variable = getenv("DREDD_ENABLED_MUTATION");
     if (dredd_environment_variable) {
       char* temp = malloc(strlen(dredd_environment_variable) + 1);
@@ -16,17 +18,20 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
         int local_value = value - 0;
         if (local_value >= 0 && local_value < 48) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+          some_mutation_enabled = 1;
         }
         token = strtok(NULL, ",");
       }
       free(temp);
     }
     initialized = 1;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64));
 }
 
 static int __dredd_replace_unary_operator_PreInc_int(int* arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return ++(*arg);
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return --(*arg);
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~(*arg);
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return -(*arg);
@@ -36,6 +41,7 @@ static int __dredd_replace_unary_operator_PreInc_int(int* arg, int local_mutatio
 }
 
 static int __dredd_replace_unary_operator_PreDec_int(int* arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return --(*arg);
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ++(*arg);
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~(*arg);
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return -(*arg);
@@ -45,6 +51,7 @@ static int __dredd_replace_unary_operator_PreDec_int(int* arg, int local_mutatio
 }
 
 static int __dredd_replace_unary_operator_PostInc_int(int* arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return (*arg)++;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return (*arg)--;
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~(*arg);
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return -(*arg);
@@ -54,6 +61,7 @@ static int __dredd_replace_unary_operator_PostInc_int(int* arg, int local_mutati
 }
 
 static int __dredd_replace_unary_operator_PostDec_int(int* arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return (*arg)--;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return (*arg)++;
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~(*arg);
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return -(*arg);
@@ -63,6 +71,7 @@ static int __dredd_replace_unary_operator_PostDec_int(int* arg, int local_mutati
 }
 
 static int __dredd_replace_unary_operator_Minus_int(int arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return -arg;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~arg;
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return !arg;
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg;
@@ -70,6 +79,7 @@ static int __dredd_replace_unary_operator_Minus_int(int arg, int local_mutation_
 }
 
 static float __dredd_replace_unary_operator_PreInc_float(float* arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return ++(*arg);
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return --(*arg);
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return -(*arg);
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return !(*arg);
@@ -78,6 +88,7 @@ static float __dredd_replace_unary_operator_PreInc_float(float* arg, int local_m
 }
 
 static float __dredd_replace_unary_operator_PreDec_float(float* arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return --(*arg);
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ++(*arg);
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return -(*arg);
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return !(*arg);
@@ -86,6 +97,7 @@ static float __dredd_replace_unary_operator_PreDec_float(float* arg, int local_m
 }
 
 static float __dredd_replace_unary_operator_PostInc_float(float* arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return (*arg)++;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return (*arg)--;
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return -(*arg);
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return !(*arg);
@@ -94,6 +106,7 @@ static float __dredd_replace_unary_operator_PostInc_float(float* arg, int local_
 }
 
 static float __dredd_replace_unary_operator_PostDec_float(float* arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return (*arg)--;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return (*arg)++;
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return -(*arg);
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return !(*arg);

--- a/test/single_file/unary.cc.expected
+++ b/test/single_file/unary.cc.expected
@@ -3,10 +3,12 @@
 #include <functional>
 #include <string>
 
+static bool __dredd_some_mutation_enabled = true;
 static bool __dredd_enabled_mutation(int local_mutation_id) {
   static bool initialized = false;
   static uint64_t enabled_bitset[1];
   if (!initialized) {
+    bool some_mutation_enabled = false;
     const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
     if (dredd_environment_variable != nullptr) {
       std::string contents(dredd_environment_variable);
@@ -18,6 +20,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
           int local_value = value - 0;
           if (local_value >= 0 && local_value < 38) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+            some_mutation_enabled = true;
           }
         }
         if (pos == std::string::npos) {
@@ -27,23 +30,27 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
       }
     }
     initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }
 
 static int& __dredd_replace_unary_operator_PreInc_int(std::function<int&()> arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return ++arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return --arg();
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg();
   return ++arg();
 }
 
 static int& __dredd_replace_unary_operator_PreDec_int(std::function<int&()> arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return --arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ++arg();
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg();
   return --arg();
 }
 
 static int __dredd_replace_unary_operator_PostInc_int(std::function<int&()> arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg()++;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg()--;
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~arg();
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return -arg();
@@ -53,6 +60,7 @@ static int __dredd_replace_unary_operator_PostInc_int(std::function<int&()> arg,
 }
 
 static int __dredd_replace_unary_operator_PostDec_int(std::function<int&()> arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg()--;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg()++;
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~arg();
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return -arg();
@@ -62,6 +70,7 @@ static int __dredd_replace_unary_operator_PostDec_int(std::function<int&()> arg,
 }
 
 static int __dredd_replace_unary_operator_Minus_int(std::function<int()> arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return -arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~arg();
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return !arg();
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg();
@@ -69,18 +78,21 @@ static int __dredd_replace_unary_operator_Minus_int(std::function<int()> arg, in
 }
 
 static float& __dredd_replace_unary_operator_PreInc_float(std::function<float&()> arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return ++arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return --arg();
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg();
   return ++arg();
 }
 
 static float& __dredd_replace_unary_operator_PreDec_float(std::function<float&()> arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return --arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ++arg();
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg();
   return --arg();
 }
 
 static float __dredd_replace_unary_operator_PostInc_float(std::function<float&()> arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg()++;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg()--;
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return -arg();
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return !arg();
@@ -89,6 +101,7 @@ static float __dredd_replace_unary_operator_PostInc_float(std::function<float&()
 }
 
 static float __dredd_replace_unary_operator_PostDec_float(std::function<float&()> arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg()--;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg()++;
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return -arg();
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return !arg();

--- a/test/single_file/unary_logical_not.c.expected
+++ b/test/single_file/unary_logical_not.c.expected
@@ -3,10 +3,12 @@
 #include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
+static int __dredd_some_mutation_enabled = 1;
 static int __dredd_enabled_mutation(int local_mutation_id) {
   static int initialized = 0;
   static uint64_t enabled_bitset[1];
   if (!initialized) {
+    int some_mutation_enabled = 0;
     const char* dredd_environment_variable = getenv("DREDD_ENABLED_MUTATION");
     if (dredd_environment_variable) {
       char* temp = malloc(strlen(dredd_environment_variable) + 1);
@@ -18,17 +20,20 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
         int local_value = value - 0;
         if (local_value >= 0 && local_value < 6) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+          some_mutation_enabled = 1;
         }
         token = strtok(NULL, ",");
       }
       free(temp);
     }
     initialized = 1;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64));
 }
 
 static int __dredd_replace_unary_operator_LNot__Bool(_Bool arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return !arg;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~arg;
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return -arg;
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg;

--- a/test/single_file/unary_logical_not.cc.expected
+++ b/test/single_file/unary_logical_not.cc.expected
@@ -3,10 +3,12 @@
 #include <functional>
 #include <string>
 
+static bool __dredd_some_mutation_enabled = true;
 static bool __dredd_enabled_mutation(int local_mutation_id) {
   static bool initialized = false;
   static uint64_t enabled_bitset[1];
   if (!initialized) {
+    bool some_mutation_enabled = false;
     const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
     if (dredd_environment_variable != nullptr) {
       std::string contents(dredd_environment_variable);
@@ -18,6 +20,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
           int local_value = value - 0;
           if (local_value >= 0 && local_value < 6) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+            some_mutation_enabled = true;
           }
         }
         if (pos == std::string::npos) {
@@ -27,11 +30,13 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
       }
     }
     initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }
 
 static bool __dredd_replace_unary_operator_LNot_bool(std::function<bool()> arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return !arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~arg();
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return -arg();
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg();

--- a/test/single_file/unary_minus.c.expected
+++ b/test/single_file/unary_minus.c.expected
@@ -1,10 +1,12 @@
 #include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
+static int __dredd_some_mutation_enabled = 1;
 static int __dredd_enabled_mutation(int local_mutation_id) {
   static int initialized = 0;
   static uint64_t enabled_bitset[1];
   if (!initialized) {
+    int some_mutation_enabled = 0;
     const char* dredd_environment_variable = getenv("DREDD_ENABLED_MUTATION");
     if (dredd_environment_variable) {
       char* temp = malloc(strlen(dredd_environment_variable) + 1);
@@ -16,17 +18,20 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
         int local_value = value - 0;
         if (local_value >= 0 && local_value < 4) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+          some_mutation_enabled = 1;
         }
         token = strtok(NULL, ",");
       }
       free(temp);
     }
     initialized = 1;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64));
 }
 
 static int __dredd_replace_unary_operator_Minus_int(int arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return -arg;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~arg;
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return !arg;
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg;

--- a/test/single_file/unary_minus.cc.expected
+++ b/test/single_file/unary_minus.cc.expected
@@ -3,10 +3,12 @@
 #include <functional>
 #include <string>
 
+static bool __dredd_some_mutation_enabled = true;
 static bool __dredd_enabled_mutation(int local_mutation_id) {
   static bool initialized = false;
   static uint64_t enabled_bitset[1];
   if (!initialized) {
+    bool some_mutation_enabled = false;
     const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
     if (dredd_environment_variable != nullptr) {
       std::string contents(dredd_environment_variable);
@@ -18,6 +20,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
           int local_value = value - 0;
           if (local_value >= 0 && local_value < 4) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+            some_mutation_enabled = true;
           }
         }
         if (pos == std::string::npos) {
@@ -27,11 +30,13 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
       }
     }
     initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }
 
 static int __dredd_replace_unary_operator_Minus_int(std::function<int()> arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return -arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~arg();
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return !arg();
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg();

--- a/test/single_file/using.cc.expected
+++ b/test/single_file/using.cc.expected
@@ -3,10 +3,12 @@
 #include <functional>
 #include <string>
 
+static bool __dredd_some_mutation_enabled = true;
 static bool __dredd_enabled_mutation(int local_mutation_id) {
   static bool initialized = false;
   static uint64_t enabled_bitset[1];
   if (!initialized) {
+    bool some_mutation_enabled = false;
     const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
     if (dredd_environment_variable != nullptr) {
       std::string contents(dredd_environment_variable);
@@ -18,6 +20,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
           int local_value = value - 0;
           if (local_value >= 0 && local_value < 7) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+            some_mutation_enabled = true;
           }
         }
         if (pos == std::string::npos) {
@@ -27,11 +30,13 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
       }
     }
     initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }
 
 static int __dredd_replace_binary_operator_Add_int_int(std::function<int()> arg1, std::function<int()> arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1() + arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() / arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1() * arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1() % arg2();

--- a/test/single_file/volatile.c.expected
+++ b/test/single_file/volatile.c.expected
@@ -1,10 +1,12 @@
 #include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
+static int __dredd_some_mutation_enabled = 1;
 static int __dredd_enabled_mutation(int local_mutation_id) {
   static int initialized = 0;
   static uint64_t enabled_bitset[1];
   if (!initialized) {
+    int some_mutation_enabled = 0;
     const char* dredd_environment_variable = getenv("DREDD_ENABLED_MUTATION");
     if (dredd_environment_variable) {
       char* temp = malloc(strlen(dredd_environment_variable) + 1);
@@ -16,17 +18,20 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
         int local_value = value - 0;
         if (local_value >= 0 && local_value < 11) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+          some_mutation_enabled = 1;
         }
         token = strtok(NULL, ",");
       }
       free(temp);
     }
     initialized = 1;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64));
 }
 
 static int __dredd_replace_binary_operator_AddAssign_volatile_int_int(volatile int* arg1, int arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return (*arg1) += arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return (*arg1) &= arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return (*arg1) = arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return (*arg1) /= arg2;

--- a/test/single_file/volatile.cc.expected
+++ b/test/single_file/volatile.cc.expected
@@ -3,10 +3,12 @@
 #include <functional>
 #include <string>
 
+static bool __dredd_some_mutation_enabled = true;
 static bool __dredd_enabled_mutation(int local_mutation_id) {
   static bool initialized = false;
   static uint64_t enabled_bitset[1];
   if (!initialized) {
+    bool some_mutation_enabled = false;
     const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
     if (dredd_environment_variable != nullptr) {
       std::string contents(dredd_environment_variable);
@@ -18,6 +20,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
           int local_value = value - 0;
           if (local_value >= 0 && local_value < 11) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+            some_mutation_enabled = true;
           }
         }
         if (pos == std::string::npos) {
@@ -27,11 +30,13 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
       }
     }
     initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }
 
 static volatile int& __dredd_replace_binary_operator_AddAssign_volatile_int_int(std::function<volatile int&()> arg1, std::function<int()> arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1() += arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() &= arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1() = arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1() /= arg2();


### PR DESCRIPTION
If no mutants are enabled, it makes sense to quickly return the
original expression. As this will be common when several files have
been mutated but only certain mutants are enabled, it is worth
optimising for. Benchmarking showed substantial speedups running zlib
after mutating all compression files, and then running with no mutants
enabled.