### PR TITLE
Add command line option for dumping ASTs

### DIFF
--- a/src/dredd/src/main.cc
+++ b/src/dredd/src/main.cc
@@ -49,6 +49,11 @@ static llvm::cl::opt<bool> no_mutation_opts(
     "no-mutation-opts", llvm::cl::desc("Disable Dredd's optimisations"),
     llvm::cl::cat(mutate_category));
 // NOLINTNEXTLINE
+static llvm::cl::opt<bool> dump_asts(
+    "dump-asts",
+    llvm::cl::desc("Dump each AST that is processed; useful for debugging"),
+    llvm::cl::cat(mutate_category));
+// NOLINTNEXTLINE
 static llvm::cl::opt<std::string> mutation_info_file(
     "mutation-info-file", llvm::cl::Required,
     llvm::cl::desc(
@@ -85,8 +90,8 @@ int main(int argc, const char** argv) {
   dredd::MutationInfo mutation_info;
 
   std::unique_ptr<clang::tooling::FrontendActionFactory> factory =
-      dredd::NewMutateFrontendActionFactory(!no_mutation_opts, mutation_id,
-                                            mutation_info);
+      dredd::NewMutateFrontendActionFactory(!no_mutation_opts, dump_asts,
+                                            mutation_id, mutation_info);
 
   const int return_code = Tool.run(factory.get());
 

--- a/src/libdredd/include/libdredd/new_mutate_frontend_action_factory.h
+++ b/src/libdredd/include/libdredd/new_mutate_frontend_action_factory.h
@@ -23,8 +23,8 @@
 namespace dredd {
 
 std::unique_ptr<clang::tooling::FrontendActionFactory>
-NewMutateFrontendActionFactory(bool optimise_mutations, int& mutation_id,
-                               MutationInfo& mutation_info);
+NewMutateFrontendActionFactory(bool optimise_mutations, bool dump_asts,
+                               int& mutation_id, MutationInfo& mutation_info);
 
 }
 

--- a/src/libdredd/include_private/include/libdredd/mutate_ast_consumer.h
+++ b/src/libdredd/include_private/include/libdredd/mutate_ast_consumer.h
@@ -32,10 +32,11 @@ namespace dredd {
 class MutateAstConsumer : public clang::ASTConsumer {
  public:
   MutateAstConsumer(const clang::CompilerInstance& compiler_instance,
-                    bool optimise_mutations, int& mutation_id,
+                    bool optimise_mutations, bool dump_ast, int& mutation_id,
                     MutationInfo& mutation_info)
       : compiler_instance_(compiler_instance),
         optimise_mutations_(optimise_mutations),
+        dump_ast_(dump_ast),
         visitor_(std::make_unique<MutateVisitor>(compiler_instance,
                                                  optimise_mutations)),
         mutation_id_(mutation_id),
@@ -57,6 +58,10 @@ class MutateAstConsumer : public clang::ASTConsumer {
 
   // True if and only if Dredd's optimisations are enabled.
   const bool optimise_mutations_;
+
+  // True if and only if the AST being consumed should be dumped; useful for
+  // debugging.
+  const bool dump_ast_;
 
   std::unique_ptr<MutateVisitor> visitor_;
 

--- a/src/libdredd/src/mutate_ast_consumer.cc
+++ b/src/libdredd/src/mutate_ast_consumer.cc
@@ -41,6 +41,16 @@ void MutateAstConsumer::HandleTranslationUnit(clang::ASTContext& ast_context) {
     // There has been an error, so we don't do any processing.
     return;
   }
+  if (dump_ast_) {
+    llvm::errs() << "AST for: "
+                 << ast_context.getSourceManager()
+                        .getFileEntryForID(
+                            ast_context.getSourceManager().getMainFileID())
+                        ->getName()
+                 << "\n";
+    ast_context.getTranslationUnitDecl()->dump();
+    llvm::errs() << "\n";
+  }
   visitor_->TraverseDecl(ast_context.getTranslationUnitDecl());
 
   rewriter_.setSourceMgr(compiler_instance_.getSourceManager(),

--- a/src/libdredd/src/mutate_ast_consumer.cc
+++ b/src/libdredd/src/mutate_ast_consumer.cc
@@ -33,6 +33,7 @@
 #include "clang/Rewrite/Core/Rewriter.h"
 #include "libdredd/mutation.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/raw_ostream.h"
 
 namespace dredd {
 


### PR DESCRIPTION
It is very useful to be able to dump ASTs when debugging; this adds a command line option, --dump-asts, to enable it.