### PR TITLE
Restrict mutation of cast expressions

### DIFF
--- a/test/single_file/add_float.c.expected
+++ b/test/single_file/add_float.c.expected
@@ -16,7 +16,7 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
       while(token) {
         int value = atoi(token);
         int local_value = value - 0;
-        if (local_value >= 0 && local_value < 44) {
+        if (local_value >= 0 && local_value < 38) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
           some_mutation_enabled = 1;
         }
@@ -83,9 +83,9 @@ static double __dredd_replace_expr_double(double arg, int local_mutation_id) {
 }
 
 int main() {
-  float x = __dredd_replace_expr_float(__dredd_replace_expr_double(5.235, 0), 3);
-  float y = __dredd_replace_expr_float(__dredd_replace_expr_double(754.34623, 6), 9);
+  float x = __dredd_replace_expr_double(5.235, 0);
+  float y = __dredd_replace_expr_double(754.34623, 3);
   float z;
-  if (!__dredd_enabled_mutation(37)) { __dredd_replace_expr_float(__dredd_replace_binary_operator_Assign_float_float(&(z) , __dredd_replace_expr_float(__dredd_replace_binary_operator_Add_float_float(__dredd_replace_expr_float(__dredd_replace_expr_float_lvalue(&(x), 12), 14) , __dredd_replace_expr_float(__dredd_replace_expr_float_lvalue(&(y), 17), 19), 22), 27), 30), 34); }
-  if (!__dredd_enabled_mutation(43)) { return __dredd_replace_expr_int(0, 38); }
+  if (!__dredd_enabled_mutation(31)) { __dredd_replace_expr_float(__dredd_replace_binary_operator_Assign_float_float(&(z) , __dredd_replace_expr_float(__dredd_replace_binary_operator_Add_float_float(__dredd_replace_expr_float(__dredd_replace_expr_float_lvalue(&(x), 6), 8) , __dredd_replace_expr_float(__dredd_replace_expr_float_lvalue(&(y), 11), 13), 16), 21), 24), 28); }
+  if (!__dredd_enabled_mutation(37)) { return __dredd_replace_expr_int(0, 32); }
 }

--- a/test/single_file/add_float.cc.expected
+++ b/test/single_file/add_float.cc.expected
@@ -18,7 +18,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
         if (!token.empty()) {
           int value = std::stoi(token);
           int local_value = value - 0;
-          if (local_value >= 0 && local_value < 41) {
+          if (local_value >= 0 && local_value < 35) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
             some_mutation_enabled = true;
           }
@@ -88,9 +88,9 @@ static double __dredd_replace_expr_double(std::function<double()> arg, int local
 }
 
 int main() {
-  float x = __dredd_replace_expr_float([&]() -> float { return __dredd_replace_expr_double([&]() -> double { return 5.235; }, 0); }, 3);
-  float y = __dredd_replace_expr_float([&]() -> float { return __dredd_replace_expr_double([&]() -> double { return 754.34623; }, 6); }, 9);
+  float x = __dredd_replace_expr_double([&]() -> double { return 5.235; }, 0);
+  float y = __dredd_replace_expr_double([&]() -> double { return 754.34623; }, 3);
   float z;
-  if (!__dredd_enabled_mutation(34)) { __dredd_replace_binary_operator_Assign_float_float([&]() -> float& { return static_cast<float&>(z); } , [&]() -> float { return static_cast<float>(__dredd_replace_expr_float([&]() -> float { return static_cast<float>(__dredd_replace_binary_operator_Add_float_float([&]() -> float { return static_cast<float>(__dredd_replace_expr_float([&]() -> float { return static_cast<float>(__dredd_replace_expr_float_lvalue([&]() -> float& { return static_cast<float&>(x); }, 12)); }, 14)); } , [&]() -> float { return static_cast<float>(__dredd_replace_expr_float([&]() -> float { return static_cast<float>(__dredd_replace_expr_float_lvalue([&]() -> float& { return static_cast<float&>(y); }, 17)); }, 19)); }, 22)); }, 27)); }, 30); }
-  if (!__dredd_enabled_mutation(40)) { return __dredd_replace_expr_int([&]() -> int { return 0; }, 35); }
+  if (!__dredd_enabled_mutation(28)) { __dredd_replace_binary_operator_Assign_float_float([&]() -> float& { return static_cast<float&>(z); } , [&]() -> float { return static_cast<float>(__dredd_replace_expr_float([&]() -> float { return static_cast<float>(__dredd_replace_binary_operator_Add_float_float([&]() -> float { return static_cast<float>(__dredd_replace_expr_float([&]() -> float { return static_cast<float>(__dredd_replace_expr_float_lvalue([&]() -> float& { return static_cast<float&>(x); }, 6)); }, 8)); } , [&]() -> float { return static_cast<float>(__dredd_replace_expr_float([&]() -> float { return static_cast<float>(__dredd_replace_expr_float_lvalue([&]() -> float& { return static_cast<float&>(y); }, 11)); }, 13)); }, 16)); }, 21)); }, 24); }
+  if (!__dredd_enabled_mutation(34)) { return __dredd_replace_expr_int([&]() -> int { return 0; }, 29); }
 }

--- a/test/single_file/floats.c.expected
+++ b/test/single_file/floats.c.expected
@@ -4,7 +4,7 @@
 static int __dredd_some_mutation_enabled = 1;
 static int __dredd_enabled_mutation(int local_mutation_id) {
   static int initialized = 0;
-  static uint64_t enabled_bitset[2];
+  static uint64_t enabled_bitset[1];
   if (!initialized) {
     int some_mutation_enabled = 0;
     const char* dredd_environment_variable = getenv("DREDD_ENABLED_MUTATION");
@@ -16,7 +16,7 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
       while(token) {
         int value = atoi(token);
         int local_value = value - 0;
-        if (local_value >= 0 && local_value < 71) {
+        if (local_value >= 0 && local_value < 63) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
           some_mutation_enabled = 1;
         }
@@ -28,16 +28,6 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
     __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64));
-}
-
-static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
-  if (!__dredd_some_mutation_enabled) return arg;
-  if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg);
-  if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~(arg);
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 0;
-  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 1;
-  if (__dredd_enabled_mutation(local_mutation_id + 4)) return -1;
-  return arg;
 }
 
 static float __dredd_replace_expr_float(float arg, int local_mutation_id) {
@@ -104,8 +94,8 @@ static double __dredd_replace_binary_operator_AddAssign_double_double(double* ar
 int main() {
   double x = __dredd_replace_expr_double(5.32, 0);
   if (!__dredd_enabled_mutation(13)) { __dredd_replace_expr_double(__dredd_replace_binary_operator_AddAssign_double_double(&(x) , __dredd_replace_expr_double(0.5, 3), 6), 10); }
-  float y = __dredd_replace_expr_float(__dredd_replace_expr_double(64343.7, 14), 17);
-  if (!__dredd_enabled_mutation(30)) { __dredd_replace_expr_float(__dredd_replace_binary_operator_SubAssign_float_double(&(y) , __dredd_replace_expr_double(1.2, 20), 23), 27); }
-  double z = __dredd_replace_expr_double(__dredd_replace_binary_operator_Mul_double_double(__dredd_replace_expr_double(__dredd_replace_expr_double_lvalue(&(x), 31), 33) , __dredd_replace_expr_double(5.5, 36), 39), 44);
-  if (!__dredd_enabled_mutation(70)) { return __dredd_replace_expr_int(__dredd_replace_expr_double(__dredd_replace_binary_operator_Add_double_double(__dredd_replace_expr_double(__dredd_replace_expr_double_lvalue(&(z), 47), 49) , __dredd_replace_expr_double(__dredd_replace_expr_double_lvalue(&(x), 52), 54), 57), 62), 65); }
+  float y = __dredd_replace_expr_double(64343.7, 14);
+  if (!__dredd_enabled_mutation(27)) { __dredd_replace_expr_float(__dredd_replace_binary_operator_SubAssign_float_double(&(y) , __dredd_replace_expr_double(1.2, 17), 20), 24); }
+  double z = __dredd_replace_expr_double(__dredd_replace_binary_operator_Mul_double_double(__dredd_replace_expr_double(__dredd_replace_expr_double_lvalue(&(x), 28), 30) , __dredd_replace_expr_double(5.5, 33), 36), 41);
+  if (!__dredd_enabled_mutation(62)) { return __dredd_replace_expr_double(__dredd_replace_binary_operator_Add_double_double(__dredd_replace_expr_double(__dredd_replace_expr_double_lvalue(&(z), 44), 46) , __dredd_replace_expr_double(__dredd_replace_expr_double_lvalue(&(x), 49), 51), 54), 59); }
 }

--- a/test/single_file/floats.cc.expected
+++ b/test/single_file/floats.cc.expected
@@ -6,7 +6,7 @@
 static bool __dredd_some_mutation_enabled = true;
 static bool __dredd_enabled_mutation(int local_mutation_id) {
   static bool initialized = false;
-  static uint64_t enabled_bitset[2];
+  static uint64_t enabled_bitset[1];
   if (!initialized) {
     bool some_mutation_enabled = false;
     const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
@@ -18,7 +18,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
         if (!token.empty()) {
           int value = std::stoi(token);
           int local_value = value - 0;
-          if (local_value >= 0 && local_value < 65) {
+          if (local_value >= 0 && local_value < 57) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
             some_mutation_enabled = true;
           }
@@ -35,16 +35,6 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }
 
-static int __dredd_replace_expr_int(std::function<int()> arg, int local_mutation_id) {
-  if (!__dredd_some_mutation_enabled) return arg();
-  if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg());
-  if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~(arg());
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 0;
-  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 1;
-  if (__dredd_enabled_mutation(local_mutation_id + 4)) return -1;
-  return arg();
-}
-
 static float& __dredd_replace_binary_operator_SubAssign_float_double(std::function<float&()> arg1, std::function<double()> arg2, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg1() -= arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() += arg2();
@@ -52,14 +42,6 @@ static float& __dredd_replace_binary_operator_SubAssign_float_double(std::functi
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1() /= arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 3)) return arg1() *= arg2();
   return arg1() -= arg2();
-}
-
-static float __dredd_replace_expr_float(std::function<float()> arg, int local_mutation_id) {
-  if (!__dredd_some_mutation_enabled) return arg();
-  if (__dredd_enabled_mutation(local_mutation_id + 0)) return 0.0;
-  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 1.0;
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1.0;
-  return arg();
 }
 
 static double& __dredd_replace_binary_operator_AddAssign_double_double(std::function<double&()> arg1, std::function<double()> arg2, int local_mutation_id) {
@@ -109,8 +91,8 @@ static double __dredd_replace_binary_operator_Add_double_double(std::function<do
 int main() {
   double x = __dredd_replace_expr_double([&]() -> double { return 5.32; }, 0);
   if (!__dredd_enabled_mutation(10)) { __dredd_replace_binary_operator_AddAssign_double_double([&]() -> double& { return static_cast<double&>(x); } , [&]() -> double { return static_cast<double>(__dredd_replace_expr_double([&]() -> double { return 0.5; }, 3)); }, 6); }
-  float y = __dredd_replace_expr_float([&]() -> float { return __dredd_replace_expr_double([&]() -> double { return 64343.7; }, 11); }, 14);
-  if (!__dredd_enabled_mutation(24)) { __dredd_replace_binary_operator_SubAssign_float_double([&]() -> float& { return static_cast<float&>(y); } , [&]() -> double { return static_cast<double>(__dredd_replace_expr_double([&]() -> double { return 1.2; }, 17)); }, 20); }
-  double z = __dredd_replace_expr_double([&]() -> double { return static_cast<double>(__dredd_replace_binary_operator_Mul_double_double([&]() -> double { return static_cast<double>(__dredd_replace_expr_double([&]() -> double { return static_cast<double>(__dredd_replace_expr_double_lvalue([&]() -> double& { return static_cast<double&>(x); }, 25)); }, 27)); } , [&]() -> double { return static_cast<double>(__dredd_replace_expr_double([&]() -> double { return 5.5; }, 30)); }, 33)); }, 38);
-  if (!__dredd_enabled_mutation(64)) { return __dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_double([&]() -> double { return static_cast<double>(__dredd_replace_binary_operator_Add_double_double([&]() -> double { return static_cast<double>(__dredd_replace_expr_double([&]() -> double { return static_cast<double>(__dredd_replace_expr_double_lvalue([&]() -> double& { return static_cast<double&>(z); }, 41)); }, 43)); } , [&]() -> double { return static_cast<double>(__dredd_replace_expr_double([&]() -> double { return static_cast<double>(__dredd_replace_expr_double_lvalue([&]() -> double& { return static_cast<double&>(x); }, 46)); }, 48)); }, 51)); }, 56)); }, 59); }
+  float y = __dredd_replace_expr_double([&]() -> double { return 64343.7; }, 11);
+  if (!__dredd_enabled_mutation(21)) { __dredd_replace_binary_operator_SubAssign_float_double([&]() -> float& { return static_cast<float&>(y); } , [&]() -> double { return static_cast<double>(__dredd_replace_expr_double([&]() -> double { return 1.2; }, 14)); }, 17); }
+  double z = __dredd_replace_expr_double([&]() -> double { return static_cast<double>(__dredd_replace_binary_operator_Mul_double_double([&]() -> double { return static_cast<double>(__dredd_replace_expr_double([&]() -> double { return static_cast<double>(__dredd_replace_expr_double_lvalue([&]() -> double& { return static_cast<double&>(x); }, 22)); }, 24)); } , [&]() -> double { return static_cast<double>(__dredd_replace_expr_double([&]() -> double { return 5.5; }, 27)); }, 30)); }, 35);
+  if (!__dredd_enabled_mutation(56)) { return __dredd_replace_expr_double([&]() -> double { return static_cast<double>(__dredd_replace_binary_operator_Add_double_double([&]() -> double { return static_cast<double>(__dredd_replace_expr_double([&]() -> double { return static_cast<double>(__dredd_replace_expr_double_lvalue([&]() -> double& { return static_cast<double&>(z); }, 38)); }, 40)); } , [&]() -> double { return static_cast<double>(__dredd_replace_expr_double([&]() -> double { return static_cast<double>(__dredd_replace_expr_double_lvalue([&]() -> double& { return static_cast<double&>(x); }, 43)); }, 45)); }, 48)); }, 53); }
 }

--- a/test/single_file/positive_int_as_minus_one.c.expected
+++ b/test/single_file/positive_int_as_minus_one.c.expected
@@ -16,7 +16,7 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
       while(token) {
         int value = atoi(token);
         int local_value = value - 0;
-        if (local_value >= 0 && local_value < 39) {
+        if (local_value >= 0 && local_value < 26) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
           some_mutation_enabled = 1;
         }
@@ -78,6 +78,6 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
 }
 
 int main() {
-  unsigned int x = __dredd_replace_expr_unsigned_int(__dredd_replace_expr_long(4294967295, 0), 5);
-  int y = __dredd_replace_expr_int(__dredd_replace_expr_unsigned_int(__dredd_replace_binary_operator_Sub_unsigned_int_unsigned_int(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 9), 11) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_int(20, 15), 20), 24), 30), 34);
+  unsigned int x = __dredd_replace_expr_long(4294967295, 0);
+  int y = __dredd_replace_expr_unsigned_int(__dredd_replace_binary_operator_Sub_unsigned_int_unsigned_int(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 5), 7) , __dredd_replace_expr_int(20, 11), 16), 22);
 }

--- a/test/single_file/positive_int_as_minus_one.cc.expected
+++ b/test/single_file/positive_int_as_minus_one.cc.expected
@@ -18,7 +18,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
         if (!token.empty()) {
           int value = std::stoi(token);
           int local_value = value - 0;
-          if (local_value >= 0 && local_value < 39) {
+          if (local_value >= 0 && local_value < 26) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
             some_mutation_enabled = true;
           }
@@ -83,6 +83,6 @@ static int __dredd_replace_expr_int(std::function<int()> arg, int local_mutation
 }
 
 int main() {
-  unsigned int x = __dredd_replace_expr_unsigned_int([&]() -> unsigned int { return __dredd_replace_expr_long([&]() -> long { return 4294967295; }, 0); }, 5);
-  int y = __dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_unsigned_int([&]() -> unsigned int { return static_cast<unsigned int>(__dredd_replace_binary_operator_Sub_unsigned_int_unsigned_int([&]() -> unsigned int { return static_cast<unsigned int>(__dredd_replace_expr_unsigned_int([&]() -> unsigned int { return static_cast<unsigned int>(__dredd_replace_expr_unsigned_int_lvalue([&]() -> unsigned int& { return static_cast<unsigned int&>(x); }, 9)); }, 11)); } , [&]() -> unsigned int { return static_cast<unsigned int>(__dredd_replace_expr_unsigned_int([&]() -> unsigned int { return __dredd_replace_expr_int([&]() -> int { return 20; }, 15); }, 20)); }, 24)); }, 30)); }, 34);
+  unsigned int x = __dredd_replace_expr_long([&]() -> long { return 4294967295; }, 0);
+  int y = __dredd_replace_expr_unsigned_int([&]() -> unsigned int { return static_cast<unsigned int>(__dredd_replace_binary_operator_Sub_unsigned_int_unsigned_int([&]() -> unsigned int { return static_cast<unsigned int>(__dredd_replace_expr_unsigned_int([&]() -> unsigned int { return static_cast<unsigned int>(__dredd_replace_expr_unsigned_int_lvalue([&]() -> unsigned int& { return static_cast<unsigned int&>(x); }, 5)); }, 7)); } , [&]() -> unsigned int { return static_cast<unsigned int>(__dredd_replace_expr_int([&]() -> int { return 20; }, 11)); }, 16)); }, 22);
 }

--- a/test/single_file/unary.c.expected
+++ b/test/single_file/unary.c.expected
@@ -16,7 +16,7 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
       while(token) {
         int value = atoi(token);
         int local_value = value - 0;
-        if (local_value >= 0 && local_value < 94) {
+        if (local_value >= 0 && local_value < 91) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
           some_mutation_enabled = 1;
         }
@@ -140,14 +140,14 @@ static double __dredd_replace_expr_double(double arg, int local_mutation_id) {
 
 int main() {
   int x = __dredd_replace_expr_int(3, 0);
-  float y = __dredd_replace_expr_float(__dredd_replace_expr_double(3.532, 5), 8);
-  if (!__dredd_enabled_mutation(20)) { __dredd_replace_expr_int(__dredd_replace_unary_operator_PostInc_int(&(x), 11), 15); }
-  if (!__dredd_enabled_mutation(27)) { __dredd_replace_expr_float(__dredd_replace_unary_operator_PostInc_float(&(y), 21), 24); }
-  if (!__dredd_enabled_mutation(37)) { __dredd_replace_expr_int(__dredd_replace_unary_operator_PreInc_int(&(x), 28), 32); }
-  if (!__dredd_enabled_mutation(44)) { __dredd_replace_expr_float(__dredd_replace_unary_operator_PreInc_float(&(y), 38), 41); }
-  if (!__dredd_enabled_mutation(54)) { __dredd_replace_expr_int(__dredd_replace_unary_operator_PreDec_int(&(x), 45), 49); }
-  if (!__dredd_enabled_mutation(61)) { __dredd_replace_expr_float(__dredd_replace_unary_operator_PreDec_float(&(y), 55), 58); }
-  if (!__dredd_enabled_mutation(71)) { __dredd_replace_expr_int(__dredd_replace_unary_operator_PostDec_int(&(x), 62), 66); }
-  if (!__dredd_enabled_mutation(78)) { __dredd_replace_expr_float(__dredd_replace_unary_operator_PostDec_float(&(y), 72), 75); }
-  if (!__dredd_enabled_mutation(93)) { return __dredd_replace_expr_int(__dredd_replace_unary_operator_Minus_int(__dredd_replace_expr_int(__dredd_replace_expr_int_lvalue(&(x), 79), 81), 86), 88); }
+  float y = __dredd_replace_expr_double(3.532, 5);
+  if (!__dredd_enabled_mutation(17)) { __dredd_replace_expr_int(__dredd_replace_unary_operator_PostInc_int(&(x), 8), 12); }
+  if (!__dredd_enabled_mutation(24)) { __dredd_replace_expr_float(__dredd_replace_unary_operator_PostInc_float(&(y), 18), 21); }
+  if (!__dredd_enabled_mutation(34)) { __dredd_replace_expr_int(__dredd_replace_unary_operator_PreInc_int(&(x), 25), 29); }
+  if (!__dredd_enabled_mutation(41)) { __dredd_replace_expr_float(__dredd_replace_unary_operator_PreInc_float(&(y), 35), 38); }
+  if (!__dredd_enabled_mutation(51)) { __dredd_replace_expr_int(__dredd_replace_unary_operator_PreDec_int(&(x), 42), 46); }
+  if (!__dredd_enabled_mutation(58)) { __dredd_replace_expr_float(__dredd_replace_unary_operator_PreDec_float(&(y), 52), 55); }
+  if (!__dredd_enabled_mutation(68)) { __dredd_replace_expr_int(__dredd_replace_unary_operator_PostDec_int(&(x), 59), 63); }
+  if (!__dredd_enabled_mutation(75)) { __dredd_replace_expr_float(__dredd_replace_unary_operator_PostDec_float(&(y), 69), 72); }
+  if (!__dredd_enabled_mutation(90)) { return __dredd_replace_expr_int(__dredd_replace_unary_operator_Minus_int(__dredd_replace_expr_int(__dredd_replace_expr_int_lvalue(&(x), 76), 78), 83), 85); }
 }

--- a/test/single_file/unary.cc.expected
+++ b/test/single_file/unary.cc.expected
@@ -18,7 +18,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
         if (!token.empty()) {
           int value = std::stoi(token);
           int local_value = value - 0;
-          if (local_value >= 0 && local_value < 68) {
+          if (local_value >= 0 && local_value < 65) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
             some_mutation_enabled = true;
           }
@@ -135,14 +135,14 @@ static double __dredd_replace_expr_double(std::function<double()> arg, int local
 
 int main() {
   int x = __dredd_replace_expr_int([&]() -> int { return 3; }, 0);
-  float y = __dredd_replace_expr_float([&]() -> float { return __dredd_replace_expr_double([&]() -> double { return 3.532; }, 5); }, 8);
-  if (!__dredd_enabled_mutation(20)) { __dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_unary_operator_PostInc_int([&]() -> int& { return static_cast<int&>(x); }, 11)); }, 15); }
-  if (!__dredd_enabled_mutation(27)) { __dredd_replace_expr_float([&]() -> float { return static_cast<float>(__dredd_replace_unary_operator_PostInc_float([&]() -> float& { return static_cast<float&>(y); }, 21)); }, 24); }
-  if (!__dredd_enabled_mutation(29)) { __dredd_replace_unary_operator_PreInc_int([&]() -> int& { return static_cast<int&>(x); }, 28); }
-  if (!__dredd_enabled_mutation(31)) { __dredd_replace_unary_operator_PreInc_float([&]() -> float& { return static_cast<float&>(y); }, 30); }
-  if (!__dredd_enabled_mutation(33)) { __dredd_replace_unary_operator_PreDec_int([&]() -> int& { return static_cast<int&>(x); }, 32); }
-  if (!__dredd_enabled_mutation(35)) { __dredd_replace_unary_operator_PreDec_float([&]() -> float& { return static_cast<float&>(y); }, 34); }
-  if (!__dredd_enabled_mutation(45)) { __dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_unary_operator_PostDec_int([&]() -> int& { return static_cast<int&>(x); }, 36)); }, 40); }
-  if (!__dredd_enabled_mutation(52)) { __dredd_replace_expr_float([&]() -> float { return static_cast<float>(__dredd_replace_unary_operator_PostDec_float([&]() -> float& { return static_cast<float&>(y); }, 46)); }, 49); }
-  if (!__dredd_enabled_mutation(67)) { return __dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_unary_operator_Minus_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int_lvalue([&]() -> int& { return static_cast<int&>(x); }, 53)); }, 55)); }, 60)); }, 62); }
+  float y = __dredd_replace_expr_double([&]() -> double { return 3.532; }, 5);
+  if (!__dredd_enabled_mutation(17)) { __dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_unary_operator_PostInc_int([&]() -> int& { return static_cast<int&>(x); }, 8)); }, 12); }
+  if (!__dredd_enabled_mutation(24)) { __dredd_replace_expr_float([&]() -> float { return static_cast<float>(__dredd_replace_unary_operator_PostInc_float([&]() -> float& { return static_cast<float&>(y); }, 18)); }, 21); }
+  if (!__dredd_enabled_mutation(26)) { __dredd_replace_unary_operator_PreInc_int([&]() -> int& { return static_cast<int&>(x); }, 25); }
+  if (!__dredd_enabled_mutation(28)) { __dredd_replace_unary_operator_PreInc_float([&]() -> float& { return static_cast<float&>(y); }, 27); }
+  if (!__dredd_enabled_mutation(30)) { __dredd_replace_unary_operator_PreDec_int([&]() -> int& { return static_cast<int&>(x); }, 29); }
+  if (!__dredd_enabled_mutation(32)) { __dredd_replace_unary_operator_PreDec_float([&]() -> float& { return static_cast<float&>(y); }, 31); }
+  if (!__dredd_enabled_mutation(42)) { __dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_unary_operator_PostDec_int([&]() -> int& { return static_cast<int&>(x); }, 33)); }, 37); }
+  if (!__dredd_enabled_mutation(49)) { __dredd_replace_expr_float([&]() -> float { return static_cast<float>(__dredd_replace_unary_operator_PostDec_float([&]() -> float& { return static_cast<float&>(y); }, 43)); }, 46); }
+  if (!__dredd_enabled_mutation(64)) { return __dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_unary_operator_Minus_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int_lvalue([&]() -> int& { return static_cast<int&>(x); }, 50)); }, 52)); }, 57)); }, 59); }
 }

--- a/test/single_file/unary_logical_not.c.expected
+++ b/test/single_file/unary_logical_not.c.expected
@@ -18,7 +18,7 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
       while(token) {
         int value = atoi(token);
         int local_value = value - 0;
-        if (local_value >= 0 && local_value < 21) {
+        if (local_value >= 0 && local_value < 17) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
           some_mutation_enabled = 1;
         }
@@ -59,6 +59,6 @@ static _Bool __dredd_replace_expr__Bool(_Bool arg, int local_mutation_id) {
 }
 
 int main() {
-  bool y = __dredd_replace_expr__Bool(__dredd_replace_expr_int(true, 0), 5);
-  if (!__dredd_enabled_mutation(20)) { return __dredd_replace_expr_int(__dredd_replace_unary_operator_LNot__Bool(__dredd_replace_expr__Bool(y, 9), 13), 15); }
+  bool y = __dredd_replace_expr_int(true, 0);
+  if (!__dredd_enabled_mutation(16)) { return __dredd_replace_expr_int(__dredd_replace_unary_operator_LNot__Bool(__dredd_replace_expr__Bool(y, 5), 9), 11); }
 }

--- a/test/single_file/unary_logical_not.cc.expected
+++ b/test/single_file/unary_logical_not.cc.expected
@@ -18,7 +18,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
         if (!token.empty()) {
           int value = std::stoi(token);
           int local_value = value - 0;
-          if (local_value >= 0 && local_value < 20) {
+          if (local_value >= 0 && local_value < 15) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
             some_mutation_enabled = true;
           }
@@ -33,16 +33,6 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
     __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
-}
-
-static int __dredd_replace_expr_int(std::function<int()> arg, int local_mutation_id) {
-  if (!__dredd_some_mutation_enabled) return arg();
-  if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg());
-  if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~(arg());
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 0;
-  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 1;
-  if (__dredd_enabled_mutation(local_mutation_id + 4)) return -1;
-  return arg();
 }
 
 static bool __dredd_replace_unary_operator_LNot_bool(std::function<bool()> arg, int local_mutation_id) {
@@ -63,5 +53,5 @@ static bool __dredd_replace_expr_bool(std::function<bool()> arg, int local_mutat
 
 int main() {
   bool y = __dredd_replace_expr_bool([&]() -> bool { return true; }, 0);
-  if (!__dredd_enabled_mutation(19)) { return __dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_bool([&]() -> bool { return static_cast<bool>(__dredd_replace_unary_operator_LNot_bool([&]() -> bool { return static_cast<bool>(__dredd_replace_expr_bool([&]() -> bool { return static_cast<bool>(y); }, 4)); }, 8)); }, 10)); }, 14); }
+  if (!__dredd_enabled_mutation(14)) { return __dredd_replace_expr_bool([&]() -> bool { return static_cast<bool>(__dredd_replace_unary_operator_LNot_bool([&]() -> bool { return static_cast<bool>(__dredd_replace_expr_bool([&]() -> bool { return static_cast<bool>(y); }, 4)); }, 8)); }, 10); }
 }

--- a/test/single_file/unsigned_int.c.expected
+++ b/test/single_file/unsigned_int.c.expected
@@ -16,7 +16,7 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
       while(token) {
         int value = atoi(token);
         int local_value = value - 0;
-        if (local_value >= 0 && local_value < 32) {
+        if (local_value >= 0 && local_value < 24) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
           some_mutation_enabled = 1;
         }
@@ -28,15 +28,6 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
     __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64));
-}
-
-static unsigned int __dredd_replace_expr_unsigned_int(unsigned int arg, int local_mutation_id) {
-  if (!__dredd_some_mutation_enabled) return arg;
-  if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg);
-  if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~(arg);
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 0;
-  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 1;
-  return arg;
 }
 
 static int __dredd_replace_unary_operator_Not_int(int arg, int local_mutation_id) {
@@ -64,6 +55,6 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
 }
 
 int main() {
-  unsigned int x = __dredd_replace_expr_unsigned_int(__dredd_replace_expr_int(__dredd_replace_unary_operator_LNot_int_zero(__dredd_replace_expr_int(0, 0), 5), 7), 12);
-  unsigned int y = __dredd_replace_expr_unsigned_int(__dredd_replace_expr_int(__dredd_replace_unary_operator_Not_int(__dredd_replace_expr_int(7, 16), 21), 23), 28);
+  unsigned int x = __dredd_replace_expr_int(__dredd_replace_unary_operator_LNot_int_zero(__dredd_replace_expr_int(0, 0), 5), 7);
+  unsigned int y = __dredd_replace_expr_int(__dredd_replace_unary_operator_Not_int(__dredd_replace_expr_int(7, 12), 17), 19);
 }

--- a/test/single_file/unsigned_int.cc.expected
+++ b/test/single_file/unsigned_int.cc.expected
@@ -18,7 +18,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
         if (!token.empty()) {
           int value = std::stoi(token);
           int local_value = value - 0;
-          if (local_value >= 0 && local_value < 35) {
+          if (local_value >= 0 && local_value < 23) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
             some_mutation_enabled = true;
           }
@@ -33,15 +33,6 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
     __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
-}
-
-static unsigned int __dredd_replace_expr_unsigned_int(std::function<unsigned int()> arg, int local_mutation_id) {
-  if (!__dredd_some_mutation_enabled) return arg();
-  if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg());
-  if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~(arg());
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 0;
-  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 1;
-  return arg();
 }
 
 static int __dredd_replace_unary_operator_Not_int(std::function<int()> arg, int local_mutation_id) {
@@ -78,6 +69,6 @@ static bool __dredd_replace_expr_bool(std::function<bool()> arg, int local_mutat
 }
 
 int main() {
-  unsigned int x = __dredd_replace_expr_unsigned_int([&]() -> unsigned int { return __dredd_replace_expr_bool([&]() -> bool { return __dredd_replace_unary_operator_LNot_bool_zero([&]() -> bool { return __dredd_replace_expr_bool([&]() -> bool { return __dredd_replace_expr_int([&]() -> int { return 0; }, 0); }, 5); }, 9); }, 11); }, 15);
-  unsigned int y = __dredd_replace_expr_unsigned_int([&]() -> unsigned int { return __dredd_replace_expr_int([&]() -> int { return __dredd_replace_unary_operator_Not_int([&]() -> int { return __dredd_replace_expr_int([&]() -> int { return 7; }, 19); }, 24); }, 26); }, 31);
+  unsigned int x = __dredd_replace_expr_bool([&]() -> bool { return __dredd_replace_unary_operator_LNot_bool_zero([&]() -> bool { return __dredd_replace_expr_int([&]() -> int { return 0; }, 0); }, 5); }, 7);
+  unsigned int y = __dredd_replace_expr_int([&]() -> int { return __dredd_replace_unary_operator_Not_int([&]() -> int { return __dredd_replace_expr_int([&]() -> int { return 7; }, 11); }, 16); }, 18);
 }


### PR DESCRIPTION
Restricts mutation of cast expressions to the case where the expression inside the case is an l-value and the cast expression is an r-value. This avoids a large number of cases where literal values are implicitly case from signed to unsigned, or from double to float, and get mutated twice as a result.

Fixes #121.