### PR TITLE
Do not mutate parentheses expressions

### DIFF
--- a/src/libdredd/src/mutate_visitor.cc
+++ b/src/libdredd/src/mutate_visitor.cc
@@ -314,6 +314,14 @@ bool MutateVisitor::VisitBinaryOperator(
 }
 
 bool MutateVisitor::VisitExpr(clang::Expr* expr) {
+  // Unary and binary operators are intercepted separately. There is no value in
+  // mutating a parentheses expression.
+  if (llvm::dyn_cast<clang::BinaryOperator>(expr) != nullptr ||
+      llvm::dyn_cast<clang::UnaryOperator>(expr) != nullptr ||
+      llvm::dyn_cast<clang::ParenExpr>(expr) != nullptr) {
+    return true;
+  }
+
   if (!IsInFunction()) {
     // Only consider mutating expressions that occur inside functions.
     return true;
@@ -332,12 +340,6 @@ bool MutateVisitor::VisitExpr(clang::Expr* expr) {
 
   if (GetSourceRangeInMainFile(compiler_instance_.getPreprocessor(), *expr)
           .isInvalid()) {
-    return true;
-  }
-
-  // Unary and binary operators are intercepted separately.
-  if (llvm::dyn_cast<clang::BinaryOperator>(expr) != nullptr ||
-      llvm::dyn_cast<clang::UnaryOperator>(expr) != nullptr) {
     return true;
   }
 

--- a/test/single_file/parens.cc
+++ b/test/single_file/parens.cc
@@ -1,0 +1,3 @@
+int foo(int x) {
+  return ((x));
+}

--- a/test/single_file/parens.cc.expected
+++ b/test/single_file/parens.cc.expected
@@ -1,0 +1,57 @@
+#include <cinttypes>
+#include <cstddef>
+#include <functional>
+#include <string>
+
+static bool __dredd_some_mutation_enabled = true;
+static bool __dredd_enabled_mutation(int local_mutation_id) {
+  static bool initialized = false;
+  static uint64_t enabled_bitset[1];
+  if (!initialized) {
+    bool some_mutation_enabled = false;
+    const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
+    if (dredd_environment_variable != nullptr) {
+      std::string contents(dredd_environment_variable);
+      while (true) {
+        size_t pos = contents.find(",");
+        std::string token = (pos == std::string::npos ? contents : contents.substr(0, pos));
+        if (!token.empty()) {
+          int value = std::stoi(token);
+          int local_value = value - 0;
+          if (local_value >= 0 && local_value < 8) {
+            enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+            some_mutation_enabled = true;
+          }
+        }
+        if (pos == std::string::npos) {
+          break;
+        }
+        contents.erase(0, pos + 1);
+      }
+    }
+    initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
+  }
+  return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
+}
+
+static int& __dredd_replace_expr_int_lvalue(std::function<int&()> arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg();
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return ++(arg());
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return --(arg());
+  return arg();
+}
+
+static int __dredd_replace_expr_int(std::function<int()> arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg();
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg());
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~(arg());
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 0;
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return -1;
+  return arg();
+}
+
+int foo(int x) {
+  if (!__dredd_enabled_mutation(7)) { return __dredd_replace_expr_int([&]() -> int { return static_cast<int>(((__dredd_replace_expr_int_lvalue([&]() -> int& { return static_cast<int&>(x); }, 0)))); }, 2); }
+}


### PR DESCRIPTION
Avoids mutating expressions of the form (e), since mutating e suffices.

Fixes #99.