### PR TITLE
Avoid problems with nested replacements

### DIFF
--- a/src/libdredd/CMakeLists.txt
+++ b/src/libdredd/CMakeLists.txt
@@ -19,8 +19,8 @@ add_library(
   include/libdredd/mutation.h
   include/libdredd/mutation_remove_statement.h
   include/libdredd/mutation_replace_binary_operator.h
-  include/libdredd/new_mutate_frontend_action_factory.h
   include/libdredd/mutation_replace_unary_operator.h
+  include/libdredd/new_mutate_frontend_action_factory.h
   include_private/include/libdredd/mutate_ast_consumer.h
   include_private/include/libdredd/mutate_visitor.h
   include_private/include/libdredd/util.h

--- a/src/libdredd/src/mutation_replace_binary_operator.cc
+++ b/src/libdredd/src/mutation_replace_binary_operator.cc
@@ -398,32 +398,60 @@ void MutationReplaceBinaryOperator::ReplaceOperator(
   // Subtracting |first_mutation_id_in_file| turns the global mutation id,
   // |mutation_id|, into a file-local mutation id.
   const int local_mutation_id = mutation_id - first_mutation_id_in_file;
+
+  // Replacement of a binary operator with a function call is simulated by:
+  // - Replacing the binary operator symbol with a comma (to separate the
+  //   arguments of the function call).
+  // - Inserting suitable text before and after each argument to the binary
+  //   operator.
+  // This is preferable over the (otherwise more intuitive) approach of directly
+  // replacing the text for the binary operator node, because the Clang rewriter
+  // does not support nested replacements.
+
+  // Replace the operator symbol with ","
+  rewriter.ReplaceText(
+      binary_operator_.getOperatorLoc(),
+      static_cast<unsigned int>(
+          clang::BinaryOperator::getOpcodeStr(binary_operator_.getOpcode())
+              .size()),
+      ",");
+
+  // These record the text that should be inserted before and after the LHS and
+  // RHS operands.
+  std::string lhs_prefix;
+  std::string lhs_suffix;
+  std::string rhs_prefix;
+  std::string rhs_suffix;
+
   if (ast_context.getLangOpts().CPlusPlus) {
-    bool result = rewriter.ReplaceText(
-        binary_operator_source_range_in_main_file,
-        new_function_name + "([&]() -> " + lhs_type + " { return static_cast<" +
-            lhs_type + ">(" +
-            rewriter.getRewrittenText(lhs_source_range_in_main_file) +
-            +"); }, [&]() -> " + rhs_type + " { return static_cast<" +
-            rhs_type + ">(" +
-            rewriter.getRewrittenText(rhs_source_range_in_main_file) +
-            "); }, " + std::to_string(local_mutation_id) + ")");
-    (void)result;  // Keep release-mode compilers happy.
-    assert(!result && "Rewrite failed.\n");
+    lhs_prefix = new_function_name + "([&]() -> " + lhs_type +
+                 " { return static_cast<" + lhs_type + ">(";
+    lhs_suffix = "); }";
+    rhs_prefix =
+        "[&]() -> " + rhs_type + " { return static_cast<" + rhs_type + ">(";
+    rhs_suffix = "); }, " + std::to_string(local_mutation_id) + ")";
   } else {
-    std::string lhs_arg =
-        rewriter.getRewrittenText(lhs_source_range_in_main_file);
+    lhs_prefix = new_function_name + "(";
     if (binary_operator_.isAssignmentOp()) {
-      lhs_arg = "&(" + lhs_arg + ")";
+      lhs_prefix.append("&(");
+      lhs_suffix.append(")");
     }
-    bool result = rewriter.ReplaceText(
-        binary_operator_source_range_in_main_file,
-        new_function_name + "(" + lhs_arg + ", " +
-            rewriter.getRewrittenText(rhs_source_range_in_main_file) + ", " +
-            std::to_string(local_mutation_id) + ")");
-    (void)result;  // Keep release-mode compilers happy.
-    assert(!result && "Rewrite failed.\n");
+    rhs_suffix = ", " + std::to_string(local_mutation_id) + ")";
   }
+  // The prefixes and suffixes are ready, so make the relevant insertions.
+  bool result = rewriter.InsertTextBefore(
+      lhs_source_range_in_main_file.getBegin(), lhs_prefix);
+  assert(!result && "Rewrite failed.\n");
+  result = rewriter.InsertTextAfterToken(lhs_source_range_in_main_file.getEnd(),
+                                         lhs_suffix);
+  assert(!result && "Rewrite failed.\n");
+  result = rewriter.InsertTextBefore(rhs_source_range_in_main_file.getBegin(),
+                                     rhs_prefix);
+  assert(!result && "Rewrite failed.\n");
+  result = rewriter.InsertTextAfterToken(rhs_source_range_in_main_file.getEnd(),
+                                         rhs_suffix);
+  assert(!result && "Rewrite failed.\n");
+  (void)result;  // Keep release-mode compilers happy.
 }
 
 }  // namespace dredd

--- a/src/libdredd/src/mutation_replace_binary_operator.cc
+++ b/src/libdredd/src/mutation_replace_binary_operator.cc
@@ -381,10 +381,6 @@ void MutationReplaceBinaryOperator::ReplaceOperator(
     const std::string& new_function_name, clang::ASTContext& ast_context,
     const clang::Preprocessor& preprocessor, int first_mutation_id_in_file,
     int& mutation_id, clang::Rewriter& rewriter) const {
-  clang::SourceRange binary_operator_source_range_in_main_file =
-      GetSourceRangeInMainFile(preprocessor, binary_operator_);
-  assert(binary_operator_source_range_in_main_file.isValid() &&
-         "Invalid source range.");
   clang::SourceRange lhs_source_range_in_main_file =
       GetSourceRangeInMainFile(preprocessor, *binary_operator_.getLHS());
   assert(lhs_source_range_in_main_file.isValid() && "Invalid source range.");

--- a/src/libdredd/src/mutation_replace_unary_operator.cc
+++ b/src/libdredd/src/mutation_replace_unary_operator.cc
@@ -296,32 +296,52 @@ void MutationReplaceUnaryOperator::Apply(
   // Subtracting |first_mutation_id_in_file| turns the global mutation id,
   // |mutation_id|, into a file-local mutation id.
   const int local_mutation_id = mutation_id - first_mutation_id_in_file;
+
+  // Replacement of a unary operator with a function call is simulated by:
+  // - Removing the text associated with the unary operator symbol.
+  // - Inserting suitable text before and after the argument to the unary
+  //   operator.
+  // This is preferable over the (otherwise more intuitive) approach of directly
+  // replacing the text for the unary operator node, because the Clang rewriter
+  // does not support nested replacements.
+
+  // Remove the operator symbol.
+  rewriter.ReplaceText(
+      unary_operator_.getOperatorLoc(),
+      static_cast<unsigned int>(
+          clang::UnaryOperator::getOpcodeStr(unary_operator_.getOpcode())
+              .size()),
+      "");
+
+  // These record the text that should be inserted before and after the operand.
+  std::string prefix;
+  std::string suffix;
   if (ast_context.getLangOpts().CPlusPlus) {
-    bool result = rewriter.ReplaceText(
-        unary_operator_source_range_in_main_file,
-        new_function_name + "([&]() -> " + input_type + " { return " +
-            // We don't need to static cast constant expressions
-            (unary_operator_.getSubExpr()->isCXX11ConstantExpr(ast_context)
-                 ? rewriter.getRewrittenText(input_source_range_in_main_file)
-                 : ("static_cast<" + input_type + ">(" +
-                    rewriter.getRewrittenText(input_source_range_in_main_file) +
-                    ")")) +
-            "; }" + ", " + std::to_string(local_mutation_id) + ")");
-    (void)result;  // Keep release-mode compilers happy.
-    assert(!result && "Rewrite failed.\n");
+    prefix = new_function_name + "([&]() -> " + input_type + " { return " +
+             // We don't need to static cast constant expressions
+             (unary_operator_.getSubExpr()->isCXX11ConstantExpr(ast_context)
+                  ? ""
+                  : "static_cast<" + input_type + ">(");
+    suffix =
+        (unary_operator_.getSubExpr()->isCXX11ConstantExpr(ast_context) ? ""
+                                                                        : ")");
+    suffix.append("; }, " + std::to_string(local_mutation_id) + ")");
   } else {
-    std::string input_arg =
-        rewriter.getRewrittenText(input_source_range_in_main_file);
+    prefix = new_function_name + "(";
     if (unary_operator_.isIncrementDecrementOp()) {
-      input_arg = "&(" + input_arg + ")";
+      prefix.append("&(");
+      suffix.append(")");
     }
-    bool result =
-        rewriter.ReplaceText(unary_operator_source_range_in_main_file,
-                             new_function_name + "(" + input_arg + ", " +
-                                 std::to_string(local_mutation_id) + ")");
-    (void)result;  // Keep release-mode compilers happy.
-    assert(!result && "Rewrite failed.\n");
+    suffix.append(", " + std::to_string(local_mutation_id) + ")");
   }
+  // The prefix and suffix are ready, so make the relevant insertions.
+  bool result = rewriter.InsertTextBefore(
+      unary_operator_source_range_in_main_file.getBegin(), prefix);
+  assert(!result && "Rewrite failed.\n");
+  result = rewriter.InsertTextAfterToken(
+      unary_operator_source_range_in_main_file.getEnd(), suffix);
+  assert(!result && "Rewrite failed.\n");
+  (void)result;  // Keep release-mode compilers happy.
 
   std::string new_function;
   new_function = GenerateMutatorFunction(ast_context, new_function_name,

--- a/src/libdredd/src/mutation_replace_unary_operator.cc
+++ b/src/libdredd/src/mutation_replace_unary_operator.cc
@@ -286,9 +286,6 @@ void MutationReplaceUnaryOperator::Apply(
       GetSourceRangeInMainFile(preprocessor, unary_operator_);
   assert(unary_operator_source_range_in_main_file.isValid() &&
          "Invalid source range.");
-  clang::SourceRange input_source_range_in_main_file =
-      GetSourceRangeInMainFile(preprocessor, *unary_operator_.getSubExpr());
-  assert(input_source_range_in_main_file.isValid() && "Invalid source range.");
 
   // Replace the unary operator expression with a call to the wrapper
   // function.

--- a/src/libdreddtest/src/mutation_replace_binary_operator_test.cc
+++ b/src/libdreddtest/src/mutation_replace_binary_operator_test.cc
@@ -73,7 +73,7 @@ TEST(MutationReplaceBinaryOperatorTest, MutateAdd) {
   std::string expected =
       "void foo() { __dredd_replace_binary_operator_Add_int_int([&]() -> int { "
       "return "
-      "static_cast<int>(1); }, [&]() -> int { return static_cast<int>(2); }, "
+      "static_cast<int>(1); } , [&]() -> int { return static_cast<int>(2); }, "
       "0); "
       "}";
   std::string expected_dredd_declaration =
@@ -105,7 +105,7 @@ TEST(MutationReplaceBinaryOperatorTest, MutateAnd) {
       R"(void foo() {
   int x = 1;
   int y = 2;
-  int z = __dredd_replace_binary_operator_LAnd_bool_bool([&]() -> bool { return static_cast<bool>(x); }, [&]() -> bool { return static_cast<bool>(y); }, 0);
+  int z = __dredd_replace_binary_operator_LAnd_bool_bool([&]() -> bool { return static_cast<bool>(x); } , [&]() -> bool { return static_cast<bool>(y); }, 0);
 }
 )";
   std::string expected_dredd_declaration =
@@ -134,7 +134,7 @@ TEST(MutationReplaceBinaryOperatorTest, MutateAssign) {
   std::string expected =
       R"(void foo() {
   int x;
-  __dredd_replace_binary_operator_Assign_int_int([&]() -> int& { return static_cast<int&>(x); }, [&]() -> int { return static_cast<int>(1); }, 0);
+  __dredd_replace_binary_operator_Assign_int_int([&]() -> int& { return static_cast<int&>(x); } , [&]() -> int { return static_cast<int>(1); }, 0);
 }
 )";
   std::string expected_dredd_declaration =
@@ -172,7 +172,7 @@ void foo() {
 #define BING(X, Y, Z) (X ? Y : Z)
 void foo() {
   int x;
-  __dredd_replace_binary_operator_Assign_int_int([&]() -> int& { return static_cast<int&>(VAR); }, [&]() -> int { return static_cast<int>(BING(1, 2, 3)); }, 0);
+  __dredd_replace_binary_operator_Assign_int_int([&]() -> int& { return static_cast<int&>(VAR); } , [&]() -> int { return static_cast<int>(BING(1, 2, 3)); }, 0);
 }
 )";
   std::string expected_dredd_declaration =
@@ -208,7 +208,7 @@ TEST(MutationReplaceBinaryOperatorTest, MutateFloatDiv) {
       R"(void foo() {
   float x = 6.43622;
   float y = 3.53462;
-  float z = __dredd_replace_binary_operator_Div_float_float([&]() -> float { return static_cast<float>(x); }, [&]() -> float { return static_cast<float>(y); }, 0);
+  float z = __dredd_replace_binary_operator_Div_float_float([&]() -> float { return static_cast<float>(x); } , [&]() -> float { return static_cast<float>(y); }, 0);
 }
 )";
   std::string expected_dredd_declaration =
@@ -239,7 +239,7 @@ TEST(MutationReplaceBinaryOperatorTest, MutateFloatSubAssign) {
       R"(void foo() {
   double x = 234.23532;
   double y = 0.65433;
-  __dredd_replace_binary_operator_SubAssign_double_double([&]() -> double& { return static_cast<double&>(x); }, [&]() -> double { return static_cast<double>(y); }, 0);
+  __dredd_replace_binary_operator_SubAssign_double_double([&]() -> double& { return static_cast<double&>(x); } , [&]() -> double { return static_cast<double>(y); }, 0);
 }
 )";
   std::string expected_dredd_declaration =

--- a/test/single_file/add.c.expected
+++ b/test/single_file/add.c.expected
@@ -44,5 +44,5 @@ static int __dredd_replace_binary_operator_Add_int_int(int arg1, int arg2, int l
 int main() {
   int x = 1;
   int y = 2;
-  if (!__dredd_enabled_mutation(12)) { return __dredd_replace_binary_operator_Add_int_int(__dredd_replace_binary_operator_Add_int_int(x, y, 0), x, 6); }
+  if (!__dredd_enabled_mutation(12)) { return __dredd_replace_binary_operator_Add_int_int(__dredd_replace_binary_operator_Add_int_int(x , y, 0) , x, 6); }
 }

--- a/test/single_file/add.cc.expected
+++ b/test/single_file/add.cc.expected
@@ -49,5 +49,5 @@ static int __dredd_replace_binary_operator_Add_int_int(std::function<int()> arg1
 int main() {
   int x = 1;
   int y = 2;
-  if (!__dredd_enabled_mutation(12)) { return __dredd_replace_binary_operator_Add_int_int([&]() -> int { return static_cast<int>(__dredd_replace_binary_operator_Add_int_int([&]() -> int { return static_cast<int>(x); }, [&]() -> int { return static_cast<int>(y); }, 0)); }, [&]() -> int { return static_cast<int>(x); }, 6); }
+  if (!__dredd_enabled_mutation(12)) { return __dredd_replace_binary_operator_Add_int_int([&]() -> int { return static_cast<int>(__dredd_replace_binary_operator_Add_int_int([&]() -> int { return static_cast<int>(x); } , [&]() -> int { return static_cast<int>(y); }, 0)); } , [&]() -> int { return static_cast<int>(x); }, 6); }
 }

--- a/test/single_file/add_float.c.expected
+++ b/test/single_file/add_float.c.expected
@@ -53,6 +53,6 @@ int main() {
   float x = 5.235;
   float y = 754.34623;
   float z;
-  if (!__dredd_enabled_mutation(9)) { __dredd_replace_binary_operator_Assign_float_float(&(z), __dredd_replace_binary_operator_Add_float_float(x, y, 0), 5); }
+  if (!__dredd_enabled_mutation(9)) { __dredd_replace_binary_operator_Assign_float_float(&(z) , __dredd_replace_binary_operator_Add_float_float(x , y, 0), 5); }
   if (!__dredd_enabled_mutation(10)) { return 0; }
 }

--- a/test/single_file/add_float.cc.expected
+++ b/test/single_file/add_float.cc.expected
@@ -58,6 +58,6 @@ int main() {
   float x = 5.235;
   float y = 754.34623;
   float z;
-  if (!__dredd_enabled_mutation(9)) { __dredd_replace_binary_operator_Assign_float_float([&]() -> float& { return static_cast<float&>(z); }, [&]() -> float { return static_cast<float>(__dredd_replace_binary_operator_Add_float_float([&]() -> float { return static_cast<float>(x); }, [&]() -> float { return static_cast<float>(y); }, 0)); }, 5); }
+  if (!__dredd_enabled_mutation(9)) { __dredd_replace_binary_operator_Assign_float_float([&]() -> float& { return static_cast<float&>(z); } , [&]() -> float { return static_cast<float>(__dredd_replace_binary_operator_Add_float_float([&]() -> float { return static_cast<float>(x); } , [&]() -> float { return static_cast<float>(y); }, 0)); }, 5); }
   if (!__dredd_enabled_mutation(10)) { return 0; }
 }

--- a/test/single_file/add_mul.c.expected
+++ b/test/single_file/add_mul.c.expected
@@ -55,5 +55,5 @@ static int __dredd_replace_binary_operator_Add_int_int(int arg1, int arg2, int l
 int main() {
   int x = 1;
   int y = 2;
-  if (!__dredd_enabled_mutation(12)) { return __dredd_replace_binary_operator_Add_int_int(x, __dredd_replace_binary_operator_Mul_int_int(y, x, 0), 6); }
+  if (!__dredd_enabled_mutation(12)) { return __dredd_replace_binary_operator_Add_int_int(x , __dredd_replace_binary_operator_Mul_int_int(y , x, 0), 6); }
 }

--- a/test/single_file/add_mul.cc.expected
+++ b/test/single_file/add_mul.cc.expected
@@ -60,5 +60,5 @@ static int __dredd_replace_binary_operator_Add_int_int(std::function<int()> arg1
 int main() {
   int x = 1;
   int y = 2;
-  if (!__dredd_enabled_mutation(12)) { return __dredd_replace_binary_operator_Add_int_int([&]() -> int { return static_cast<int>(x); }, [&]() -> int { return static_cast<int>(__dredd_replace_binary_operator_Mul_int_int([&]() -> int { return static_cast<int>(y); }, [&]() -> int { return static_cast<int>(x); }, 0)); }, 6); }
+  if (!__dredd_enabled_mutation(12)) { return __dredd_replace_binary_operator_Add_int_int([&]() -> int { return static_cast<int>(x); } , [&]() -> int { return static_cast<int>(__dredd_replace_binary_operator_Mul_int_int([&]() -> int { return static_cast<int>(y); } , [&]() -> int { return static_cast<int>(x); }, 0)); }, 6); }
 }

--- a/test/single_file/add_type_aliases.c.expected
+++ b/test/single_file/add_type_aliases.c.expected
@@ -88,13 +88,13 @@ int main() {
   int64_t h;
   uint64_t i;
 
-  if (!__dredd_enabled_mutation(54)) { __dredd_replace_binary_operator_Add_unsigned_int_unsigned_int(a, a, 0); }
-  if (!__dredd_enabled_mutation(55)) { __dredd_replace_binary_operator_Add_unsigned_int_unsigned_int(b, b, 6); }
-  if (!__dredd_enabled_mutation(56)) { __dredd_replace_binary_operator_Add_int_int(c, c, 12); }
-  if (!__dredd_enabled_mutation(57)) { __dredd_replace_binary_operator_Add_int_int(d, d, 18); }
-  if (!__dredd_enabled_mutation(58)) { __dredd_replace_binary_operator_Add_unsigned_long_unsigned_long(e, e, 24); }
-  if (!__dredd_enabled_mutation(59)) { __dredd_replace_binary_operator_Add_unsigned_long_unsigned_long(f, f, 30); }
-  if (!__dredd_enabled_mutation(60)) { __dredd_replace_binary_operator_Add_long_long(g, g, 36); }
-  if (!__dredd_enabled_mutation(61)) { __dredd_replace_binary_operator_Add_long_long(h, h, 42); }
-  if (!__dredd_enabled_mutation(62)) { __dredd_replace_binary_operator_Add_unsigned_long_unsigned_long(i, i, 48); }
+  if (!__dredd_enabled_mutation(54)) { __dredd_replace_binary_operator_Add_unsigned_int_unsigned_int(a , a, 0); }
+  if (!__dredd_enabled_mutation(55)) { __dredd_replace_binary_operator_Add_unsigned_int_unsigned_int(b , b, 6); }
+  if (!__dredd_enabled_mutation(56)) { __dredd_replace_binary_operator_Add_int_int(c , c, 12); }
+  if (!__dredd_enabled_mutation(57)) { __dredd_replace_binary_operator_Add_int_int(d , d, 18); }
+  if (!__dredd_enabled_mutation(58)) { __dredd_replace_binary_operator_Add_unsigned_long_unsigned_long(e , e, 24); }
+  if (!__dredd_enabled_mutation(59)) { __dredd_replace_binary_operator_Add_unsigned_long_unsigned_long(f , f, 30); }
+  if (!__dredd_enabled_mutation(60)) { __dredd_replace_binary_operator_Add_long_long(g , g, 36); }
+  if (!__dredd_enabled_mutation(61)) { __dredd_replace_binary_operator_Add_long_long(h , h, 42); }
+  if (!__dredd_enabled_mutation(62)) { __dredd_replace_binary_operator_Add_unsigned_long_unsigned_long(i , i, 48); }
 }

--- a/test/single_file/add_type_aliases.cc.expected
+++ b/test/single_file/add_type_aliases.cc.expected
@@ -93,13 +93,13 @@ int main() {
   int64_t h;
   uint64_t i;
 
-  if (!__dredd_enabled_mutation(54)) { __dredd_replace_binary_operator_Add_unsigned_int_unsigned_int([&]() -> unsigned int { return static_cast<unsigned int>(a); }, [&]() -> unsigned int { return static_cast<unsigned int>(a); }, 0); }
-  if (!__dredd_enabled_mutation(55)) { __dredd_replace_binary_operator_Add_unsigned_int_unsigned_int([&]() -> unsigned int { return static_cast<unsigned int>(b); }, [&]() -> unsigned int { return static_cast<unsigned int>(b); }, 6); }
-  if (!__dredd_enabled_mutation(56)) { __dredd_replace_binary_operator_Add_int_int([&]() -> int { return static_cast<int>(c); }, [&]() -> int { return static_cast<int>(c); }, 12); }
-  if (!__dredd_enabled_mutation(57)) { __dredd_replace_binary_operator_Add_int_int([&]() -> int { return static_cast<int>(d); }, [&]() -> int { return static_cast<int>(d); }, 18); }
-  if (!__dredd_enabled_mutation(58)) { __dredd_replace_binary_operator_Add_unsigned_long_unsigned_long([&]() -> unsigned long { return static_cast<unsigned long>(e); }, [&]() -> unsigned long { return static_cast<unsigned long>(e); }, 24); }
-  if (!__dredd_enabled_mutation(59)) { __dredd_replace_binary_operator_Add_unsigned_long_unsigned_long([&]() -> unsigned long { return static_cast<unsigned long>(f); }, [&]() -> unsigned long { return static_cast<unsigned long>(f); }, 30); }
-  if (!__dredd_enabled_mutation(60)) { __dredd_replace_binary_operator_Add_long_long([&]() -> long { return static_cast<long>(g); }, [&]() -> long { return static_cast<long>(g); }, 36); }
-  if (!__dredd_enabled_mutation(61)) { __dredd_replace_binary_operator_Add_long_long([&]() -> long { return static_cast<long>(h); }, [&]() -> long { return static_cast<long>(h); }, 42); }
-  if (!__dredd_enabled_mutation(62)) { __dredd_replace_binary_operator_Add_unsigned_long_unsigned_long([&]() -> unsigned long { return static_cast<unsigned long>(i); }, [&]() -> unsigned long { return static_cast<unsigned long>(i); }, 48); }
+  if (!__dredd_enabled_mutation(54)) { __dredd_replace_binary_operator_Add_unsigned_int_unsigned_int([&]() -> unsigned int { return static_cast<unsigned int>(a); } , [&]() -> unsigned int { return static_cast<unsigned int>(a); }, 0); }
+  if (!__dredd_enabled_mutation(55)) { __dredd_replace_binary_operator_Add_unsigned_int_unsigned_int([&]() -> unsigned int { return static_cast<unsigned int>(b); } , [&]() -> unsigned int { return static_cast<unsigned int>(b); }, 6); }
+  if (!__dredd_enabled_mutation(56)) { __dredd_replace_binary_operator_Add_int_int([&]() -> int { return static_cast<int>(c); } , [&]() -> int { return static_cast<int>(c); }, 12); }
+  if (!__dredd_enabled_mutation(57)) { __dredd_replace_binary_operator_Add_int_int([&]() -> int { return static_cast<int>(d); } , [&]() -> int { return static_cast<int>(d); }, 18); }
+  if (!__dredd_enabled_mutation(58)) { __dredd_replace_binary_operator_Add_unsigned_long_unsigned_long([&]() -> unsigned long { return static_cast<unsigned long>(e); } , [&]() -> unsigned long { return static_cast<unsigned long>(e); }, 24); }
+  if (!__dredd_enabled_mutation(59)) { __dredd_replace_binary_operator_Add_unsigned_long_unsigned_long([&]() -> unsigned long { return static_cast<unsigned long>(f); } , [&]() -> unsigned long { return static_cast<unsigned long>(f); }, 30); }
+  if (!__dredd_enabled_mutation(60)) { __dredd_replace_binary_operator_Add_long_long([&]() -> long { return static_cast<long>(g); } , [&]() -> long { return static_cast<long>(g); }, 36); }
+  if (!__dredd_enabled_mutation(61)) { __dredd_replace_binary_operator_Add_long_long([&]() -> long { return static_cast<long>(h); } , [&]() -> long { return static_cast<long>(h); }, 42); }
+  if (!__dredd_enabled_mutation(62)) { __dredd_replace_binary_operator_Add_unsigned_long_unsigned_long([&]() -> unsigned long { return static_cast<unsigned long>(i); } , [&]() -> unsigned long { return static_cast<unsigned long>(i); }, 48); }
 }

--- a/test/single_file/assign.c.expected
+++ b/test/single_file/assign.c.expected
@@ -63,6 +63,6 @@ static int __dredd_replace_binary_operator_Assign_int_int(int* arg1, int arg2, i
 int main() {
   int x;
   volatile int y;
-  if (!__dredd_enabled_mutation(20)) { __dredd_replace_binary_operator_Assign_int_int(&(x), 2, 0); }
-  if (!__dredd_enabled_mutation(21)) { __dredd_replace_binary_operator_Assign_volatile_int_int(&(y), 4, 10); }
+  if (!__dredd_enabled_mutation(20)) { __dredd_replace_binary_operator_Assign_int_int(&(x) , 2, 0); }
+  if (!__dredd_enabled_mutation(21)) { __dredd_replace_binary_operator_Assign_volatile_int_int(&(y) , 4, 10); }
 }

--- a/test/single_file/assign.cc.expected
+++ b/test/single_file/assign.cc.expected
@@ -68,6 +68,6 @@ static int& __dredd_replace_binary_operator_Assign_int_int(std::function<int&()>
 int main() {
   int x;
   volatile int y;
-  if (!__dredd_enabled_mutation(20)) { __dredd_replace_binary_operator_Assign_int_int([&]() -> int& { return static_cast<int&>(x); }, [&]() -> int { return static_cast<int>(2); }, 0); }
-  if (!__dredd_enabled_mutation(21)) { __dredd_replace_binary_operator_Assign_volatile_int_int([&]() -> volatile int& { return static_cast<volatile int&>(y); }, [&]() -> int { return static_cast<int>(4); }, 10); }
+  if (!__dredd_enabled_mutation(20)) { __dredd_replace_binary_operator_Assign_int_int([&]() -> int& { return static_cast<int&>(x); } , [&]() -> int { return static_cast<int>(2); }, 0); }
+  if (!__dredd_enabled_mutation(21)) { __dredd_replace_binary_operator_Assign_volatile_int_int([&]() -> volatile int& { return static_cast<volatile int&>(y); } , [&]() -> int { return static_cast<int>(4); }, 10); }
 }

--- a/test/single_file/define_in_first_decl.c.expected
+++ b/test/single_file/define_in_first_decl.c.expected
@@ -44,5 +44,5 @@ static int __dredd_replace_binary_operator_Add_int_int(int arg1, int arg2, int l
 }
 
 TYPE foo() {
-  if (!__dredd_enabled_mutation(6)) { return __dredd_replace_binary_operator_Add_int_int(1, 2, 0); }
+  if (!__dredd_enabled_mutation(6)) { return __dredd_replace_binary_operator_Add_int_int(1 , 2, 0); }
 }

--- a/test/single_file/define_in_first_decl.cc.expected
+++ b/test/single_file/define_in_first_decl.cc.expected
@@ -49,5 +49,5 @@ static int __dredd_replace_binary_operator_Add_int_int(std::function<int()> arg1
 }
 
 TYPE foo() {
-  if (!__dredd_enabled_mutation(6)) { return __dredd_replace_binary_operator_Add_int_int([&]() -> int { return static_cast<int>(1); }, [&]() -> int { return static_cast<int>(2); }, 0); }
+  if (!__dredd_enabled_mutation(6)) { return __dredd_replace_binary_operator_Add_int_int([&]() -> int { return static_cast<int>(1); } , [&]() -> int { return static_cast<int>(2); }, 0); }
 }

--- a/test/single_file/floats.c.expected
+++ b/test/single_file/floats.c.expected
@@ -70,9 +70,9 @@ static double __dredd_replace_binary_operator_AddAssign_double_double(double* ar
 
 int main() {
   double x = 5.32;
-  if (!__dredd_enabled_mutation(18)) { __dredd_replace_binary_operator_AddAssign_double_double(&(x), 0.5, 0); }
+  if (!__dredd_enabled_mutation(18)) { __dredd_replace_binary_operator_AddAssign_double_double(&(x) , 0.5, 0); }
   float y = 64343.7;
-  if (!__dredd_enabled_mutation(19)) { __dredd_replace_binary_operator_SubAssign_float_double(&(y), 1.2, 4); }
-  double z = __dredd_replace_binary_operator_Mul_double_double(x, 5.5, 8);
-  if (!__dredd_enabled_mutation(20)) { return __dredd_replace_binary_operator_Add_double_double(z, x, 13); }
+  if (!__dredd_enabled_mutation(19)) { __dredd_replace_binary_operator_SubAssign_float_double(&(y) , 1.2, 4); }
+  double z = __dredd_replace_binary_operator_Mul_double_double(x , 5.5, 8);
+  if (!__dredd_enabled_mutation(20)) { return __dredd_replace_binary_operator_Add_double_double(z , x, 13); }
 }

--- a/test/single_file/floats.cc.expected
+++ b/test/single_file/floats.cc.expected
@@ -75,9 +75,9 @@ static double __dredd_replace_binary_operator_Add_double_double(std::function<do
 
 int main() {
   double x = 5.32;
-  if (!__dredd_enabled_mutation(18)) { __dredd_replace_binary_operator_AddAssign_double_double([&]() -> double& { return static_cast<double&>(x); }, [&]() -> double { return static_cast<double>(0.5); }, 0); }
+  if (!__dredd_enabled_mutation(18)) { __dredd_replace_binary_operator_AddAssign_double_double([&]() -> double& { return static_cast<double&>(x); } , [&]() -> double { return static_cast<double>(0.5); }, 0); }
   float y = 64343.7;
-  if (!__dredd_enabled_mutation(19)) { __dredd_replace_binary_operator_SubAssign_float_double([&]() -> float& { return static_cast<float&>(y); }, [&]() -> double { return static_cast<double>(1.2); }, 4); }
-  double z = __dredd_replace_binary_operator_Mul_double_double([&]() -> double { return static_cast<double>(x); }, [&]() -> double { return static_cast<double>(5.5); }, 8);
-  if (!__dredd_enabled_mutation(20)) { return __dredd_replace_binary_operator_Add_double_double([&]() -> double { return static_cast<double>(z); }, [&]() -> double { return static_cast<double>(x); }, 13); }
+  if (!__dredd_enabled_mutation(19)) { __dredd_replace_binary_operator_SubAssign_float_double([&]() -> float& { return static_cast<float&>(y); } , [&]() -> double { return static_cast<double>(1.2); }, 4); }
+  double z = __dredd_replace_binary_operator_Mul_double_double([&]() -> double { return static_cast<double>(x); } , [&]() -> double { return static_cast<double>(5.5); }, 8);
+  if (!__dredd_enabled_mutation(20)) { return __dredd_replace_binary_operator_Add_double_double([&]() -> double { return static_cast<double>(z); } , [&]() -> double { return static_cast<double>(x); }, 13); }
 }

--- a/test/single_file/initializer.c.expected
+++ b/test/single_file/initializer.c.expected
@@ -42,5 +42,5 @@ static int __dredd_replace_binary_operator_Add_int_int(int arg1, int arg2, int l
 }
 
 void foo(int a, int b) {
-  int x = __dredd_replace_binary_operator_Add_int_int(a, b, 0);
+  int x = __dredd_replace_binary_operator_Add_int_int(a , b, 0);
 }

--- a/test/single_file/initializer.cc.expected
+++ b/test/single_file/initializer.cc.expected
@@ -47,5 +47,5 @@ static int __dredd_replace_binary_operator_Add_int_int(std::function<int()> arg1
 }
 
 void foo(int a, int b) {
-  int x = __dredd_replace_binary_operator_Add_int_int([&]() -> int { return static_cast<int>(a); }, [&]() -> int { return static_cast<int>(b); }, 0);
+  int x = __dredd_replace_binary_operator_Add_int_int([&]() -> int { return static_cast<int>(a); } , [&]() -> int { return static_cast<int>(b); }, 0);
 }

--- a/test/single_file/non_const_sized_array.c.expected
+++ b/test/single_file/non_const_sized_array.c.expected
@@ -43,5 +43,5 @@ static int __dredd_replace_binary_operator_Add_int_int(int arg1, int arg2, int l
 
 void foo() {
   volatile int x = 5;
-  int A[__dredd_replace_binary_operator_Add_int_int(x, x, 0)];
+  int A[__dredd_replace_binary_operator_Add_int_int(x , x, 0)];
 }

--- a/test/single_file/post_inc_volatile.c.expected
+++ b/test/single_file/post_inc_volatile.c.expected
@@ -70,6 +70,6 @@ int main() {
   volatile int x = 9;
   volatile int y = 43;
   int z;
-  if (!__dredd_enabled_mutation(26)) { __dredd_replace_binary_operator_Assign_int_int(&(z), __dredd_replace_binary_operator_Add_int_int(__dredd_replace_unary_operator_PostInc_volatile_int(&(x), 0), __dredd_replace_unary_operator_PostInc_volatile_int(&(y), 5), 10), 16); }
+  if (!__dredd_enabled_mutation(26)) { __dredd_replace_binary_operator_Assign_int_int(&(z) , __dredd_replace_binary_operator_Add_int_int(__dredd_replace_unary_operator_PostInc_volatile_int(&(x), 0) , __dredd_replace_unary_operator_PostInc_volatile_int(&(y), 5), 10), 16); }
   if (!__dredd_enabled_mutation(27)) { return z; }
 }

--- a/test/single_file/post_inc_volatile.cc.expected
+++ b/test/single_file/post_inc_volatile.cc.expected
@@ -75,6 +75,6 @@ int main() {
   volatile int x = 9;
   volatile int y = 43;
   int z;
-  if (!__dredd_enabled_mutation(26)) { __dredd_replace_binary_operator_Assign_int_int([&]() -> int& { return static_cast<int&>(z); }, [&]() -> int { return static_cast<int>(__dredd_replace_binary_operator_Add_int_int([&]() -> int { return static_cast<int>(__dredd_replace_unary_operator_PostInc_volatile_int([&]() -> volatile int& { return static_cast<volatile int&>(x); }, 0)); }, [&]() -> int { return static_cast<int>(__dredd_replace_unary_operator_PostInc_volatile_int([&]() -> volatile int& { return static_cast<volatile int&>(y); }, 5)); }, 10)); }, 16); }
+  if (!__dredd_enabled_mutation(26)) { __dredd_replace_binary_operator_Assign_int_int([&]() -> int& { return static_cast<int&>(z); } , [&]() -> int { return static_cast<int>(__dredd_replace_binary_operator_Add_int_int([&]() -> int { return static_cast<int>(__dredd_replace_unary_operator_PostInc_volatile_int([&]() -> volatile int& { return static_cast<volatile int&>(x); }, 0)); } , [&]() -> int { return static_cast<int>(__dredd_replace_unary_operator_PostInc_volatile_int([&]() -> volatile int& { return static_cast<volatile int&>(y); }, 5)); }, 10)); }, 16); }
   if (!__dredd_enabled_mutation(27)) { return z; }
 }

--- a/test/single_file/pre_dec_assign.cc.expected
+++ b/test/single_file/pre_dec_assign.cc.expected
@@ -81,8 +81,8 @@ static int& __dredd_replace_binary_operator_Assign_int_int(std::function<int&()>
 
 int main() {
   int x = 5;
-  if (!__dredd_enabled_mutation(24)) { __dredd_replace_binary_operator_Assign_int_int([&]() -> int& { return static_cast<int&>(__dredd_replace_unary_operator_PreDec_int([&]() -> int& { return static_cast<int&>(x); }, 0)); }, [&]() -> int { return static_cast<int>(2); }, 2); }
+  if (!__dredd_enabled_mutation(24)) { __dredd_replace_binary_operator_Assign_int_int([&]() -> int& { return static_cast<int&>(__dredd_replace_unary_operator_PreDec_int([&]() -> int& { return static_cast<int&>(x); }, 0)); } , [&]() -> int { return static_cast<int>(2); }, 2); }
   volatile int y = 8;
-  if (!__dredd_enabled_mutation(25)) { __dredd_replace_binary_operator_Assign_volatile_int_int([&]() -> volatile int& { return static_cast<volatile int&>(__dredd_replace_unary_operator_PreDec_volatile_int([&]() -> volatile int& { return static_cast<volatile int&>(y); }, 12)); }, [&]() -> int { return static_cast<int>(6); }, 14); }
+  if (!__dredd_enabled_mutation(25)) { __dredd_replace_binary_operator_Assign_volatile_int_int([&]() -> volatile int& { return static_cast<volatile int&>(__dredd_replace_unary_operator_PreDec_volatile_int([&]() -> volatile int& { return static_cast<volatile int&>(y); }, 12)); } , [&]() -> int { return static_cast<int>(6); }, 14); }
   if (!__dredd_enabled_mutation(26)) { return x; }
 }

--- a/test/single_file/static_initializer.cc.expected
+++ b/test/single_file/static_initializer.cc.expected
@@ -49,5 +49,5 @@ static int __dredd_replace_binary_operator_Add_int_int(std::function<int()> arg1
 void foo() {
   int b = 0;
   int c = 0;
-  static int a = __dredd_replace_binary_operator_Add_int_int([&]() -> int { return static_cast<int>(b); }, [&]() -> int { return static_cast<int>(c); }, 0);
+  static int a = __dredd_replace_binary_operator_Add_int_int([&]() -> int { return static_cast<int>(b); } , [&]() -> int { return static_cast<int>(c); }, 0);
 }

--- a/test/single_file/template.cc.expected
+++ b/test/single_file/template.cc.expected
@@ -57,5 +57,5 @@ T foo(T a) {
 
 void foo() {
   int x;
-  if (!__dredd_enabled_mutation(11)) { __dredd_replace_binary_operator_Assign_int_int([&]() -> int& { return static_cast<int&>(x); }, [&]() -> int { return static_cast<int>(foo(3)); }, 1); }
+  if (!__dredd_enabled_mutation(11)) { __dredd_replace_binary_operator_Assign_int_int([&]() -> int& { return static_cast<int&>(x); } , [&]() -> int { return static_cast<int>(foo(3)); }, 1); }
 }

--- a/test/single_file/typedef.c.expected
+++ b/test/single_file/typedef.c.expected
@@ -46,5 +46,5 @@ typedef struct S {
 } SomeS;
 
 void foo() {
-  if (!__dredd_enabled_mutation(6)) { __dredd_replace_binary_operator_Add_int_int(1, 2, 0); }
+  if (!__dredd_enabled_mutation(6)) { __dredd_replace_binary_operator_Add_int_int(1 , 2, 0); }
 }

--- a/test/single_file/typedef.cc.expected
+++ b/test/single_file/typedef.cc.expected
@@ -51,5 +51,5 @@ typedef struct S {
 } SomeS;
 
 void foo() {
-  if (!__dredd_enabled_mutation(6)) { __dredd_replace_binary_operator_Add_int_int([&]() -> int { return static_cast<int>(1); }, [&]() -> int { return static_cast<int>(2); }, 0); }
+  if (!__dredd_enabled_mutation(6)) { __dredd_replace_binary_operator_Add_int_int([&]() -> int { return static_cast<int>(1); } , [&]() -> int { return static_cast<int>(2); }, 0); }
 }

--- a/test/single_file/using.cc.expected
+++ b/test/single_file/using.cc.expected
@@ -49,5 +49,5 @@ static int __dredd_replace_binary_operator_Add_int_int(std::function<int()> arg1
 using blah = int;
 
 void foo() {
-  if (!__dredd_enabled_mutation(6)) { __dredd_replace_binary_operator_Add_int_int([&]() -> int { return static_cast<int>(1); }, [&]() -> int { return static_cast<int>(2); }, 0); }
+  if (!__dredd_enabled_mutation(6)) { __dredd_replace_binary_operator_Add_int_int([&]() -> int { return static_cast<int>(1); } , [&]() -> int { return static_cast<int>(2); }, 0); }
 }

--- a/test/single_file/volatile.c.expected
+++ b/test/single_file/volatile.c.expected
@@ -47,5 +47,5 @@ static int __dredd_replace_binary_operator_AddAssign_volatile_int_int(volatile i
 
 void foo() {
   volatile int a;
-  if (!__dredd_enabled_mutation(10)) { __dredd_replace_binary_operator_AddAssign_volatile_int_int(&(a), 2, 0); }
+  if (!__dredd_enabled_mutation(10)) { __dredd_replace_binary_operator_AddAssign_volatile_int_int(&(a) , 2, 0); }
 }

--- a/test/single_file/volatile.cc.expected
+++ b/test/single_file/volatile.cc.expected
@@ -52,5 +52,5 @@ static volatile int& __dredd_replace_binary_operator_AddAssign_volatile_int_int(
 
 void foo() {
   volatile int a;
-  if (!__dredd_enabled_mutation(10)) { __dredd_replace_binary_operator_AddAssign_volatile_int_int([&]() -> volatile int& { return static_cast<volatile int&>(a); }, [&]() -> int { return static_cast<int>(2); }, 0); }
+  if (!__dredd_enabled_mutation(10)) { __dredd_replace_binary_operator_AddAssign_volatile_int_int([&]() -> volatile int& { return static_cast<volatile int&>(a); } , [&]() -> int { return static_cast<int>(2); }, 0); }
 }


### PR DESCRIPTION
This change uses the rewriter's insertion and deletion functions
instead of it's functions for text replacement, to overcome problems
with nested replacement.