### PR TITLE
Refactor scripts for handling single-file tests

### DIFF
--- a/scripts/check_cmakelint.sh
+++ b/scripts/check_cmakelint.sh
@@ -20,7 +20,7 @@ set -x
 
 cd "${DREDD_REPO_ROOT}"
 
-for f in `dredd_cmake_files.sh`
+for f in $(dredd_cmake_files.sh)
 do
-    cmake-lint $f
+    cmake-lint "$f"
 done

--- a/scripts/check_format.sh
+++ b/scripts/check_format.sh
@@ -21,13 +21,13 @@ set -x
 cd "${DREDD_REPO_ROOT}"
 
 dredd_source_files.sh | xargs -t clang-format --dry-run --Werror
-for f in `dredd_cmake_files.sh`
+for f in $(dredd_cmake_files.sh)
 do
-    cmake-format --first-comment-is-literal TRUE --check $f
+    cmake-format --first-comment-is-literal TRUE --check "$f"
 done
 
 examples_source_files.sh | xargs -t clang-format --dry-run --Werror
-for f in `examples_cmake_files.sh`
+for f in $(examples_cmake_files.sh)
 do
-    cmake-format --first-comment-is-literal TRUE --check $f
+    cmake-format --first-comment-is-literal TRUE --check "$f"
 done

--- a/scripts/check_one_single_file_test.sh
+++ b/scripts/check_one_single_file_test.sh
@@ -28,13 +28,15 @@ if [ -z "${DREDD_SKIP_COPY_EXECUTABLE+x}" ]
 then
   # Ensure that Dredd is in its installed location. This depends on a
   # debug build being available
-  cp build-Debug/src/dredd/dredd ${DREDD_INSTALLED_EXECUTABLE}
+  cp build-Debug/src/dredd/dredd "${DREDD_INSTALLED_EXECUTABLE}"
 fi
 
 f="${DREDD_REPO_ROOT}/${1}"
 
 for opt in "opt" "noopt"
 do
+  # Determine whether optimisations should be disabled or not, and whether the
+  # name of the expectation file should reflect this.
   DREDD_EXTRA_ARGS=""
   DREDD_EXPECTED_FILE=""
   if [ ${opt} == "noopt" ]
@@ -47,34 +49,34 @@ do
 
   # Copy the single-file test case to the temporary directory so
   # that it can be mutated without affecting the original
-  cp $f .
-  copy_of_f=$(basename $f)
+  cp "$f" .
+  copy_of_f=$(basename "$f")
 
-  # Mutate the test case using Dredd with optimisations
-  ${DREDD_INSTALLED_EXECUTABLE} ${DREDD_EXTRA_ARGS} --mutation-info-file temp.json ${copy_of_f} --
+  # Mutate the test case using Dredd
+  ${DREDD_INSTALLED_EXECUTABLE} ${DREDD_EXTRA_ARGS} --mutation-info-file temp.json "${copy_of_f}" --
 
   if [ -z "${DREDD_REGENERATE_TEST_CASE+x}" ]
   then
     # Check that the mutated test case is as expected
-    diff ${copy_of_f} ${DREDD_EXPECTED_FILE}
+    diff "${copy_of_f}" "${DREDD_EXPECTED_FILE}"
   fi
 
   # Check that the mutated file compiles
   if [[ $f == *.cc ]]
   then
-    ${CXX} -c ${copy_of_f}
+    ${CXX} -c "${copy_of_f}"
   else
-    ${CC} -c ${copy_of_f}
+    ${CC} -c "${copy_of_f}"
   fi
 
   if [ "${DREDD_REGENERATE_TEST_CASE+x}" ]
   then
     # Copy the mutated file so that it becomes the new test expectation
-    cp ${copy_of_f} ${DREDD_EXPECTED_FILE}
+    cp "${copy_of_f}" "${DREDD_EXPECTED_FILE}"
   fi
 
   # Clean up
-  rm ${copy_of_f}
-  rm ${copy_of_f%.*}.o
+  rm "${copy_of_f}"
+  rm "${copy_of_f%.*}".o
 
 done

--- a/scripts/check_one_single_file_test.sh
+++ b/scripts/check_one_single_file_test.sh
@@ -18,47 +18,55 @@ set -e
 set -u
 set -x
 
-if [ -z "${DREDD_SKIP_CHECK_COMPILE_COMMANDS+x}" ]
+DREDD_INSTALLED_EXECUTABLE=${DREDD_REPO_ROOT}/third_party/clang+llvm-13.0.1/bin/dredd
+
+# Move to the temporary directory
+cd "${DREDD_REPO_ROOT}"
+cd temp/
+
+if [ -z "${DREDD_SKIP_COPY_EXECUTABLE+x}" ]
 then
-  DREDD_INSTALLED_EXECUTABLE=${DREDD_REPO_ROOT}/third_party/clang+llvm-13.0.1/bin/dredd
-  # Move to the temporary directory
-  cd "${DREDD_REPO_ROOT}"
-  cd temp/
   # Ensure that Dredd is in its installed location. This depends on a
   # debug build being available
   cp build-Debug/src/dredd/dredd ${DREDD_INSTALLED_EXECUTABLE}
-  f="${DREDD_REPO_ROOT}/${1}"
-  # Copy the single-file test case to the temporary directory so
-  # that it can be mutated without affecting the original
-  cp $f .
-  copy_of_f=$(basename $f)      
-  # Mutate the test case using Dredd with optimisations
-  ${DREDD_INSTALLED_EXECUTABLE} --mutation-info-file temp.json ${copy_of_f} --
-  # Check that the mutated test case is as expected
-  diff ${copy_of_f} $f.expected
-  # Check that the mutated file compiles
-  if [[ $f == *.cc ]]
-  then
-    ${CXX} -c ${copy_of_f}
-  else
-    ${CC} -c ${copy_of_f}
-  fi
-  # Copy the single-file test case to the temporary directory so
-  # that it can be mutated without affecting the original
-  cp $f .
-  copy_of_f=$(basename $f)
-  # Mutate the test case using Dredd without optimisations
-  ${DREDD_INSTALLED_EXECUTABLE} --no-mutation-opts --mutation-info-file temp.json ${copy_of_f} --
-  # Check that the mutated test case is as expected
-  diff ${copy_of_f} $f.noopt.expected
-  # Check that the mutated file compiles
-  if [[ $f == *.cc ]]
-  then
-    ${CXX} -c ${copy_of_f}
-  else
-    ${CC} -c ${copy_of_f}
-  fi
-  # Clean up
-  rm ${copy_of_f}
-  rm ${copy_of_f%.*}.o
 fi
+
+f="${DREDD_REPO_ROOT}/${1}"
+
+# Copy the single-file test case to the temporary directory so
+# that it can be mutated without affecting the original
+cp $f .
+copy_of_f=$(basename $f)      
+# Mutate the test case using Dredd with optimisations
+${DREDD_INSTALLED_EXECUTABLE} --mutation-info-file temp.json ${copy_of_f} --
+# Check that the mutated test case is as expected
+diff ${copy_of_f} $f.expected
+# Check that the mutated file compiles
+if [[ $f == *.cc ]]
+then
+  ${CXX} -c ${copy_of_f}
+else
+  ${CC} -c ${copy_of_f}
+fi
+
+# Copy the single-file test case to the temporary directory so
+# that it can be mutated without affecting the original
+cp $f .
+copy_of_f=$(basename $f)
+
+# Mutate the test case using Dredd without optimisations
+${DREDD_INSTALLED_EXECUTABLE} --no-mutation-opts --mutation-info-file temp.json ${copy_of_f} --
+# Check that the mutated test case is as expected
+diff ${copy_of_f} $f.noopt.expected
+# Check that the mutated file compiles
+if [[ $f == *.cc ]]
+then
+  ${CXX} -c ${copy_of_f}
+else
+  ${CC} -c ${copy_of_f}
+fi
+
+# Clean up
+rm ${copy_of_f}
+rm ${copy_of_f%.*}.o
+

--- a/scripts/check_single_file_tests.sh
+++ b/scripts/check_single_file_tests.sh
@@ -22,19 +22,20 @@ if [ -z "${DREDD_SKIP_CHECK_COMPILE_COMMANDS+x}" ]
 then
   DREDD_INSTALLED_EXECUTABLE=${DREDD_REPO_ROOT}/third_party/clang+llvm-13.0.1/bin/dredd
 
-  cd ${DREDD_REPO_ROOT}
+  cd "${DREDD_REPO_ROOT}"
   
   # Ensure that Dredd is in its installed location. This depends on a
   # debug build being available
-  cp temp/build-Debug/src/dredd/dredd ${DREDD_INSTALLED_EXECUTABLE}
+  cp temp/build-Debug/src/dredd/dredd "${DREDD_INSTALLED_EXECUTABLE}"
 
   # Avoid copying Dredd to its installed location when invoking the script that
   # checks a single test.
   export DREDD_SKIP_COPY_EXECUTABLE=1
   
   # Consider each single-file test case
-  for f in `ls test/single_file/*.cc test/single_file/*.c`
+  for f in test/single_file/*.cc test/single_file/*.c
   do
-    check_one_single_file_test.sh ${f}
+    [[ -e "$f" ]] || break
+    check_one_single_file_test.sh "${f}"
   done
 fi

--- a/scripts/check_single_file_tests.sh
+++ b/scripts/check_single_file_tests.sh
@@ -21,47 +21,20 @@ set -x
 if [ -z "${DREDD_SKIP_CHECK_COMPILE_COMMANDS+x}" ]
 then
   DREDD_INSTALLED_EXECUTABLE=${DREDD_REPO_ROOT}/third_party/clang+llvm-13.0.1/bin/dredd
-  # Move to the temporary directory
-  cd "${DREDD_REPO_ROOT}"
-  cd temp/
+
+  cd ${DREDD_REPO_ROOT}
+  
   # Ensure that Dredd is in its installed location. This depends on a
   # debug build being available
-  cp build-Debug/src/dredd/dredd ${DREDD_INSTALLED_EXECUTABLE}
+  cp temp/build-Debug/src/dredd/dredd ${DREDD_INSTALLED_EXECUTABLE}
+
+  # Avoid copying Dredd to its installed location when invoking the script that
+  # checks a single test.
+  export DREDD_SKIP_COPY_EXECUTABLE=1
+  
   # Consider each single-file test case
-  for f in `ls ${DREDD_REPO_ROOT}/test/single_file/*.cc ${DREDD_REPO_ROOT}/test/single_file/*.c`
+  for f in `ls test/single_file/*.cc test/single_file/*.c`
   do
-    # Copy the single-file test case to the temporary directory so
-    # that it can be mutated without affecting the original
-    cp $f .
-    copy_of_f=$(basename $f)      
-    # Mutate the test case using Dredd with optimisations
-    ${DREDD_INSTALLED_EXECUTABLE} --mutation-info-file temp.json ${copy_of_f} --
-    # Check that the mutated test case is as expected
-    diff ${copy_of_f} $f.expected
-    # Check that the mutated file compiles
-    if [[ $f == *.cc ]]
-    then
-      ${CXX} -c ${copy_of_f}
-    else
-      ${CC} -c ${copy_of_f}
-    fi
-    # Copy the single-file test case to the temporary directory so
-    # that it can be mutated without affecting the original
-    cp $f .
-    copy_of_f=$(basename $f)
-    # Mutate the test case using Dredd without optimisations
-    ${DREDD_INSTALLED_EXECUTABLE} --no-mutation-opts --mutation-info-file temp.json ${copy_of_f} --
-    # Check that the mutated test case is as expected
-    diff ${copy_of_f} $f.noopt.expected
-    # Check that the mutated file compiles
-    if [[ $f == *.cc ]]
-    then
-      ${CXX} -c ${copy_of_f}
-    else
-      ${CC} -c ${copy_of_f}
-    fi
-    # Clean up
-    rm ${copy_of_f}
-    rm ${copy_of_f%.*}.o
+    check_one_single_file_test.sh ${f}
   done
 fi

--- a/scripts/fix_format.sh
+++ b/scripts/fix_format.sh
@@ -21,13 +21,13 @@ set -x
 cd "${DREDD_REPO_ROOT}"
 
 dredd_source_files.sh | xargs clang-format -i --verbose
-for f in `dredd_cmake_files.sh`
+for f in $(dredd_cmake_files.sh)
 do
-    cmake-format --first-comment-is-literal TRUE -i $f
+    cmake-format --first-comment-is-literal TRUE -i "$f"
 done
 
 examples_source_files.sh | xargs clang-format -i --verbose
-for f in `examples_cmake_files.sh`
+for f in $(examples_cmake_files.sh)
 do
-    cmake-format --first-comment-is-literal TRUE -i $f
+    cmake-format --first-comment-is-literal TRUE -i "$f"
 done

--- a/scripts/regenerate_one_single_file_expectation.sh
+++ b/scripts/regenerate_one_single_file_expectation.sh
@@ -18,47 +18,55 @@ set -e
 set -u
 set -x
 
-if [ -z "${DREDD_SKIP_CHECK_COMPILE_COMMANDS+x}" ]
+DREDD_INSTALLED_EXECUTABLE=${DREDD_REPO_ROOT}/third_party/clang+llvm-13.0.1/bin/dredd
+
+# Move to the temporary directory
+cd "${DREDD_REPO_ROOT}"
+cd temp/
+
+if [ -z "${DREDD_SKIP_COPY_EXECUTABLE+x}" ]
 then
-  DREDD_INSTALLED_EXECUTABLE=${DREDD_REPO_ROOT}/third_party/clang+llvm-13.0.1/bin/dredd
-  # Move to the temporary directory
-  cd "${DREDD_REPO_ROOT}"
-  cd temp/
   # Ensure that Dredd is in its installed location. This depends on a
   # debug build being available
   cp build-Debug/src/dredd/dredd ${DREDD_INSTALLED_EXECUTABLE}
-  f="${DREDD_REPO_ROOT}/${1}"
-  # Copy the single-file test case to the temporary directory so
-  # that it can be mutated without affecting the original
-  cp $f .
-  copy_of_f=$(basename $f)      
-  # Mutate the test case using Dredd
-  ${DREDD_INSTALLED_EXECUTABLE} --mutation-info-file temp.json  ${copy_of_f} --
-  # Check that the mutated file compiles
-  if [[ $f == *.cc ]]
-  then
-    ${CXX} -c ${copy_of_f}
-  else
-    ${CC} -c ${copy_of_f}
-  fi
-  # Copy the mutated file so that it becomes the new test expectation
-  cp ${copy_of_f} $f.expected
-  # Copy the single-file test case to the temporary directory so
-  # that it can be mutated without affecting the original
-  cp $f .
-  copy_of_f=$(basename $f)
-  # Mutate the test case using Dredd
-  ${DREDD_INSTALLED_EXECUTABLE} --no-mutation-opts --mutation-info-file temp.json ${copy_of_f} --
-  # Check that the mutated file compiles
-  if [[ $f == *.cc ]]
-  then
-    ${CXX} -c ${copy_of_f}
-  else
-    ${CC} -c ${copy_of_f}
-  fi
-  # Copy the mutated file so that it becomes the new test expectation
-  cp ${copy_of_f} $f.noopt.expected
-  # Clean up
-  rm ${copy_of_f}
-  rm ${copy_of_f%.*}.o
 fi
+
+f="${DREDD_REPO_ROOT}/${1}"
+
+# Copy the single-file test case to the temporary directory so
+# that it can be mutated without affecting the original
+cp $f .
+copy_of_f=$(basename $f)      
+# Mutate the test case using Dredd with optimisations
+${DREDD_INSTALLED_EXECUTABLE} --mutation-info-file temp.json ${copy_of_f} --
+# Check that the mutated file compiles
+if [[ $f == *.cc ]]
+then
+  ${CXX} -c ${copy_of_f}
+else
+  ${CC} -c ${copy_of_f}
+fi
+# Copy the mutated file so that it becomes the new test expectation
+cp ${copy_of_f} $f.expected
+
+# Copy the single-file test case to the temporary directory so
+# that it can be mutated without affecting the original
+cp $f .
+copy_of_f=$(basename $f)
+
+# Mutate the test case using Dredd without optimisations
+${DREDD_INSTALLED_EXECUTABLE} --no-mutation-opts --mutation-info-file temp.json ${copy_of_f} --
+# Check that the mutated file compiles
+if [[ $f == *.cc ]]
+then
+  ${CXX} -c ${copy_of_f}
+else
+  ${CC} -c ${copy_of_f}
+fi
+# Copy the mutated file so that it becomes the new test expectation
+cp ${copy_of_f} $f.noopt.expected
+
+# Clean up
+rm ${copy_of_f}
+rm ${copy_of_f%.*}.o
+

--- a/scripts/regenerate_single_file_expectations.sh
+++ b/scripts/regenerate_single_file_expectations.sh
@@ -18,23 +18,5 @@ set -e
 set -u
 set -x
 
-if [ -z "${DREDD_SKIP_CHECK_COMPILE_COMMANDS+x}" ]
-then
-  DREDD_INSTALLED_EXECUTABLE=${DREDD_REPO_ROOT}/third_party/clang+llvm-13.0.1/bin/dredd
-
-  cd ${DREDD_REPO_ROOT}
-  
-  # Ensure that Dredd is in its installed location. This depends on a
-  # debug build being available
-  cp temp/build-Debug/src/dredd/dredd ${DREDD_INSTALLED_EXECUTABLE}
-
-  # Avoid copying Dredd to its installed location when invoking the script that
-  # checks a single test.
-  export DREDD_SKIP_COPY_EXECUTABLE=1
-  
-  # Consider each single-file test case
-  for f in `ls test/single_file/*.cc test/single_file/*.c`
-  do
-    regenerate_one_single_file_expectation.sh ${f}
-  done
-fi
+export DREDD_REGENERATE_TEST_CASE=1
+check_single_file_tests.sh


### PR DESCRIPTION
Avoids duplication in the scripts for checking and regenerating
single-file tests and expectations.
    
Fixes #113.
