### PR TITLE
Avoid redundant expression replacement

### DIFF
--- a/src/libdredd/include/libdredd/mutation_replace_expr.h
+++ b/src/libdredd/include/libdredd/mutation_replace_expr.h
@@ -63,6 +63,9 @@ class MutationReplaceExpr : public Mutation {
   static bool IsRedundantOperatorInsertion(const clang::Expr& expr,
                                            clang::ASTContext& ast_context);
 
+  void AddOptimisationSpecifier(clang::ASTContext& ast_context,
+                                std::string& function_name) const;
+
   // Replace expressions with constants.
   void GenerateConstantReplacement(clang::ASTContext& ast_context,
                                    bool optimise_mutations,

--- a/src/libdredd/include/libdredd/mutation_replace_expr.h
+++ b/src/libdredd/include/libdredd/mutation_replace_expr.h
@@ -61,6 +61,7 @@ class MutationReplaceExpr : public Mutation {
 
   // Replace expressions with constants.
   void GenerateConstantReplacement(clang::ASTContext& ast_context,
+                                   bool optimise_mutations,
                                    std::stringstream& new_function,
                                    int& mutant_offset) const;
 

--- a/src/libdredd/include/libdredd/mutation_replace_expr.h
+++ b/src/libdredd/include/libdredd/mutation_replace_expr.h
@@ -65,6 +65,21 @@ class MutationReplaceExpr : public Mutation {
                                    std::stringstream& new_function,
                                    int& mutant_offset) const;
 
+  void GenerateBooleanConstantReplacement(clang::ASTContext& ast_context,
+                                          bool optimise_mutations,
+                                          std::stringstream& new_function,
+                                          int& mutant_offset) const;
+
+  void GenerateIntegerConstantReplacement(clang::ASTContext& ast_context,
+                                          bool optimise_mutations,
+                                          std::stringstream& new_function,
+                                          int& mutant_offset) const;
+
+  void GenerateFloatConstantReplacement(clang::ASTContext& ast_context,
+                                        bool optimise_mutations,
+                                        std::stringstream& new_function,
+                                        int& mutant_offset) const;
+
   // Insert valid unary operators such as !, ~, ++ and --.
   void GenerateUnaryOperatorInsertion(const std::string& arg_evaluated,
                                       clang::ASTContext& ast_context,

--- a/src/libdredd/include/libdredd/mutation_replace_expr.h
+++ b/src/libdredd/include/libdredd/mutation_replace_expr.h
@@ -41,8 +41,12 @@ class MutationReplaceExpr : public Mutation {
   static void ApplyCTypeModifiers(const clang::Expr* expr, std::string& type);
 
   // Check if an expression is equivalent to a constant.
-  static bool ExprIsEquivalentTo(const clang::Expr& expr, int constant,
-                                 clang::ASTContext& ast_context);
+  static bool ExprIsEquivalentToInt(const clang::Expr& expr, int constant,
+                                    clang::ASTContext& ast_context);
+  static bool ExprIsEquivalentToFloat(const clang::Expr& expr, double constant,
+                                      clang::ASTContext& ast_context);
+  static bool ExprIsEquivalentToBool(const clang::Expr& expr, bool constant,
+                                     clang::ASTContext& ast_context);
 
   // L-value expressions can be mutated via insertion of the ++ and -- prefix
   // operators. This is only done when an l-value is about to be implicitly

--- a/src/libdredd/src/mutate_visitor.cc
+++ b/src/libdredd/src/mutate_visitor.cc
@@ -302,10 +302,16 @@ bool MutateVisitor::HandleBinaryOperator(
   // There is no useful way to mutate this expression since it is equivalent to
   // replacement with a constant in all cases.
   if (optimise_mutations_ &&
-      MutationReplaceExpr::ExprIsEquivalentTo(
-          *binary_operator->getLHS(), 0, compiler_instance_.getASTContext()) &&
-      MutationReplaceExpr::ExprIsEquivalentTo(
-          *binary_operator->getRHS(), 1, compiler_instance_.getASTContext())) {
+      (MutationReplaceExpr::ExprIsEquivalentToInt(
+           *binary_operator->getLHS(), 0, compiler_instance_.getASTContext()) ||
+       MutationReplaceExpr::ExprIsEquivalentToFloat(
+           *binary_operator->getLHS(), 0,
+           compiler_instance_.getASTContext())) &&
+      (MutationReplaceExpr::ExprIsEquivalentToInt(
+           *binary_operator->getRHS(), 1, compiler_instance_.getASTContext()) ||
+       MutationReplaceExpr::ExprIsEquivalentToFloat(
+           *binary_operator->getRHS(), 1,
+           compiler_instance_.getASTContext()))) {
     return true;
   }
 

--- a/src/libdredd/src/mutation_replace_binary_operator.cc
+++ b/src/libdredd/src/mutation_replace_binary_operator.cc
@@ -65,10 +65,14 @@ bool MutationReplaceBinaryOperator::IsRedundantReplacementOperator(
     clang::BinaryOperatorKind op, clang::ASTContext& ast_context) const {
   // In the case where both operands are 0, the only case that isn't covered
   // by constant replacement is undefined behaviour, this is achieved by /.
-  if (MutationReplaceExpr::ExprIsEquivalentTo(*binary_operator_.getRHS(), 0,
-                                              ast_context) &&
-      MutationReplaceExpr::ExprIsEquivalentTo(*binary_operator_.getLHS(), 0,
-                                              ast_context)) {
+  if ((MutationReplaceExpr::ExprIsEquivalentToInt(*binary_operator_.getRHS(), 0,
+                                                  ast_context) ||
+       MutationReplaceExpr::ExprIsEquivalentToFloat(*binary_operator_.getRHS(),
+                                                    0, ast_context)) &&
+      (MutationReplaceExpr::ExprIsEquivalentToInt(*binary_operator_.getRHS(), 0,
+                                                  ast_context) ||
+       MutationReplaceExpr::ExprIsEquivalentToFloat(*binary_operator_.getRHS(),
+                                                    0, ast_context))) {
     if (op == clang::BO_Div) {
       return false;
     }
@@ -76,8 +80,10 @@ bool MutationReplaceBinaryOperator::IsRedundantReplacementOperator(
 
   // In the following cases, the replacement is equivalent to either replacement
   // with a constant or argument replacement.
-  if (MutationReplaceExpr::ExprIsEquivalentTo(*binary_operator_.getRHS(), 0,
-                                              ast_context)) {
+  if ((MutationReplaceExpr::ExprIsEquivalentToInt(*binary_operator_.getRHS(), 0,
+                                                  ast_context) ||
+       MutationReplaceExpr::ExprIsEquivalentToFloat(*binary_operator_.getRHS(),
+                                                    0, ast_context))) {
     // When the right operand is 0: +, -, << and >> are all equivalent to
     // replacement with the right operand; * is equivalent to replacement with
     // the constant 0 and % is equivalent to replacement with / in that both
@@ -88,8 +94,10 @@ bool MutationReplaceBinaryOperator::IsRedundantReplacementOperator(
     }
   }
 
-  if (MutationReplaceExpr::ExprIsEquivalentTo(*binary_operator_.getRHS(), 1,
-                                              ast_context)) {
+  if ((MutationReplaceExpr::ExprIsEquivalentToInt(*binary_operator_.getRHS(), 1,
+                                                  ast_context) ||
+       MutationReplaceExpr::ExprIsEquivalentToFloat(*binary_operator_.getRHS(),
+                                                    1, ast_context))) {
     // When the right operand is 1: * and / are equivalent to replacement by
     // the left operand.
     if (op == clang::BO_Mul || op == clang::BO_Div) {
@@ -97,8 +105,10 @@ bool MutationReplaceBinaryOperator::IsRedundantReplacementOperator(
     }
   }
 
-  if (MutationReplaceExpr::ExprIsEquivalentTo(*binary_operator_.getLHS(), 0,
-                                              ast_context)) {
+  if ((MutationReplaceExpr::ExprIsEquivalentToInt(*binary_operator_.getLHS(), 0,
+                                                  ast_context) ||
+       MutationReplaceExpr::ExprIsEquivalentToFloat(*binary_operator_.getLHS(),
+                                                    0, ast_context))) {
     // When the left operand is 0: *, /, %, << and >> are equivalent to
     // replacement by the constant 0 and + is equivalent to replacement by the
     // right operand.
@@ -108,8 +118,10 @@ bool MutationReplaceBinaryOperator::IsRedundantReplacementOperator(
     }
   }
 
-  if (MutationReplaceExpr::ExprIsEquivalentTo(*binary_operator_.getLHS(), 1,
-                                              ast_context) &&
+  if ((MutationReplaceExpr::ExprIsEquivalentToInt(*binary_operator_.getLHS(), 1,
+                                                  ast_context) ||
+       MutationReplaceExpr::ExprIsEquivalentToFloat(*binary_operator_.getLHS(),
+                                                    1, ast_context)) &&
       op == clang::BO_Mul) {
     // When the left operand is 1: * is equivalent to replacement by the right
     // operand.
@@ -268,24 +280,36 @@ std::string MutationReplaceBinaryOperator::GetFunctionName(
   // with other versions that apply to the same operator and types but cannot
   // be optimised.
   if (optimise_mutations && !binary_operator_.isAssignmentOp()) {
-    if (MutationReplaceExpr::ExprIsEquivalentTo(*binary_operator_.getRHS(), 0,
-                                                ast_context)) {
+    if (MutationReplaceExpr::ExprIsEquivalentToInt(*binary_operator_.getRHS(),
+                                                   0, ast_context) ||
+        MutationReplaceExpr::ExprIsEquivalentToFloat(*binary_operator_.getRHS(),
+                                                     0, ast_context)) {
       result += "_rhs_zero";
-    } else if (MutationReplaceExpr::ExprIsEquivalentTo(
+    } else if (MutationReplaceExpr::ExprIsEquivalentToInt(
+                   *binary_operator_.getRHS(), 1, ast_context) ||
+               MutationReplaceExpr::ExprIsEquivalentToFloat(
                    *binary_operator_.getRHS(), 1, ast_context)) {
       result += "_rhs_one";
-    } else if (MutationReplaceExpr::ExprIsEquivalentTo(
+    } else if (MutationReplaceExpr::ExprIsEquivalentToInt(
+                   *binary_operator_.getRHS(), -1, ast_context) ||
+               MutationReplaceExpr::ExprIsEquivalentToFloat(
                    *binary_operator_.getRHS(), -1, ast_context)) {
       result += "_rhs_minus_one";
     }
 
-    if (MutationReplaceExpr::ExprIsEquivalentTo(*binary_operator_.getLHS(), 0,
-                                                ast_context)) {
+    if (MutationReplaceExpr::ExprIsEquivalentToInt(*binary_operator_.getLHS(),
+                                                   0, ast_context) ||
+        MutationReplaceExpr::ExprIsEquivalentToFloat(*binary_operator_.getLHS(),
+                                                     0, ast_context)) {
       result += "_lhs_zero";
-    } else if (MutationReplaceExpr::ExprIsEquivalentTo(
+    } else if (MutationReplaceExpr::ExprIsEquivalentToInt(
+                   *binary_operator_.getLHS(), 1, ast_context) ||
+               MutationReplaceExpr::ExprIsEquivalentToFloat(
                    *binary_operator_.getLHS(), 1, ast_context)) {
       result += "_lhs_one";
-    } else if (MutationReplaceExpr::ExprIsEquivalentTo(
+    } else if (MutationReplaceExpr::ExprIsEquivalentToInt(
+                   *binary_operator_.getLHS(), -1, ast_context) ||
+               MutationReplaceExpr::ExprIsEquivalentToFloat(
                    *binary_operator_.getLHS(), -1, ast_context)) {
       result += "_lhs_minus_one";
     }

--- a/src/libdredd/src/mutation_replace_binary_operator.cc
+++ b/src/libdredd/src/mutation_replace_binary_operator.cc
@@ -268,30 +268,25 @@ std::string MutationReplaceBinaryOperator::GetFunctionName(
   // with other versions that apply to the same operator and types but cannot
   // be optimised.
   if (optimise_mutations && !binary_operator_.isAssignmentOp()) {
-    clang::Expr::EvalResult eval_result;
-    bool rhs_is_int =
-        binary_operator_.getRHS()->EvaluateAsInt(eval_result, ast_context);
-    if (rhs_is_int && llvm::APSInt::isSameValue(eval_result.Val.getInt(),
-                                                llvm::APSInt::get(0))) {
+    if (MutationReplaceExpr::ExprIsEquivalentTo(*binary_operator_.getRHS(), 0,
+                                                ast_context)) {
       result += "_rhs_zero";
-    } else if (rhs_is_int && llvm::APSInt::isSameValue(eval_result.Val.getInt(),
-                                                       llvm::APSInt::get(1))) {
+    } else if (MutationReplaceExpr::ExprIsEquivalentTo(
+                   *binary_operator_.getRHS(), 1, ast_context)) {
       result += "_rhs_one";
-    } else if (rhs_is_int && llvm::APSInt::isSameValue(eval_result.Val.getInt(),
-                                                       llvm::APSInt::get(-1))) {
+    } else if (MutationReplaceExpr::ExprIsEquivalentTo(
+                   *binary_operator_.getRHS(), -1, ast_context)) {
       result += "_rhs_minus_one";
     }
 
-    bool lhs_is_int =
-        binary_operator_.getLHS()->EvaluateAsInt(eval_result, ast_context);
-    if (lhs_is_int && llvm::APSInt::isSameValue(eval_result.Val.getInt(),
-                                                llvm::APSInt::get(0))) {
+    if (MutationReplaceExpr::ExprIsEquivalentTo(*binary_operator_.getLHS(), 0,
+                                                ast_context)) {
       result += "_lhs_zero";
-    } else if (lhs_is_int && llvm::APSInt::isSameValue(eval_result.Val.getInt(),
-                                                       llvm::APSInt::get(1))) {
+    } else if (MutationReplaceExpr::ExprIsEquivalentTo(
+                   *binary_operator_.getLHS(), 1, ast_context)) {
       result += "_lhs_one";
-    } else if (lhs_is_int && llvm::APSInt::isSameValue(eval_result.Val.getInt(),
-                                                       llvm::APSInt::get(-1))) {
+    } else if (MutationReplaceExpr::ExprIsEquivalentTo(
+                   *binary_operator_.getLHS(), -1, ast_context)) {
       result += "_lhs_minus_one";
     }
   }

--- a/src/libdredd/src/mutation_replace_expr.cc
+++ b/src/libdredd/src/mutation_replace_expr.cc
@@ -73,12 +73,17 @@ std::string MutationReplaceExpr::GetFunctionName(
       result += "_uoi_optimised";
     }
 
-    if ((expr_.getType()->isIntegerType() && !expr_.getType()->isBooleanType()) || expr_.getType()->isFloatingType()) {
-      if (ExprIsEquivalentToInt(expr_, 0, ast_context) || ExprIsEquivalentToFloat(expr_, 0, ast_context)) {
+    if ((expr_.getType()->isIntegerType() &&
+         !expr_.getType()->isBooleanType()) ||
+        expr_.getType()->isFloatingType()) {
+      if (ExprIsEquivalentToInt(expr_, 0, ast_context) ||
+          ExprIsEquivalentToFloat(expr_, 0, ast_context)) {
         result += "_zero";
-      } else if (ExprIsEquivalentToInt(expr_, 1, ast_context) || ExprIsEquivalentToFloat(expr_, 1, ast_context)) {
+      } else if (ExprIsEquivalentToInt(expr_, 1, ast_context) ||
+                 ExprIsEquivalentToFloat(expr_, 1, ast_context)) {
         result += "_one";
-      } else if (ExprIsEquivalentToInt(expr_, -1, ast_context) || ExprIsEquivalentToFloat(expr_, -1, ast_context)) {
+      } else if (ExprIsEquivalentToInt(expr_, -1, ast_context) ||
+                 ExprIsEquivalentToFloat(expr_, -1, ast_context)) {
         result += "_minus_one";
       }
     }

--- a/src/libdredd/src/mutation_replace_expr.cc
+++ b/src/libdredd/src/mutation_replace_expr.cc
@@ -64,40 +64,45 @@ std::string MutationReplaceExpr::GetFunctionName(
   }
 
   if (optimise_mutations) {
-    // This is sufficient to prevent name clashes as this is the
-    // only unary operator insertion optimisation that depends on the
-    // input expression. ~ is omitted for all boolean expressions
-    // so the type that is included in the function name will be enough
-    // in that case.
-    if (IsRedundantOperatorInsertion(expr_, ast_context)) {
-      result += "_uoi_optimised";
-    }
-
-    if ((expr_.getType()->isIntegerType() &&
-         !expr_.getType()->isBooleanType()) ||
-        expr_.getType()->isFloatingType()) {
-      if (ExprIsEquivalentToInt(expr_, 0, ast_context) ||
-          ExprIsEquivalentToFloat(expr_, 0, ast_context)) {
-        result += "_zero";
-      } else if (ExprIsEquivalentToInt(expr_, 1, ast_context) ||
-                 ExprIsEquivalentToFloat(expr_, 1, ast_context)) {
-        result += "_one";
-      } else if (ExprIsEquivalentToInt(expr_, -1, ast_context) ||
-                 ExprIsEquivalentToFloat(expr_, -1, ast_context)) {
-        result += "_minus_one";
-      }
-    }
-
-    if (expr_.getType()->isBooleanType()) {
-      if (ExprIsEquivalentToBool(expr_, true, ast_context)) {
-        result += "_true";
-      } else if (ExprIsEquivalentToBool(expr_, false, ast_context)) {
-        result += "_false";
-      }
-    }
+    AddOptimisationSpecifier(ast_context, result);
   }
 
   return result;
+}
+
+void MutationReplaceExpr::AddOptimisationSpecifier(
+    clang::ASTContext& ast_context,
+    std::string& function_name)
+    const {  // This is sufficient to prevent name clashes as this is the
+             // only unary operator insertion optimisation that depends on the
+             // input expression. ~ is omitted for all boolean expressions
+             // so the type that is included in the function name will be enough
+             // in that case.
+  if (IsRedundantOperatorInsertion(expr_, ast_context)) {
+    function_name += "_uoi_optimised";
+  }
+
+  if ((expr_.getType()->isIntegerType() && !expr_.getType()->isBooleanType()) ||
+      expr_.getType()->isFloatingType()) {
+    if (ExprIsEquivalentToInt(expr_, 0, ast_context) ||
+        ExprIsEquivalentToFloat(expr_, 0, ast_context)) {
+      function_name += "_zero";
+    } else if (ExprIsEquivalentToInt(expr_, 1, ast_context) ||
+               ExprIsEquivalentToFloat(expr_, 1, ast_context)) {
+      function_name += "_one";
+    } else if (ExprIsEquivalentToInt(expr_, -1, ast_context) ||
+               ExprIsEquivalentToFloat(expr_, -1, ast_context)) {
+      function_name += "_minus_one";
+    }
+  }
+
+  if (expr_.getType()->isBooleanType()) {
+    if (ExprIsEquivalentToBool(expr_, true, ast_context)) {
+      function_name += "_true";
+    } else if (ExprIsEquivalentToBool(expr_, false, ast_context)) {
+      function_name += "_false";
+    }
+  }
 }
 
 bool MutationReplaceExpr::ExprIsEquivalentToInt(

--- a/src/libdredd/src/mutation_replace_unary_operator.cc
+++ b/src/libdredd/src/mutation_replace_unary_operator.cc
@@ -168,18 +168,24 @@ std::string MutationReplaceUnaryOperator::GetFunctionName(
   // with other versions that apply to the same operator and types but cannot
   // be optimised.
   if (optimise_mutations) {
-    if (MutationReplaceExpr::ExprIsEquivalentTo(*unary_operator_.getSubExpr(),
-                                                0, ast_context)) {
+    if (MutationReplaceExpr::ExprIsEquivalentToInt(
+            *unary_operator_.getSubExpr(), 0, ast_context) ||
+        MutationReplaceExpr::ExprIsEquivalentToFloat(
+            *unary_operator_.getSubExpr(), 0, ast_context)) {
       result += "_zero";
     }
 
-    if (MutationReplaceExpr::ExprIsEquivalentTo(*unary_operator_.getSubExpr(),
-                                                1, ast_context)) {
+    if (MutationReplaceExpr::ExprIsEquivalentToInt(
+            *unary_operator_.getSubExpr(), 1, ast_context) ||
+        MutationReplaceExpr::ExprIsEquivalentToFloat(
+            *unary_operator_.getSubExpr(), 1, ast_context)) {
       result += "_one";
     }
 
-    if (MutationReplaceExpr::ExprIsEquivalentTo(*unary_operator_.getSubExpr(),
-                                                -1, ast_context)) {
+    if (MutationReplaceExpr::ExprIsEquivalentToInt(
+            *unary_operator_.getSubExpr(), -1, ast_context) ||
+        MutationReplaceExpr::ExprIsEquivalentToFloat(
+            *unary_operator_.getSubExpr(), -1, ast_context)) {
       result += "_minus_one";
     }
   }
@@ -249,18 +255,24 @@ bool MutationReplaceUnaryOperator::IsRedundantReplacementOperator(
   // When the operand is 0: - is equivalent to replacement with 0 and ! is
   // equivalent to replacement with 1. When the operand is 1: - is equivalent to
   // replacement with -1 and ! is equivalent to replacement with 0.
-  if (MutationReplaceExpr::ExprIsEquivalentTo(*unary_operator_.getSubExpr(), 0,
-                                              ast_context) ||
-      MutationReplaceExpr::ExprIsEquivalentTo(*unary_operator_.getSubExpr(), 1,
-                                              ast_context)) {
+  if (MutationReplaceExpr::ExprIsEquivalentToInt(*unary_operator_.getSubExpr(),
+                                                 0, ast_context) ||
+      MutationReplaceExpr::ExprIsEquivalentToFloat(
+          *unary_operator_.getSubExpr(), 0, ast_context) ||
+      MutationReplaceExpr::ExprIsEquivalentToInt(*unary_operator_.getSubExpr(),
+                                                 1, ast_context) ||
+      MutationReplaceExpr::ExprIsEquivalentToFloat(
+          *unary_operator_.getSubExpr(), 1, ast_context)) {
     if (op == clang::UO_Minus || op == clang::UO_LNot) {
       return true;
     }
   }
 
   // When the operand is -1: - is equivalent to replacement with 1.
-  if (MutationReplaceExpr::ExprIsEquivalentTo(*unary_operator_.getSubExpr(), -1,
-                                              ast_context) &&
+  if ((MutationReplaceExpr::ExprIsEquivalentToInt(*unary_operator_.getSubExpr(),
+                                                  -1, ast_context) ||
+       MutationReplaceExpr::ExprIsEquivalentToFloat(
+           *unary_operator_.getSubExpr(), -1, ast_context)) &&
       op == clang::UO_Minus) {
     return true;
   }
@@ -294,12 +306,18 @@ void MutationReplaceUnaryOperator::GenerateUnaryOperatorReplacement(
   // In these cases, replacement with the argument is equivalent to replacement
   // with the respective constant.
   if (!optimise_mutations ||
-      MutationReplaceExpr::ExprIsEquivalentTo(*unary_operator_.getSubExpr(), 0,
-                                              ast_context) ||
-      MutationReplaceExpr::ExprIsEquivalentTo(*unary_operator_.getSubExpr(), 1,
-                                              ast_context) ||
-      MutationReplaceExpr::ExprIsEquivalentTo(*unary_operator_.getSubExpr(), -1,
-                                              ast_context)) {
+      MutationReplaceExpr::ExprIsEquivalentToInt(*unary_operator_.getSubExpr(),
+                                                 0, ast_context) ||
+      MutationReplaceExpr::ExprIsEquivalentToFloat(
+          *unary_operator_.getSubExpr(), 0, ast_context) ||
+      MutationReplaceExpr::ExprIsEquivalentToInt(*unary_operator_.getSubExpr(),
+                                                 1, ast_context) ||
+      MutationReplaceExpr::ExprIsEquivalentToFloat(
+          *unary_operator_.getSubExpr(), 1, ast_context) ||
+      MutationReplaceExpr::ExprIsEquivalentToInt(*unary_operator_.getSubExpr(),
+                                                 -1, ast_context) ||
+      MutationReplaceExpr::ExprIsEquivalentToFloat(
+          *unary_operator_.getSubExpr(), -1, ast_context)) {
     new_function << "  if (__dredd_enabled_mutation(local_mutation_id + "
                  << mutant_offset << ")) return " + arg_evaluated + ";\n";
     mutant_offset++;

--- a/test/single_file/add.c.expected
+++ b/test/single_file/add.c.expected
@@ -16,7 +16,7 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
       while(token) {
         int value = atoi(token);
         int local_value = value - 0;
-        if (local_value >= 0 && local_value < 53) {
+        if (local_value >= 0 && local_value < 52) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
           some_mutation_enabled = 1;
         }
@@ -30,12 +30,11 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
   return enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64));
 }
 
-static int __dredd_replace_expr_int_uoi_optimised(int arg, int local_mutation_id) {
+static int __dredd_replace_expr_int_uoi_optimised_one(int arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg);
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return 0;
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 1;
-  if (__dredd_enabled_mutation(local_mutation_id + 3)) return -1;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
   return arg;
 }
 
@@ -68,7 +67,7 @@ static int __dredd_replace_binary_operator_Add_int_int(int arg1, int arg2, int l
 }
 
 int main() {
-  int x = __dredd_replace_expr_int_uoi_optimised(1, 0);
-  int y = __dredd_replace_expr_int(2, 4);
-  if (!__dredd_enabled_mutation(52)) { return __dredd_replace_expr_int(__dredd_replace_binary_operator_Add_int_int(__dredd_replace_expr_int(__dredd_replace_binary_operator_Add_int_int(__dredd_replace_expr_int(__dredd_replace_expr_int_lvalue(&(x), 9), 11) , __dredd_replace_expr_int(__dredd_replace_expr_int_lvalue(&(y), 16), 18), 23), 29) , __dredd_replace_expr_int(__dredd_replace_expr_int_lvalue(&(x), 34), 36), 41), 47); }
+  int x = __dredd_replace_expr_int_uoi_optimised_one(1, 0);
+  int y = __dredd_replace_expr_int(2, 3);
+  if (!__dredd_enabled_mutation(51)) { return __dredd_replace_expr_int(__dredd_replace_binary_operator_Add_int_int(__dredd_replace_expr_int(__dredd_replace_binary_operator_Add_int_int(__dredd_replace_expr_int(__dredd_replace_expr_int_lvalue(&(x), 8), 10) , __dredd_replace_expr_int(__dredd_replace_expr_int_lvalue(&(y), 15), 17), 22), 28) , __dredd_replace_expr_int(__dredd_replace_expr_int_lvalue(&(x), 33), 35), 40), 46); }
 }

--- a/test/single_file/add.cc.expected
+++ b/test/single_file/add.cc.expected
@@ -18,7 +18,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
         if (!token.empty()) {
           int value = std::stoi(token);
           int local_value = value - 0;
-          if (local_value >= 0 && local_value < 53) {
+          if (local_value >= 0 && local_value < 52) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
             some_mutation_enabled = true;
           }
@@ -35,12 +35,11 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }
 
-static int __dredd_replace_expr_int_uoi_optimised(std::function<int()> arg, int local_mutation_id) {
+static int __dredd_replace_expr_int_uoi_optimised_one(std::function<int()> arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg());
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return 0;
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 1;
-  if (__dredd_enabled_mutation(local_mutation_id + 3)) return -1;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
   return arg();
 }
 
@@ -73,7 +72,7 @@ static int __dredd_replace_binary_operator_Add_int_int(std::function<int()> arg1
 }
 
 int main() {
-  int x = __dredd_replace_expr_int_uoi_optimised([&]() -> int { return 1; }, 0);
-  int y = __dredd_replace_expr_int([&]() -> int { return 2; }, 4);
-  if (!__dredd_enabled_mutation(52)) { return __dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_binary_operator_Add_int_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_binary_operator_Add_int_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int_lvalue([&]() -> int& { return static_cast<int&>(x); }, 9)); }, 11)); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int_lvalue([&]() -> int& { return static_cast<int&>(y); }, 16)); }, 18)); }, 23)); }, 29)); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int_lvalue([&]() -> int& { return static_cast<int&>(x); }, 34)); }, 36)); }, 41)); }, 47); }
+  int x = __dredd_replace_expr_int_uoi_optimised_one([&]() -> int { return 1; }, 0);
+  int y = __dredd_replace_expr_int([&]() -> int { return 2; }, 3);
+  if (!__dredd_enabled_mutation(51)) { return __dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_binary_operator_Add_int_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_binary_operator_Add_int_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int_lvalue([&]() -> int& { return static_cast<int&>(x); }, 8)); }, 10)); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int_lvalue([&]() -> int& { return static_cast<int&>(y); }, 15)); }, 17)); }, 22)); }, 28)); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int_lvalue([&]() -> int& { return static_cast<int&>(x); }, 33)); }, 35)); }, 40)); }, 46); }
 }

--- a/test/single_file/add_float.c.expected
+++ b/test/single_file/add_float.c.expected
@@ -16,7 +16,7 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
       while(token) {
         int value = atoi(token);
         int local_value = value - 0;
-        if (local_value >= 0 && local_value < 34) {
+        if (local_value >= 0 && local_value < 33) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
           some_mutation_enabled = 1;
         }
@@ -30,12 +30,11 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
   return enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64));
 }
 
-static int __dredd_replace_expr_int_uoi_optimised(int arg, int local_mutation_id) {
+static int __dredd_replace_expr_int_uoi_optimised_zero(int arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg);
-  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 0;
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 1;
-  if (__dredd_enabled_mutation(local_mutation_id + 3)) return -1;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
   return arg;
 }
 
@@ -86,5 +85,5 @@ int main() {
   float y = __dredd_replace_expr_double(754.34623, 3);
   float z;
   if (!__dredd_enabled_mutation(28)) { __dredd_replace_binary_operator_Assign_float_float(&(z) , __dredd_replace_expr_float(__dredd_replace_binary_operator_Add_float_float(__dredd_replace_expr_float(__dredd_replace_expr_float_lvalue(&(x), 6), 8) , __dredd_replace_expr_float(__dredd_replace_expr_float_lvalue(&(y), 11), 13), 16), 21), 24); }
-  if (!__dredd_enabled_mutation(33)) { return __dredd_replace_expr_int_uoi_optimised(0, 29); }
+  if (!__dredd_enabled_mutation(32)) { return __dredd_replace_expr_int_uoi_optimised_zero(0, 29); }
 }

--- a/test/single_file/add_float.cc.expected
+++ b/test/single_file/add_float.cc.expected
@@ -18,7 +18,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
         if (!token.empty()) {
           int value = std::stoi(token);
           int local_value = value - 0;
-          if (local_value >= 0 && local_value < 34) {
+          if (local_value >= 0 && local_value < 33) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
             some_mutation_enabled = true;
           }
@@ -35,12 +35,11 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }
 
-static int __dredd_replace_expr_int_uoi_optimised(std::function<int()> arg, int local_mutation_id) {
+static int __dredd_replace_expr_int_uoi_optimised_zero(std::function<int()> arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg());
-  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 0;
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 1;
-  if (__dredd_enabled_mutation(local_mutation_id + 3)) return -1;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
   return arg();
 }
 
@@ -91,5 +90,5 @@ int main() {
   float y = __dredd_replace_expr_double([&]() -> double { return 754.34623; }, 3);
   float z;
   if (!__dredd_enabled_mutation(28)) { __dredd_replace_binary_operator_Assign_float_float([&]() -> float& { return static_cast<float&>(z); } , [&]() -> float { return static_cast<float>(__dredd_replace_expr_float([&]() -> float { return static_cast<float>(__dredd_replace_binary_operator_Add_float_float([&]() -> float { return static_cast<float>(__dredd_replace_expr_float([&]() -> float { return static_cast<float>(__dredd_replace_expr_float_lvalue([&]() -> float& { return static_cast<float&>(x); }, 6)); }, 8)); } , [&]() -> float { return static_cast<float>(__dredd_replace_expr_float([&]() -> float { return static_cast<float>(__dredd_replace_expr_float_lvalue([&]() -> float& { return static_cast<float&>(y); }, 11)); }, 13)); }, 16)); }, 21)); }, 24); }
-  if (!__dredd_enabled_mutation(33)) { return __dredd_replace_expr_int_uoi_optimised([&]() -> int { return 0; }, 29); }
+  if (!__dredd_enabled_mutation(32)) { return __dredd_replace_expr_int_uoi_optimised_zero([&]() -> int { return 0; }, 29); }
 }

--- a/test/single_file/add_mul.c.expected
+++ b/test/single_file/add_mul.c.expected
@@ -16,7 +16,7 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
       while(token) {
         int value = atoi(token);
         int local_value = value - 0;
-        if (local_value >= 0 && local_value < 53) {
+        if (local_value >= 0 && local_value < 52) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
           some_mutation_enabled = 1;
         }
@@ -30,12 +30,11 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
   return enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64));
 }
 
-static int __dredd_replace_expr_int_uoi_optimised(int arg, int local_mutation_id) {
+static int __dredd_replace_expr_int_uoi_optimised_one(int arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg);
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return 0;
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 1;
-  if (__dredd_enabled_mutation(local_mutation_id + 3)) return -1;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
   return arg;
 }
 
@@ -79,7 +78,7 @@ static int __dredd_replace_binary_operator_Add_int_int(int arg1, int arg2, int l
 }
 
 int main() {
-  int x = __dredd_replace_expr_int_uoi_optimised(1, 0);
-  int y = __dredd_replace_expr_int(2, 4);
-  if (!__dredd_enabled_mutation(52)) { return __dredd_replace_expr_int(__dredd_replace_binary_operator_Add_int_int(__dredd_replace_expr_int(__dredd_replace_expr_int_lvalue(&(x), 9), 11) , __dredd_replace_expr_int(__dredd_replace_binary_operator_Mul_int_int(__dredd_replace_expr_int(__dredd_replace_expr_int_lvalue(&(y), 16), 18) , __dredd_replace_expr_int(__dredd_replace_expr_int_lvalue(&(x), 23), 25), 30), 36), 41), 47); }
+  int x = __dredd_replace_expr_int_uoi_optimised_one(1, 0);
+  int y = __dredd_replace_expr_int(2, 3);
+  if (!__dredd_enabled_mutation(51)) { return __dredd_replace_expr_int(__dredd_replace_binary_operator_Add_int_int(__dredd_replace_expr_int(__dredd_replace_expr_int_lvalue(&(x), 8), 10) , __dredd_replace_expr_int(__dredd_replace_binary_operator_Mul_int_int(__dredd_replace_expr_int(__dredd_replace_expr_int_lvalue(&(y), 15), 17) , __dredd_replace_expr_int(__dredd_replace_expr_int_lvalue(&(x), 22), 24), 29), 35), 40), 46); }
 }

--- a/test/single_file/add_mul.cc.expected
+++ b/test/single_file/add_mul.cc.expected
@@ -18,7 +18,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
         if (!token.empty()) {
           int value = std::stoi(token);
           int local_value = value - 0;
-          if (local_value >= 0 && local_value < 53) {
+          if (local_value >= 0 && local_value < 52) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
             some_mutation_enabled = true;
           }
@@ -35,12 +35,11 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }
 
-static int __dredd_replace_expr_int_uoi_optimised(std::function<int()> arg, int local_mutation_id) {
+static int __dredd_replace_expr_int_uoi_optimised_one(std::function<int()> arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg());
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return 0;
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 1;
-  if (__dredd_enabled_mutation(local_mutation_id + 3)) return -1;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
   return arg();
 }
 
@@ -84,7 +83,7 @@ static int __dredd_replace_binary_operator_Add_int_int(std::function<int()> arg1
 }
 
 int main() {
-  int x = __dredd_replace_expr_int_uoi_optimised([&]() -> int { return 1; }, 0);
-  int y = __dredd_replace_expr_int([&]() -> int { return 2; }, 4);
-  if (!__dredd_enabled_mutation(52)) { return __dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_binary_operator_Add_int_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int_lvalue([&]() -> int& { return static_cast<int&>(x); }, 9)); }, 11)); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_binary_operator_Mul_int_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int_lvalue([&]() -> int& { return static_cast<int&>(y); }, 16)); }, 18)); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int_lvalue([&]() -> int& { return static_cast<int&>(x); }, 23)); }, 25)); }, 30)); }, 36)); }, 41)); }, 47); }
+  int x = __dredd_replace_expr_int_uoi_optimised_one([&]() -> int { return 1; }, 0);
+  int y = __dredd_replace_expr_int([&]() -> int { return 2; }, 3);
+  if (!__dredd_enabled_mutation(51)) { return __dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_binary_operator_Add_int_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int_lvalue([&]() -> int& { return static_cast<int&>(x); }, 8)); }, 10)); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_binary_operator_Mul_int_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int_lvalue([&]() -> int& { return static_cast<int&>(y); }, 15)); }, 17)); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int_lvalue([&]() -> int& { return static_cast<int&>(x); }, 22)); }, 24)); }, 29)); }, 35)); }, 40)); }, 46); }
 }

--- a/test/single_file/basic.c.expected
+++ b/test/single_file/basic.c.expected
@@ -16,7 +16,7 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
       while(token) {
         int value = atoi(token);
         int local_value = value - 0;
-        if (local_value >= 0 && local_value < 5) {
+        if (local_value >= 0 && local_value < 4) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
           some_mutation_enabled = 1;
         }
@@ -30,15 +30,14 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
   return enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64));
 }
 
-static int __dredd_replace_expr_int_uoi_optimised(int arg, int local_mutation_id) {
+static int __dredd_replace_expr_int_uoi_optimised_zero(int arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg);
-  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 0;
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 1;
-  if (__dredd_enabled_mutation(local_mutation_id + 3)) return -1;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
   return arg;
 }
 
 int main() {
-  if (!__dredd_enabled_mutation(4)) { return __dredd_replace_expr_int_uoi_optimised(0, 0); }
+  if (!__dredd_enabled_mutation(3)) { return __dredd_replace_expr_int_uoi_optimised_zero(0, 0); }
 }

--- a/test/single_file/basic.cc.expected
+++ b/test/single_file/basic.cc.expected
@@ -18,7 +18,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
         if (!token.empty()) {
           int value = std::stoi(token);
           int local_value = value - 0;
-          if (local_value >= 0 && local_value < 5) {
+          if (local_value >= 0 && local_value < 4) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
             some_mutation_enabled = true;
           }
@@ -35,15 +35,14 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }
 
-static int __dredd_replace_expr_int_uoi_optimised(std::function<int()> arg, int local_mutation_id) {
+static int __dredd_replace_expr_int_uoi_optimised_zero(std::function<int()> arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg());
-  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 0;
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 1;
-  if (__dredd_enabled_mutation(local_mutation_id + 3)) return -1;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
   return arg();
 }
 
 int main() {
-  if (!__dredd_enabled_mutation(4)) { return __dredd_replace_expr_int_uoi_optimised([&]() -> int { return 0; }, 0); }
+  if (!__dredd_enabled_mutation(3)) { return __dredd_replace_expr_int_uoi_optimised_zero([&]() -> int { return 0; }, 0); }
 }

--- a/test/single_file/binary_lhs_zero.cc.expected
+++ b/test/single_file/binary_lhs_zero.cc.expected
@@ -18,7 +18,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
         if (!token.empty()) {
           int value = std::stoi(token);
           int local_value = value - 0;
-          if (local_value >= 0 && local_value < 24) {
+          if (local_value >= 0 && local_value < 23) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
             some_mutation_enabled = true;
           }
@@ -35,12 +35,11 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }
 
-static int __dredd_replace_expr_int_uoi_optimised(std::function<int()> arg, int local_mutation_id) {
+static int __dredd_replace_expr_int_uoi_optimised_zero(std::function<int()> arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg());
-  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 0;
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 1;
-  if (__dredd_enabled_mutation(local_mutation_id + 3)) return -1;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
   return arg();
 }
 
@@ -69,6 +68,6 @@ static int __dredd_replace_binary_operator_Add_int_int_lhs_zero(std::function<in
 }
 
 int main() {
-  int x = __dredd_replace_expr_int([&]() -> int { return __dredd_replace_binary_operator_Add_int_int_lhs_zero([&]() -> int { return static_cast<int>(__dredd_replace_expr_int_uoi_optimised([&]() -> int { return 0; }, 0)); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return 8; }, 4)); }, 9); }, 11);
-  if (!__dredd_enabled_mutation(23)) { return __dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int_lvalue([&]() -> int& { return static_cast<int&>(x); }, 16)); }, 18); }
+  int x = __dredd_replace_expr_int([&]() -> int { return __dredd_replace_binary_operator_Add_int_int_lhs_zero([&]() -> int { return static_cast<int>(__dredd_replace_expr_int_uoi_optimised_zero([&]() -> int { return 0; }, 0)); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return 8; }, 3)); }, 8); }, 10);
+  if (!__dredd_enabled_mutation(22)) { return __dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int_lvalue([&]() -> int& { return static_cast<int&>(x); }, 15)); }, 17); }
 }

--- a/test/single_file/binary_no_arg_replacement.cc.expected
+++ b/test/single_file/binary_no_arg_replacement.cc.expected
@@ -18,7 +18,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
         if (!token.empty()) {
           int value = std::stoi(token);
           int local_value = value - 0;
-          if (local_value >= 0 && local_value < 59) {
+          if (local_value >= 0 && local_value < 55) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
             some_mutation_enabled = true;
           }
@@ -42,12 +42,28 @@ static int __dredd_replace_unary_operator_Minus_int_one(std::function<int()> arg
   return -arg();
 }
 
-static int __dredd_replace_expr_int_uoi_optimised(std::function<int()> arg, int local_mutation_id) {
+static int __dredd_replace_expr_int_uoi_optimised_zero(std::function<int()> arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg();
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg());
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
+  return arg();
+}
+
+static int __dredd_replace_expr_int_uoi_optimised_one(std::function<int()> arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg());
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return 0;
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 1;
-  if (__dredd_enabled_mutation(local_mutation_id + 3)) return -1;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
+  return arg();
+}
+
+static int __dredd_replace_expr_int_minus_one(std::function<int()> arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg();
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg());
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~(arg());
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 0;
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 1;
   return arg();
 }
 
@@ -87,7 +103,7 @@ static int __dredd_replace_binary_operator_Div_int_int_rhs_one(std::function<int
 }
 
 int main() {
-  int x = __dredd_replace_expr_int([&]() -> int { return __dredd_replace_binary_operator_Sub_int_int_lhs_zero([&]() -> int { return static_cast<int>(__dredd_replace_expr_int_uoi_optimised([&]() -> int { return 0; }, 0)); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return 7; }, 4)); }, 9); }, 10);
-  int y = __dredd_replace_expr_int([&]() -> int { return __dredd_replace_binary_operator_Div_int_int_rhs_one([&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return 5; }, 15)); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int_uoi_optimised([&]() -> int { return 1; }, 20)); }, 24); }, 28);
-  int z = __dredd_replace_expr_int([&]() -> int { return __dredd_replace_binary_operator_Mul_int_int_lhs_minus_one([&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return __dredd_replace_unary_operator_Minus_int_one([&]() -> int { return __dredd_replace_expr_int_uoi_optimised([&]() -> int { return 1; }, 33); }, 37); }, 39)); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return 3; }, 44)); }, 49); }, 54);
+  int x = __dredd_replace_expr_int([&]() -> int { return __dredd_replace_binary_operator_Sub_int_int_lhs_zero([&]() -> int { return static_cast<int>(__dredd_replace_expr_int_uoi_optimised_zero([&]() -> int { return 0; }, 0)); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return 7; }, 3)); }, 8); }, 9);
+  int y = __dredd_replace_expr_int([&]() -> int { return __dredd_replace_binary_operator_Div_int_int_rhs_one([&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return 5; }, 14)); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int_uoi_optimised_one([&]() -> int { return 1; }, 19)); }, 22); }, 26);
+  int z = __dredd_replace_expr_int([&]() -> int { return __dredd_replace_binary_operator_Mul_int_int_lhs_minus_one([&]() -> int { return static_cast<int>(__dredd_replace_expr_int_minus_one([&]() -> int { return __dredd_replace_unary_operator_Minus_int_one([&]() -> int { return __dredd_replace_expr_int_uoi_optimised_one([&]() -> int { return 1; }, 31); }, 34); }, 36)); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return 3; }, 40)); }, 45); }, 50);
 }

--- a/test/single_file/binary_operands_both_zero.c.expected
+++ b/test/single_file/binary_operands_both_zero.c.expected
@@ -16,7 +16,7 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
       while(token) {
         int value = atoi(token);
         int local_value = value - 0;
-        if (local_value >= 0 && local_value < 189) {
+        if (local_value >= 0 && local_value < 164) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
           some_mutation_enabled = 1;
         }
@@ -37,22 +37,28 @@ static int __dredd_replace_unary_operator_Minus_int_one(int arg, int local_mutat
   return -arg;
 }
 
-static int __dredd_replace_expr_int_uoi_optimised(int arg, int local_mutation_id) {
+static int __dredd_replace_expr_int_uoi_optimised_zero(int arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg);
-  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 0;
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 1;
-  if (__dredd_enabled_mutation(local_mutation_id + 3)) return -1;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
   return arg;
 }
 
-static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
+static int __dredd_replace_expr_int_uoi_optimised_one(int arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 0;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
+  return arg;
+}
+
+static int __dredd_replace_expr_int_minus_one(int arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg);
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~(arg);
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return 0;
   if (__dredd_enabled_mutation(local_mutation_id + 3)) return 1;
-  if (__dredd_enabled_mutation(local_mutation_id + 4)) return -1;
   return arg;
 }
 
@@ -111,11 +117,11 @@ static int __dredd_replace_binary_operator_Add_int_int_rhs_minus_one_lhs_one(int
 }
 
 int main() {
-  int x = __dredd_replace_expr_int_uoi_optimised(__dredd_replace_binary_operator_Add_int_int_rhs_zero_lhs_zero(__dredd_replace_expr_int_uoi_optimised(0, 0) , __dredd_replace_expr_int_uoi_optimised(0, 4), 8), 9);
-  if (!__dredd_enabled_mutation(35)) { __dredd_replace_binary_operator_Assign_int_int(&(x) , __dredd_replace_expr_int_uoi_optimised(__dredd_replace_expr_int_uoi_optimised(0, 13) + __dredd_replace_expr_int_uoi_optimised(1, 17), 21), 25); }
-  if (!__dredd_enabled_mutation(59)) { __dredd_replace_binary_operator_Assign_int_int(&(x) , __dredd_replace_expr_int_uoi_optimised(__dredd_replace_binary_operator_Add_int_int_rhs_zero_lhs_one(__dredd_replace_expr_int_uoi_optimised(1, 36) , __dredd_replace_expr_int_uoi_optimised(0, 40), 44), 45), 49); }
-  if (!__dredd_enabled_mutation(91)) { __dredd_replace_binary_operator_Assign_int_int(&(x) , __dredd_replace_expr_int(__dredd_replace_binary_operator_Add_int_int_rhs_minus_one_lhs_zero(__dredd_replace_expr_int_uoi_optimised(0, 60) , __dredd_replace_expr_int(__dredd_replace_unary_operator_Minus_int_one(__dredd_replace_expr_int_uoi_optimised(1, 64), 68), 70), 75), 76), 81); }
-  if (!__dredd_enabled_mutation(123)) { __dredd_replace_binary_operator_Assign_int_int(&(x) , __dredd_replace_expr_int(__dredd_replace_binary_operator_Add_int_int_rhs_zero_lhs_minus_one(__dredd_replace_expr_int(__dredd_replace_unary_operator_Minus_int_one(__dredd_replace_expr_int_uoi_optimised(1, 92), 96), 98) , __dredd_replace_expr_int_uoi_optimised(0, 103), 107), 108), 113); }
-  if (!__dredd_enabled_mutation(156)) { __dredd_replace_binary_operator_Assign_int_int(&(x) , __dredd_replace_expr_int_uoi_optimised(__dredd_replace_binary_operator_Add_int_int_rhs_minus_one_lhs_one(__dredd_replace_expr_int_uoi_optimised(1, 124) , __dredd_replace_expr_int(__dredd_replace_unary_operator_Minus_int_one(__dredd_replace_expr_int_uoi_optimised(1, 128), 132), 134), 139), 142), 146); }
-  if (!__dredd_enabled_mutation(188)) { __dredd_replace_binary_operator_Assign_int_int(&(x) , __dredd_replace_expr_int_uoi_optimised(__dredd_replace_binary_operator_Add_int_int_rhs_one_lhs_minus_one(__dredd_replace_expr_int(__dredd_replace_unary_operator_Minus_int_one(__dredd_replace_expr_int_uoi_optimised(1, 157), 161), 163) , __dredd_replace_expr_int_uoi_optimised(1, 168), 172), 174), 178); }
+  int x = __dredd_replace_expr_int_uoi_optimised_zero(__dredd_replace_binary_operator_Add_int_int_rhs_zero_lhs_zero(__dredd_replace_expr_int_uoi_optimised_zero(0, 0) , __dredd_replace_expr_int_uoi_optimised_zero(0, 3), 6), 7);
+  if (!__dredd_enabled_mutation(29)) { __dredd_replace_binary_operator_Assign_int_int(&(x) , __dredd_replace_expr_int_uoi_optimised_one(__dredd_replace_expr_int_uoi_optimised_zero(0, 10) + __dredd_replace_expr_int_uoi_optimised_one(1, 13), 16), 19); }
+  if (!__dredd_enabled_mutation(50)) { __dredd_replace_binary_operator_Assign_int_int(&(x) , __dredd_replace_expr_int_uoi_optimised_one(__dredd_replace_binary_operator_Add_int_int_rhs_zero_lhs_one(__dredd_replace_expr_int_uoi_optimised_one(1, 30) , __dredd_replace_expr_int_uoi_optimised_zero(0, 33), 36), 37), 40); }
+  if (!__dredd_enabled_mutation(78)) { __dredd_replace_binary_operator_Assign_int_int(&(x) , __dredd_replace_expr_int_minus_one(__dredd_replace_binary_operator_Add_int_int_rhs_minus_one_lhs_zero(__dredd_replace_expr_int_uoi_optimised_zero(0, 51) , __dredd_replace_expr_int_minus_one(__dredd_replace_unary_operator_Minus_int_one(__dredd_replace_expr_int_uoi_optimised_one(1, 54), 57), 59), 63), 64), 68); }
+  if (!__dredd_enabled_mutation(106)) { __dredd_replace_binary_operator_Assign_int_int(&(x) , __dredd_replace_expr_int_minus_one(__dredd_replace_binary_operator_Add_int_int_rhs_zero_lhs_minus_one(__dredd_replace_expr_int_minus_one(__dredd_replace_unary_operator_Minus_int_one(__dredd_replace_expr_int_uoi_optimised_one(1, 79), 82), 84) , __dredd_replace_expr_int_uoi_optimised_zero(0, 88), 91), 92), 96); }
+  if (!__dredd_enabled_mutation(135)) { __dredd_replace_binary_operator_Assign_int_int(&(x) , __dredd_replace_expr_int_uoi_optimised_zero(__dredd_replace_binary_operator_Add_int_int_rhs_minus_one_lhs_one(__dredd_replace_expr_int_uoi_optimised_one(1, 107) , __dredd_replace_expr_int_minus_one(__dredd_replace_unary_operator_Minus_int_one(__dredd_replace_expr_int_uoi_optimised_one(1, 110), 113), 115), 119), 122), 125); }
+  if (!__dredd_enabled_mutation(163)) { __dredd_replace_binary_operator_Assign_int_int(&(x) , __dredd_replace_expr_int_uoi_optimised_zero(__dredd_replace_binary_operator_Add_int_int_rhs_one_lhs_minus_one(__dredd_replace_expr_int_minus_one(__dredd_replace_unary_operator_Minus_int_one(__dredd_replace_expr_int_uoi_optimised_one(1, 136), 139), 141) , __dredd_replace_expr_int_uoi_optimised_one(1, 145), 148), 150), 153); }
 }

--- a/test/single_file/binary_operands_both_zero.cc.expected
+++ b/test/single_file/binary_operands_both_zero.cc.expected
@@ -18,7 +18,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
         if (!token.empty()) {
           int value = std::stoi(token);
           int local_value = value - 0;
-          if (local_value >= 0 && local_value < 189) {
+          if (local_value >= 0 && local_value < 164) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
             some_mutation_enabled = true;
           }
@@ -57,22 +57,28 @@ static int __dredd_replace_unary_operator_Minus_int_one(std::function<int()> arg
   return -arg();
 }
 
-static int __dredd_replace_expr_int_uoi_optimised(std::function<int()> arg, int local_mutation_id) {
+static int __dredd_replace_expr_int_uoi_optimised_zero(std::function<int()> arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg());
-  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 0;
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 1;
-  if (__dredd_enabled_mutation(local_mutation_id + 3)) return -1;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
   return arg();
 }
 
-static int __dredd_replace_expr_int(std::function<int()> arg, int local_mutation_id) {
+static int __dredd_replace_expr_int_uoi_optimised_one(std::function<int()> arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg();
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg());
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 0;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
+  return arg();
+}
+
+static int __dredd_replace_expr_int_minus_one(std::function<int()> arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg());
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~(arg());
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return 0;
   if (__dredd_enabled_mutation(local_mutation_id + 3)) return 1;
-  if (__dredd_enabled_mutation(local_mutation_id + 4)) return -1;
   return arg();
 }
 
@@ -116,11 +122,11 @@ static int __dredd_replace_binary_operator_Add_int_int_rhs_minus_one_lhs_one(std
 }
 
 int main() {
-  int x = __dredd_replace_expr_int_uoi_optimised([&]() -> int { return __dredd_replace_binary_operator_Add_int_int_rhs_zero_lhs_zero([&]() -> int { return static_cast<int>(__dredd_replace_expr_int_uoi_optimised([&]() -> int { return 0; }, 0)); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int_uoi_optimised([&]() -> int { return 0; }, 4)); }, 8); }, 9);
-  if (!__dredd_enabled_mutation(35)) { __dredd_replace_binary_operator_Assign_int_int([&]() -> int& { return static_cast<int&>(x); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int_uoi_optimised([&]() -> int { return __dredd_replace_expr_int_uoi_optimised([&]() -> int { return 0; }, 13) + __dredd_replace_expr_int_uoi_optimised([&]() -> int { return 1; }, 17); }, 21)); }, 25); }
-  if (!__dredd_enabled_mutation(59)) { __dredd_replace_binary_operator_Assign_int_int([&]() -> int& { return static_cast<int&>(x); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int_uoi_optimised([&]() -> int { return __dredd_replace_binary_operator_Add_int_int_rhs_zero_lhs_one([&]() -> int { return static_cast<int>(__dredd_replace_expr_int_uoi_optimised([&]() -> int { return 1; }, 36)); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int_uoi_optimised([&]() -> int { return 0; }, 40)); }, 44); }, 45)); }, 49); }
-  if (!__dredd_enabled_mutation(91)) { __dredd_replace_binary_operator_Assign_int_int([&]() -> int& { return static_cast<int&>(x); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return __dredd_replace_binary_operator_Add_int_int_rhs_minus_one_lhs_zero([&]() -> int { return static_cast<int>(__dredd_replace_expr_int_uoi_optimised([&]() -> int { return 0; }, 60)); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return __dredd_replace_unary_operator_Minus_int_one([&]() -> int { return __dredd_replace_expr_int_uoi_optimised([&]() -> int { return 1; }, 64); }, 68); }, 70)); }, 75); }, 76)); }, 81); }
-  if (!__dredd_enabled_mutation(123)) { __dredd_replace_binary_operator_Assign_int_int([&]() -> int& { return static_cast<int&>(x); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return __dredd_replace_binary_operator_Add_int_int_rhs_zero_lhs_minus_one([&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return __dredd_replace_unary_operator_Minus_int_one([&]() -> int { return __dredd_replace_expr_int_uoi_optimised([&]() -> int { return 1; }, 92); }, 96); }, 98)); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int_uoi_optimised([&]() -> int { return 0; }, 103)); }, 107); }, 108)); }, 113); }
-  if (!__dredd_enabled_mutation(156)) { __dredd_replace_binary_operator_Assign_int_int([&]() -> int& { return static_cast<int&>(x); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int_uoi_optimised([&]() -> int { return __dredd_replace_binary_operator_Add_int_int_rhs_minus_one_lhs_one([&]() -> int { return static_cast<int>(__dredd_replace_expr_int_uoi_optimised([&]() -> int { return 1; }, 124)); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return __dredd_replace_unary_operator_Minus_int_one([&]() -> int { return __dredd_replace_expr_int_uoi_optimised([&]() -> int { return 1; }, 128); }, 132); }, 134)); }, 139); }, 142)); }, 146); }
-  if (!__dredd_enabled_mutation(188)) { __dredd_replace_binary_operator_Assign_int_int([&]() -> int& { return static_cast<int&>(x); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int_uoi_optimised([&]() -> int { return __dredd_replace_binary_operator_Add_int_int_rhs_one_lhs_minus_one([&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return __dredd_replace_unary_operator_Minus_int_one([&]() -> int { return __dredd_replace_expr_int_uoi_optimised([&]() -> int { return 1; }, 157); }, 161); }, 163)); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int_uoi_optimised([&]() -> int { return 1; }, 168)); }, 172); }, 174)); }, 178); }
+  int x = __dredd_replace_expr_int_uoi_optimised_zero([&]() -> int { return __dredd_replace_binary_operator_Add_int_int_rhs_zero_lhs_zero([&]() -> int { return static_cast<int>(__dredd_replace_expr_int_uoi_optimised_zero([&]() -> int { return 0; }, 0)); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int_uoi_optimised_zero([&]() -> int { return 0; }, 3)); }, 6); }, 7);
+  if (!__dredd_enabled_mutation(29)) { __dredd_replace_binary_operator_Assign_int_int([&]() -> int& { return static_cast<int&>(x); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int_uoi_optimised_one([&]() -> int { return __dredd_replace_expr_int_uoi_optimised_zero([&]() -> int { return 0; }, 10) + __dredd_replace_expr_int_uoi_optimised_one([&]() -> int { return 1; }, 13); }, 16)); }, 19); }
+  if (!__dredd_enabled_mutation(50)) { __dredd_replace_binary_operator_Assign_int_int([&]() -> int& { return static_cast<int&>(x); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int_uoi_optimised_one([&]() -> int { return __dredd_replace_binary_operator_Add_int_int_rhs_zero_lhs_one([&]() -> int { return static_cast<int>(__dredd_replace_expr_int_uoi_optimised_one([&]() -> int { return 1; }, 30)); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int_uoi_optimised_zero([&]() -> int { return 0; }, 33)); }, 36); }, 37)); }, 40); }
+  if (!__dredd_enabled_mutation(78)) { __dredd_replace_binary_operator_Assign_int_int([&]() -> int& { return static_cast<int&>(x); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int_minus_one([&]() -> int { return __dredd_replace_binary_operator_Add_int_int_rhs_minus_one_lhs_zero([&]() -> int { return static_cast<int>(__dredd_replace_expr_int_uoi_optimised_zero([&]() -> int { return 0; }, 51)); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int_minus_one([&]() -> int { return __dredd_replace_unary_operator_Minus_int_one([&]() -> int { return __dredd_replace_expr_int_uoi_optimised_one([&]() -> int { return 1; }, 54); }, 57); }, 59)); }, 63); }, 64)); }, 68); }
+  if (!__dredd_enabled_mutation(106)) { __dredd_replace_binary_operator_Assign_int_int([&]() -> int& { return static_cast<int&>(x); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int_minus_one([&]() -> int { return __dredd_replace_binary_operator_Add_int_int_rhs_zero_lhs_minus_one([&]() -> int { return static_cast<int>(__dredd_replace_expr_int_minus_one([&]() -> int { return __dredd_replace_unary_operator_Minus_int_one([&]() -> int { return __dredd_replace_expr_int_uoi_optimised_one([&]() -> int { return 1; }, 79); }, 82); }, 84)); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int_uoi_optimised_zero([&]() -> int { return 0; }, 88)); }, 91); }, 92)); }, 96); }
+  if (!__dredd_enabled_mutation(135)) { __dredd_replace_binary_operator_Assign_int_int([&]() -> int& { return static_cast<int&>(x); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int_uoi_optimised_zero([&]() -> int { return __dredd_replace_binary_operator_Add_int_int_rhs_minus_one_lhs_one([&]() -> int { return static_cast<int>(__dredd_replace_expr_int_uoi_optimised_one([&]() -> int { return 1; }, 107)); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int_minus_one([&]() -> int { return __dredd_replace_unary_operator_Minus_int_one([&]() -> int { return __dredd_replace_expr_int_uoi_optimised_one([&]() -> int { return 1; }, 110); }, 113); }, 115)); }, 119); }, 122)); }, 125); }
+  if (!__dredd_enabled_mutation(163)) { __dredd_replace_binary_operator_Assign_int_int([&]() -> int& { return static_cast<int&>(x); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int_uoi_optimised_zero([&]() -> int { return __dredd_replace_binary_operator_Add_int_int_rhs_one_lhs_minus_one([&]() -> int { return static_cast<int>(__dredd_replace_expr_int_minus_one([&]() -> int { return __dredd_replace_unary_operator_Minus_int_one([&]() -> int { return __dredd_replace_expr_int_uoi_optimised_one([&]() -> int { return 1; }, 136); }, 139); }, 141)); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int_uoi_optimised_one([&]() -> int { return 1; }, 145)); }, 148); }, 150)); }, 153); }
 }

--- a/test/single_file/binary_redundant_name_clash.cc.expected
+++ b/test/single_file/binary_redundant_name_clash.cc.expected
@@ -18,7 +18,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
         if (!token.empty()) {
           int value = std::stoi(token);
           int local_value = value - 0;
-          if (local_value >= 0 && local_value < 32) {
+          if (local_value >= 0 && local_value < 30) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
             some_mutation_enabled = true;
           }
@@ -35,12 +35,11 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }
 
-static int __dredd_replace_expr_int_uoi_optimised(std::function<int()> arg, int local_mutation_id) {
+static int __dredd_replace_expr_int_uoi_optimised_zero(std::function<int()> arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg());
-  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 0;
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 1;
-  if (__dredd_enabled_mutation(local_mutation_id + 3)) return -1;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
   return arg();
 }
 
@@ -69,6 +68,6 @@ static int __dredd_replace_binary_operator_Add_int_int_lhs_zero(std::function<in
 }
 
 int main() {
-  int x = __dredd_replace_expr_int([&]() -> int { return __dredd_replace_binary_operator_Add_int_int_lhs_zero([&]() -> int { return static_cast<int>(__dredd_replace_expr_int_uoi_optimised([&]() -> int { return 0; }, 0)); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return 5; }, 4)); }, 9); }, 11);
-  int y = __dredd_replace_expr_int([&]() -> int { return __dredd_replace_binary_operator_Add_int_int_rhs_zero([&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return 5; }, 16)); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int_uoi_optimised([&]() -> int { return 0; }, 21)); }, 25); }, 27);
+  int x = __dredd_replace_expr_int([&]() -> int { return __dredd_replace_binary_operator_Add_int_int_lhs_zero([&]() -> int { return static_cast<int>(__dredd_replace_expr_int_uoi_optimised_zero([&]() -> int { return 0; }, 0)); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return 5; }, 3)); }, 8); }, 10);
+  int y = __dredd_replace_expr_int([&]() -> int { return __dredd_replace_binary_operator_Add_int_int_rhs_zero([&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return 5; }, 15)); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int_uoi_optimised_zero([&]() -> int { return 0; }, 20)); }, 23); }, 25);
 }

--- a/test/single_file/binary_rhs_zero.cc.expected
+++ b/test/single_file/binary_rhs_zero.cc.expected
@@ -18,7 +18,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
         if (!token.empty()) {
           int value = std::stoi(token);
           int local_value = value - 0;
-          if (local_value >= 0 && local_value < 24) {
+          if (local_value >= 0 && local_value < 23) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
             some_mutation_enabled = true;
           }
@@ -35,12 +35,11 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }
 
-static int __dredd_replace_expr_int_uoi_optimised(std::function<int()> arg, int local_mutation_id) {
+static int __dredd_replace_expr_int_uoi_optimised_zero(std::function<int()> arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg());
-  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 0;
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 1;
-  if (__dredd_enabled_mutation(local_mutation_id + 3)) return -1;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
   return arg();
 }
 
@@ -69,6 +68,6 @@ static int __dredd_replace_binary_operator_Add_int_int_rhs_zero(std::function<in
 }
 
 int main() {
-  int x = __dredd_replace_expr_int([&]() -> int { return __dredd_replace_binary_operator_Add_int_int_rhs_zero([&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return 5; }, 0)); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int_uoi_optimised([&]() -> int { return 0; }, 5)); }, 9); }, 11);
-  if (!__dredd_enabled_mutation(23)) { return __dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int_lvalue([&]() -> int& { return static_cast<int&>(x); }, 16)); }, 18); }
+  int x = __dredd_replace_expr_int([&]() -> int { return __dredd_replace_binary_operator_Add_int_int_rhs_zero([&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return 5; }, 0)); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int_uoi_optimised_zero([&]() -> int { return 0; }, 5)); }, 8); }, 10);
+  if (!__dredd_enabled_mutation(22)) { return __dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int_lvalue([&]() -> int& { return static_cast<int&>(x); }, 15)); }, 17); }
 }

--- a/test/single_file/bool_assignment.cc
+++ b/test/single_file/bool_assignment.cc
@@ -1,0 +1,4 @@
+int main() {
+  bool x = true;
+  bool y = false;
+}

--- a/test/single_file/bool_assignment.cc.expected
+++ b/test/single_file/bool_assignment.cc.expected
@@ -18,7 +18,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
         if (!token.empty()) {
           int value = std::stoi(token);
           int local_value = value - 0;
-          if (local_value >= 0 && local_value < 4) {
+          if (local_value >= 0 && local_value < 2) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
             some_mutation_enabled = true;
           }
@@ -35,19 +35,19 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }
 
-static int __dredd_replace_expr_int_uoi_optimised_zero(std::function<int()> arg, int local_mutation_id) {
+static bool __dredd_replace_expr_bool_uoi_optimised_zero(std::function<bool()> arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg();
-  if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg());
-  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 1;
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return true;
+  return arg();
+}
+
+static bool __dredd_replace_expr_bool_uoi_optimised_one(std::function<bool()> arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg();
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return false;
   return arg();
 }
 
 int main() {
-  if (!__dredd_enabled_mutation(3)) { switch(__dredd_replace_expr_int_uoi_optimised_zero([&]() -> int { return 0; }, 0)) {
-  case -1:
-    break;
-  default:
-    break;
-  } }
+  bool x = __dredd_replace_expr_bool_uoi_optimised_one([&]() -> bool { return true; }, 0);
+  bool y = __dredd_replace_expr_bool_uoi_optimised_zero([&]() -> bool { return false; }, 1);
 }

--- a/test/single_file/bool_assignment.cc.expected
+++ b/test/single_file/bool_assignment.cc.expected
@@ -35,19 +35,19 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }
 
-static bool __dredd_replace_expr_bool_uoi_optimised_zero(std::function<bool()> arg, int local_mutation_id) {
-  if (!__dredd_some_mutation_enabled) return arg();
-  if (__dredd_enabled_mutation(local_mutation_id + 0)) return true;
-  return arg();
-}
-
-static bool __dredd_replace_expr_bool_uoi_optimised_one(std::function<bool()> arg, int local_mutation_id) {
+static bool __dredd_replace_expr_bool_uoi_optimised_true(std::function<bool()> arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return false;
   return arg();
 }
 
+static bool __dredd_replace_expr_bool_uoi_optimised_false(std::function<bool()> arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg();
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return true;
+  return arg();
+}
+
 int main() {
-  bool x = __dredd_replace_expr_bool_uoi_optimised_one([&]() -> bool { return true; }, 0);
-  bool y = __dredd_replace_expr_bool_uoi_optimised_zero([&]() -> bool { return false; }, 1);
+  bool x = __dredd_replace_expr_bool_uoi_optimised_true([&]() -> bool { return true; }, 0);
+  bool y = __dredd_replace_expr_bool_uoi_optimised_false([&]() -> bool { return false; }, 1);
 }

--- a/test/single_file/bool_assignment.cc.noopt.expected
+++ b/test/single_file/bool_assignment.cc.noopt.expected
@@ -18,7 +18,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
         if (!token.empty()) {
           int value = std::stoi(token);
           int local_value = value - 0;
-          if (local_value >= 0 && local_value < 4) {
+          if (local_value >= 0 && local_value < 6) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
             some_mutation_enabled = true;
           }
@@ -35,19 +35,15 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }
 
-static int __dredd_replace_expr_int_uoi_optimised_zero(std::function<int()> arg, int local_mutation_id) {
+static bool __dredd_replace_expr_bool(std::function<bool()> arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg();
-  if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg());
-  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 1;
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg());
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return true;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return false;
   return arg();
 }
 
 int main() {
-  if (!__dredd_enabled_mutation(3)) { switch(__dredd_replace_expr_int_uoi_optimised_zero([&]() -> int { return 0; }, 0)) {
-  case -1:
-    break;
-  default:
-    break;
-  } }
+  bool x = __dredd_replace_expr_bool([&]() -> bool { return true; }, 0);
+  bool y = __dredd_replace_expr_bool([&]() -> bool { return false; }, 3);
 }

--- a/test/single_file/boolean_not_insertion_optimisation.c.expected
+++ b/test/single_file/boolean_not_insertion_optimisation.c.expected
@@ -18,7 +18,7 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
       while(token) {
         int value = atoi(token);
         int local_value = value - 0;
-        if (local_value >= 0 && local_value < 15) {
+        if (local_value >= 0 && local_value < 12) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
           some_mutation_enabled = 1;
         }
@@ -32,12 +32,19 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
   return enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64));
 }
 
-static int __dredd_replace_expr_int_uoi_optimised(int arg, int local_mutation_id) {
+static int __dredd_replace_expr_int_uoi_optimised_zero(int arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
+  return arg;
+}
+
+static int __dredd_replace_expr_int_uoi_optimised_one(int arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg);
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return 0;
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 1;
-  if (__dredd_enabled_mutation(local_mutation_id + 3)) return -1;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
   return arg;
 }
 
@@ -58,5 +65,5 @@ static int __dredd_replace_binary_operator_LAnd_int_int_rhs_zero_lhs_one_lhs(int
   return arg;
 }
 int main() {
-  int x = __dredd_replace_expr_int_uoi_optimised(__dredd_replace_binary_operator_LAnd_int_int_rhs_zero_lhs_one_outer(__dredd_replace_binary_operator_LAnd_int_int_rhs_zero_lhs_one_lhs(__dredd_replace_expr_int_uoi_optimised(1, 0), 8) && __dredd_replace_binary_operator_LAnd_int_int_rhs_zero_lhs_one_rhs(__dredd_replace_expr_int_uoi_optimised(0, 4), 8), 8), 11);
+  int x = __dredd_replace_expr_int_uoi_optimised_zero(__dredd_replace_binary_operator_LAnd_int_int_rhs_zero_lhs_one_outer(__dredd_replace_binary_operator_LAnd_int_int_rhs_zero_lhs_one_lhs(__dredd_replace_expr_int_uoi_optimised_one(1, 0), 6) && __dredd_replace_binary_operator_LAnd_int_int_rhs_zero_lhs_one_rhs(__dredd_replace_expr_int_uoi_optimised_zero(0, 3), 6), 6), 9);
 }

--- a/test/single_file/boolean_not_insertion_optimisation.cc.expected
+++ b/test/single_file/boolean_not_insertion_optimisation.cc.expected
@@ -18,7 +18,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
         if (!token.empty()) {
           int value = std::stoi(token);
           int local_value = value - 0;
-          if (local_value >= 0 && local_value < 15) {
+          if (local_value >= 0 && local_value < 13) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
             some_mutation_enabled = true;
           }
@@ -50,14 +50,19 @@ static bool& __dredd_replace_binary_operator_Assign_bool_bool(std::function<bool
   return arg1() = arg2();
 }
 
-static bool __dredd_replace_expr_bool_uoi_optimised(std::function<bool()> arg, int local_mutation_id) {
+static bool __dredd_replace_expr_bool_uoi_optimised_zero(std::function<bool()> arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return true;
-  if (__dredd_enabled_mutation(local_mutation_id + 1)) return false;
+  return arg();
+}
+
+static bool __dredd_replace_expr_bool_uoi_optimised_one(std::function<bool()> arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg();
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return false;
   return arg();
 }
 
 int main() {
-  bool x = __dredd_replace_expr_bool_uoi_optimised([&]() -> bool { return true; }, 0);
-  if (!__dredd_enabled_mutation(14)) { __dredd_replace_binary_operator_Assign_bool_bool([&]() -> bool& { return static_cast<bool&>(x); } , [&]() -> bool { return static_cast<bool>(__dredd_replace_expr_bool_uoi_optimised([&]() -> bool { return false; }, 2)); }, 4); }
+  bool x = __dredd_replace_expr_bool_uoi_optimised_one([&]() -> bool { return true; }, 0);
+  if (!__dredd_enabled_mutation(12)) { __dredd_replace_binary_operator_Assign_bool_bool([&]() -> bool& { return static_cast<bool&>(x); } , [&]() -> bool { return static_cast<bool>(__dredd_replace_expr_bool_uoi_optimised_zero([&]() -> bool { return false; }, 1)); }, 2); }
 }

--- a/test/single_file/boolean_not_insertion_optimisation.cc.expected
+++ b/test/single_file/boolean_not_insertion_optimisation.cc.expected
@@ -50,19 +50,19 @@ static bool& __dredd_replace_binary_operator_Assign_bool_bool(std::function<bool
   return arg1() = arg2();
 }
 
-static bool __dredd_replace_expr_bool_uoi_optimised_zero(std::function<bool()> arg, int local_mutation_id) {
-  if (!__dredd_some_mutation_enabled) return arg();
-  if (__dredd_enabled_mutation(local_mutation_id + 0)) return true;
-  return arg();
-}
-
-static bool __dredd_replace_expr_bool_uoi_optimised_one(std::function<bool()> arg, int local_mutation_id) {
+static bool __dredd_replace_expr_bool_uoi_optimised_true(std::function<bool()> arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return false;
   return arg();
 }
 
+static bool __dredd_replace_expr_bool_uoi_optimised_false(std::function<bool()> arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg();
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return true;
+  return arg();
+}
+
 int main() {
-  bool x = __dredd_replace_expr_bool_uoi_optimised_one([&]() -> bool { return true; }, 0);
-  if (!__dredd_enabled_mutation(12)) { __dredd_replace_binary_operator_Assign_bool_bool([&]() -> bool& { return static_cast<bool&>(x); } , [&]() -> bool { return static_cast<bool>(__dredd_replace_expr_bool_uoi_optimised_zero([&]() -> bool { return false; }, 1)); }, 2); }
+  bool x = __dredd_replace_expr_bool_uoi_optimised_true([&]() -> bool { return true; }, 0);
+  if (!__dredd_enabled_mutation(12)) { __dredd_replace_binary_operator_Assign_bool_bool([&]() -> bool& { return static_cast<bool&>(x); } , [&]() -> bool { return static_cast<bool>(__dredd_replace_expr_bool_uoi_optimised_false([&]() -> bool { return false; }, 1)); }, 2); }
 }

--- a/test/single_file/comma.c.expected
+++ b/test/single_file/comma.c.expected
@@ -16,7 +16,7 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
       while(token) {
         int value = atoi(token);
         int local_value = value - 0;
-        if (local_value >= 0 && local_value < 29) {
+        if (local_value >= 0 && local_value < 28) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
           some_mutation_enabled = 1;
         }
@@ -30,12 +30,11 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
   return enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64));
 }
 
-static int __dredd_replace_expr_int_uoi_optimised(int arg, int local_mutation_id) {
+static int __dredd_replace_expr_int_uoi_optimised_one(int arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg);
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return 0;
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 1;
-  if (__dredd_enabled_mutation(local_mutation_id + 3)) return -1;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
   return arg;
 }
 
@@ -57,7 +56,7 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
 }
 
 int main() {
-  int x = __dredd_replace_expr_int_uoi_optimised(1, 0);
-  int y = __dredd_replace_expr_int(2, 4);
-  if (!__dredd_enabled_mutation(28)) { return __dredd_replace_expr_int((__dredd_replace_expr_int(__dredd_replace_expr_int_lvalue(&(x), 9), 11), __dredd_replace_expr_int(__dredd_replace_expr_int_lvalue(&(y), 16), 18)), 23); }
+  int x = __dredd_replace_expr_int_uoi_optimised_one(1, 0);
+  int y = __dredd_replace_expr_int(2, 3);
+  if (!__dredd_enabled_mutation(27)) { return __dredd_replace_expr_int((__dredd_replace_expr_int(__dredd_replace_expr_int_lvalue(&(x), 8), 10), __dredd_replace_expr_int(__dredd_replace_expr_int_lvalue(&(y), 15), 17)), 22); }
 }

--- a/test/single_file/comment.cc.expected
+++ b/test/single_file/comment.cc.expected
@@ -18,7 +18,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
         if (!token.empty()) {
           int value = std::stoi(token);
           int local_value = value - 0;
-          if (local_value >= 0 && local_value < 8) {
+          if (local_value >= 0 && local_value < 6) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
             some_mutation_enabled = true;
           }
@@ -35,10 +35,9 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }
 
-static bool __dredd_replace_expr_bool_uoi_optimised(std::function<bool()> arg, int local_mutation_id) {
+static bool __dredd_replace_expr_bool_uoi_optimised_one(std::function<bool()> arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg();
-  if (__dredd_enabled_mutation(local_mutation_id + 0)) return true;
-  if (__dredd_enabled_mutation(local_mutation_id + 1)) return false;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return false;
   return arg();
 }
 
@@ -50,12 +49,12 @@ int f()
   if (!__dredd_enabled_mutation(1)) { g() // something
 ; }
 
-  if (!__dredd_enabled_mutation(4)) { if(__dredd_replace_expr_bool_uoi_optimised([&]() -> bool { return true; }, 2)) {
+  if (!__dredd_enabled_mutation(3)) { if(__dredd_replace_expr_bool_uoi_optimised_one([&]() -> bool { return true; }, 2)) {
 
   }
   // something
 }
-  if (!__dredd_enabled_mutation(7)) { if(__dredd_replace_expr_bool_uoi_optimised([&]() -> bool { return true; }, 5)) {
+  if (!__dredd_enabled_mutation(5)) { if(__dredd_replace_expr_bool_uoi_optimised_one([&]() -> bool { return true; }, 4)) {
 
   } /* something */
 }

--- a/test/single_file/comment.cc.expected
+++ b/test/single_file/comment.cc.expected
@@ -35,7 +35,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }
 
-static bool __dredd_replace_expr_bool_uoi_optimised_one(std::function<bool()> arg, int local_mutation_id) {
+static bool __dredd_replace_expr_bool_uoi_optimised_true(std::function<bool()> arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return false;
   return arg();
@@ -49,12 +49,12 @@ int f()
   if (!__dredd_enabled_mutation(1)) { g() // something
 ; }
 
-  if (!__dredd_enabled_mutation(3)) { if(__dredd_replace_expr_bool_uoi_optimised_one([&]() -> bool { return true; }, 2)) {
+  if (!__dredd_enabled_mutation(3)) { if(__dredd_replace_expr_bool_uoi_optimised_true([&]() -> bool { return true; }, 2)) {
 
   }
   // something
 }
-  if (!__dredd_enabled_mutation(5)) { if(__dredd_replace_expr_bool_uoi_optimised_one([&]() -> bool { return true; }, 4)) {
+  if (!__dredd_enabled_mutation(5)) { if(__dredd_replace_expr_bool_uoi_optimised_true([&]() -> bool { return true; }, 4)) {
 
   } /* something */
 }

--- a/test/single_file/const_sized_array_int.c.expected
+++ b/test/single_file/const_sized_array_int.c.expected
@@ -16,7 +16,7 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
       while(token) {
         int value = atoi(token);
         int local_value = value - 0;
-        if (local_value >= 0 && local_value < 4) {
+        if (local_value >= 0 && local_value < 3) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
           some_mutation_enabled = 1;
         }
@@ -30,15 +30,14 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
   return enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64));
 }
 
-static int __dredd_replace_expr_int_uoi_optimised(int arg, int local_mutation_id) {
+static int __dredd_replace_expr_int_uoi_optimised_zero(int arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg);
-  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 0;
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 1;
-  if (__dredd_enabled_mutation(local_mutation_id + 3)) return -1;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
   return arg;
 }
 
 void foo() {
-  int A[1 + 3] = {__dredd_replace_expr_int_uoi_optimised(0, 0)};
+  int A[1 + 3] = {__dredd_replace_expr_int_uoi_optimised_zero(0, 0)};
 }

--- a/test/single_file/const_sized_array_int.cc.expected
+++ b/test/single_file/const_sized_array_int.cc.expected
@@ -18,7 +18,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
         if (!token.empty()) {
           int value = std::stoi(token);
           int local_value = value - 0;
-          if (local_value >= 0 && local_value < 4) {
+          if (local_value >= 0 && local_value < 3) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
             some_mutation_enabled = true;
           }
@@ -35,15 +35,14 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }
 
-static int __dredd_replace_expr_int_uoi_optimised(std::function<int()> arg, int local_mutation_id) {
+static int __dredd_replace_expr_int_uoi_optimised_zero(std::function<int()> arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg());
-  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 0;
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 1;
-  if (__dredd_enabled_mutation(local_mutation_id + 3)) return -1;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
   return arg();
 }
 
 void foo() {
-  int A[1 + 3] = {__dredd_replace_expr_int_uoi_optimised([&]() -> int { return 0; }, 0)};
+  int A[1 + 3] = {__dredd_replace_expr_int_uoi_optimised_zero([&]() -> int { return 0; }, 0)};
 }

--- a/test/single_file/define_in_first_decl.c.expected
+++ b/test/single_file/define_in_first_decl.c.expected
@@ -18,7 +18,7 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
       while(token) {
         int value = atoi(token);
         int local_value = value - 0;
-        if (local_value >= 0 && local_value < 19) {
+        if (local_value >= 0 && local_value < 18) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
           some_mutation_enabled = 1;
         }
@@ -32,12 +32,11 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
   return enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64));
 }
 
-static int __dredd_replace_expr_int_uoi_optimised(int arg, int local_mutation_id) {
+static int __dredd_replace_expr_int_uoi_optimised_one(int arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg);
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return 0;
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 1;
-  if (__dredd_enabled_mutation(local_mutation_id + 3)) return -1;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
   return arg;
 }
 
@@ -61,5 +60,5 @@ static int __dredd_replace_binary_operator_Add_int_int_lhs_one(int arg1, int arg
 }
 
 TYPE foo() {
-  if (!__dredd_enabled_mutation(18)) { return __dredd_replace_expr_int(__dredd_replace_binary_operator_Add_int_int_lhs_one(__dredd_replace_expr_int_uoi_optimised(1, 0) , __dredd_replace_expr_int(2, 4), 9), 13); }
+  if (!__dredd_enabled_mutation(17)) { return __dredd_replace_expr_int(__dredd_replace_binary_operator_Add_int_int_lhs_one(__dredd_replace_expr_int_uoi_optimised_one(1, 0) , __dredd_replace_expr_int(2, 3), 8), 12); }
 }

--- a/test/single_file/define_in_first_decl.cc.expected
+++ b/test/single_file/define_in_first_decl.cc.expected
@@ -20,7 +20,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
         if (!token.empty()) {
           int value = std::stoi(token);
           int local_value = value - 0;
-          if (local_value >= 0 && local_value < 19) {
+          if (local_value >= 0 && local_value < 18) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
             some_mutation_enabled = true;
           }
@@ -37,12 +37,11 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }
 
-static int __dredd_replace_expr_int_uoi_optimised(std::function<int()> arg, int local_mutation_id) {
+static int __dredd_replace_expr_int_uoi_optimised_one(std::function<int()> arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg());
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return 0;
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 1;
-  if (__dredd_enabled_mutation(local_mutation_id + 3)) return -1;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
   return arg();
 }
 
@@ -66,5 +65,5 @@ static int __dredd_replace_binary_operator_Add_int_int_lhs_one(std::function<int
 }
 
 TYPE foo() {
-  if (!__dredd_enabled_mutation(18)) { return __dredd_replace_expr_int([&]() -> int { return __dredd_replace_binary_operator_Add_int_int_lhs_one([&]() -> int { return static_cast<int>(__dredd_replace_expr_int_uoi_optimised([&]() -> int { return 1; }, 0)); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return 2; }, 4)); }, 9); }, 13); }
+  if (!__dredd_enabled_mutation(17)) { return __dredd_replace_expr_int([&]() -> int { return __dredd_replace_binary_operator_Add_int_int_lhs_one([&]() -> int { return static_cast<int>(__dredd_replace_expr_int_uoi_optimised_one([&]() -> int { return 1; }, 0)); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return 2; }, 3)); }, 8); }, 12); }
 }

--- a/test/single_file/enum.c.expected
+++ b/test/single_file/enum.c.expected
@@ -16,7 +16,7 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
       while(token) {
         int value = atoi(token);
         int local_value = value - 0;
-        if (local_value >= 0 && local_value < 4) {
+        if (local_value >= 0 && local_value < 3) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
           some_mutation_enabled = 1;
         }
@@ -30,12 +30,11 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
   return enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64));
 }
 
-static int __dredd_replace_expr_int_uoi_optimised(int arg, int local_mutation_id) {
+static int __dredd_replace_expr_int_uoi_optimised_zero(int arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg);
-  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 0;
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 1;
-  if (__dredd_enabled_mutation(local_mutation_id + 3)) return -1;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
   return arg;
 }
 
@@ -45,5 +44,5 @@ enum A {
 };
 
 void foo() {
-  enum A myA = __dredd_replace_expr_int_uoi_optimised(X, 0);
+  enum A myA = __dredd_replace_expr_int_uoi_optimised_zero(X, 0);
 }

--- a/test/single_file/float_binary_opts.c
+++ b/test/single_file/float_binary_opts.c
@@ -1,0 +1,4 @@
+int main() {
+  double x = 0.0 + 5.32;
+  double y = 5.234 + 2.352;
+}

--- a/test/single_file/float_binary_opts.c.expected
+++ b/test/single_file/float_binary_opts.c.expected
@@ -1,0 +1,69 @@
+#include <inttypes.h>
+#include <stdlib.h>
+#include <string.h>
+static int __dredd_some_mutation_enabled = 1;
+static int __dredd_enabled_mutation(int local_mutation_id) {
+  static int initialized = 0;
+  static uint64_t enabled_bitset[1];
+  if (!initialized) {
+    int some_mutation_enabled = 0;
+    const char* dredd_environment_variable = getenv("DREDD_ENABLED_MUTATION");
+    if (dredd_environment_variable) {
+      char* temp = malloc(strlen(dredd_environment_variable) + 1);
+      strcpy(temp, dredd_environment_variable);
+      char* token;
+      token = strtok(temp, ",");
+      while(token) {
+        int value = atoi(token);
+        int local_value = value - 0;
+        if (local_value >= 0 && local_value < 25) {
+          enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+          some_mutation_enabled = 1;
+        }
+        token = strtok(NULL, ",");
+      }
+      free(temp);
+    }
+    initialized = 1;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
+  }
+  return enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64));
+}
+
+static double __dredd_replace_expr_double_zero(double arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return 1.0;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return -1.0;
+  return arg;
+}
+
+static double __dredd_replace_expr_double(double arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return 0.0;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 1.0;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1.0;
+  return arg;
+}
+
+static double __dredd_replace_binary_operator_Add_double_double_lhs_zero(double arg1, double arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1 + arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1 - arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg2;
+  return arg1 + arg2;
+}
+
+static double __dredd_replace_binary_operator_Add_double_double(double arg1, double arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1 + arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1 / arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1 * arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1 - arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return arg1;
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return arg2;
+  return arg1 + arg2;
+}
+
+int main() {
+  double x = __dredd_replace_expr_double(__dredd_replace_binary_operator_Add_double_double_lhs_zero(__dredd_replace_expr_double_zero(0.0, 0) , __dredd_replace_expr_double(5.32, 2), 5), 8);
+  double y = __dredd_replace_expr_double(__dredd_replace_binary_operator_Add_double_double(__dredd_replace_expr_double(5.234, 11) , __dredd_replace_expr_double(2.352, 14), 17), 22);
+}

--- a/test/single_file/float_binary_opts.c.noopt.expected
+++ b/test/single_file/float_binary_opts.c.noopt.expected
@@ -1,0 +1,54 @@
+#include <inttypes.h>
+#include <stdlib.h>
+#include <string.h>
+static int __dredd_some_mutation_enabled = 1;
+static int __dredd_enabled_mutation(int local_mutation_id) {
+  static int initialized = 0;
+  static uint64_t enabled_bitset[1];
+  if (!initialized) {
+    int some_mutation_enabled = 0;
+    const char* dredd_environment_variable = getenv("DREDD_ENABLED_MUTATION");
+    if (dredd_environment_variable) {
+      char* temp = malloc(strlen(dredd_environment_variable) + 1);
+      strcpy(temp, dredd_environment_variable);
+      char* token;
+      token = strtok(temp, ",");
+      while(token) {
+        int value = atoi(token);
+        int local_value = value - 0;
+        if (local_value >= 0 && local_value < 28) {
+          enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+          some_mutation_enabled = 1;
+        }
+        token = strtok(NULL, ",");
+      }
+      free(temp);
+    }
+    initialized = 1;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
+  }
+  return enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64));
+}
+
+static double __dredd_replace_expr_double(double arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return 0.0;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 1.0;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1.0;
+  return arg;
+}
+
+static double __dredd_replace_binary_operator_Add_double_double(double arg1, double arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1 + arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1 / arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1 * arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1 - arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return arg1;
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return arg2;
+  return arg1 + arg2;
+}
+
+int main() {
+  double x = __dredd_replace_expr_double(__dredd_replace_binary_operator_Add_double_double(__dredd_replace_expr_double(0.0, 0) , __dredd_replace_expr_double(5.32, 3), 6), 11);
+  double y = __dredd_replace_expr_double(__dredd_replace_binary_operator_Add_double_double(__dredd_replace_expr_double(5.234, 14) , __dredd_replace_expr_double(2.352, 17), 20), 25);
+}

--- a/test/single_file/float_binary_opts.cc
+++ b/test/single_file/float_binary_opts.cc
@@ -1,0 +1,4 @@
+int main() {
+  double x = 0.0 + 5.32;
+  double y = 5.234 + 2.352;
+}

--- a/test/single_file/float_binary_opts.cc.expected
+++ b/test/single_file/float_binary_opts.cc.expected
@@ -1,0 +1,74 @@
+#include <cinttypes>
+#include <cstddef>
+#include <functional>
+#include <string>
+
+static bool __dredd_some_mutation_enabled = true;
+static bool __dredd_enabled_mutation(int local_mutation_id) {
+  static bool initialized = false;
+  static uint64_t enabled_bitset[1];
+  if (!initialized) {
+    bool some_mutation_enabled = false;
+    const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
+    if (dredd_environment_variable != nullptr) {
+      std::string contents(dredd_environment_variable);
+      while (true) {
+        size_t pos = contents.find(",");
+        std::string token = (pos == std::string::npos ? contents : contents.substr(0, pos));
+        if (!token.empty()) {
+          int value = std::stoi(token);
+          int local_value = value - 0;
+          if (local_value >= 0 && local_value < 25) {
+            enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+            some_mutation_enabled = true;
+          }
+        }
+        if (pos == std::string::npos) {
+          break;
+        }
+        contents.erase(0, pos + 1);
+      }
+    }
+    initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
+  }
+  return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
+}
+
+static double __dredd_replace_expr_double_zero(std::function<double()> arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg();
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return 1.0;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return -1.0;
+  return arg();
+}
+
+static double __dredd_replace_expr_double(std::function<double()> arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg();
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return 0.0;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 1.0;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1.0;
+  return arg();
+}
+
+static double __dredd_replace_binary_operator_Add_double_double_lhs_zero(std::function<double()> arg1, std::function<double()> arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1() + arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() - arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1();
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg2();
+  return arg1() + arg2();
+}
+
+static double __dredd_replace_binary_operator_Add_double_double(std::function<double()> arg1, std::function<double()> arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1() + arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() / arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1() * arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1() - arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return arg1();
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return arg2();
+  return arg1() + arg2();
+}
+
+int main() {
+  double x = __dredd_replace_expr_double([&]() -> double { return __dredd_replace_binary_operator_Add_double_double_lhs_zero([&]() -> double { return static_cast<double>(__dredd_replace_expr_double_zero([&]() -> double { return 0.0; }, 0)); } , [&]() -> double { return static_cast<double>(__dredd_replace_expr_double([&]() -> double { return 5.32; }, 2)); }, 5); }, 8);
+  double y = __dredd_replace_expr_double([&]() -> double { return __dredd_replace_binary_operator_Add_double_double([&]() -> double { return static_cast<double>(__dredd_replace_expr_double([&]() -> double { return 5.234; }, 11)); } , [&]() -> double { return static_cast<double>(__dredd_replace_expr_double([&]() -> double { return 2.352; }, 14)); }, 17); }, 22);
+}

--- a/test/single_file/float_binary_opts.cc.noopt.expected
+++ b/test/single_file/float_binary_opts.cc.noopt.expected
@@ -1,0 +1,59 @@
+#include <cinttypes>
+#include <cstddef>
+#include <functional>
+#include <string>
+
+static bool __dredd_some_mutation_enabled = true;
+static bool __dredd_enabled_mutation(int local_mutation_id) {
+  static bool initialized = false;
+  static uint64_t enabled_bitset[1];
+  if (!initialized) {
+    bool some_mutation_enabled = false;
+    const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
+    if (dredd_environment_variable != nullptr) {
+      std::string contents(dredd_environment_variable);
+      while (true) {
+        size_t pos = contents.find(",");
+        std::string token = (pos == std::string::npos ? contents : contents.substr(0, pos));
+        if (!token.empty()) {
+          int value = std::stoi(token);
+          int local_value = value - 0;
+          if (local_value >= 0 && local_value < 28) {
+            enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+            some_mutation_enabled = true;
+          }
+        }
+        if (pos == std::string::npos) {
+          break;
+        }
+        contents.erase(0, pos + 1);
+      }
+    }
+    initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
+  }
+  return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
+}
+
+static double __dredd_replace_expr_double(std::function<double()> arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg();
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return 0.0;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 1.0;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1.0;
+  return arg();
+}
+
+static double __dredd_replace_binary_operator_Add_double_double(std::function<double()> arg1, std::function<double()> arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1() + arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() / arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1() * arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1() - arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return arg1();
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return arg2();
+  return arg1() + arg2();
+}
+
+int main() {
+  double x = __dredd_replace_expr_double([&]() -> double { return __dredd_replace_binary_operator_Add_double_double([&]() -> double { return static_cast<double>(__dredd_replace_expr_double([&]() -> double { return 0.0; }, 0)); } , [&]() -> double { return static_cast<double>(__dredd_replace_expr_double([&]() -> double { return 5.32; }, 3)); }, 6); }, 11);
+  double y = __dredd_replace_expr_double([&]() -> double { return __dredd_replace_binary_operator_Add_double_double([&]() -> double { return static_cast<double>(__dredd_replace_expr_double([&]() -> double { return 5.234; }, 14)); } , [&]() -> double { return static_cast<double>(__dredd_replace_expr_double([&]() -> double { return 2.352; }, 17)); }, 20); }, 25);
+}

--- a/test/single_file/floats.c
+++ b/test/single_file/floats.c
@@ -1,4 +1,5 @@
 int main() {
+  double a = 1.0;
   double x = 5.32;
   x += 0.5;
   float y = 64343.7;

--- a/test/single_file/floats.c.expected
+++ b/test/single_file/floats.c.expected
@@ -16,7 +16,7 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
       while(token) {
         int value = atoi(token);
         int local_value = value - 0;
-        if (local_value >= 0 && local_value < 57) {
+        if (local_value >= 0 && local_value < 59) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
           some_mutation_enabled = 1;
         }
@@ -37,6 +37,13 @@ static float __dredd_replace_binary_operator_SubAssign_float_double(float* arg1,
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return (*arg1) /= arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 3)) return (*arg1) *= arg2;
   return (*arg1) -= arg2;
+}
+
+static double __dredd_replace_expr_double_one(double arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return 0.0;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return -1.0;
+  return arg;
 }
 
 static double __dredd_replace_expr_double_lvalue(double* arg, int local_mutation_id) {
@@ -84,10 +91,11 @@ static double __dredd_replace_binary_operator_AddAssign_double_double(double* ar
 }
 
 int main() {
-  double x = __dredd_replace_expr_double(5.32, 0);
-  if (!__dredd_enabled_mutation(10)) { __dredd_replace_binary_operator_AddAssign_double_double(&(x) , __dredd_replace_expr_double(0.5, 3), 6); }
-  float y = __dredd_replace_expr_double(64343.7, 11);
-  if (!__dredd_enabled_mutation(21)) { __dredd_replace_binary_operator_SubAssign_float_double(&(y) , __dredd_replace_expr_double(1.2, 14), 17); }
-  double z = __dredd_replace_expr_double(__dredd_replace_binary_operator_Mul_double_double(__dredd_replace_expr_double(__dredd_replace_expr_double_lvalue(&(x), 22), 24) , __dredd_replace_expr_double(5.5, 27), 30), 35);
-  if (!__dredd_enabled_mutation(56)) { return __dredd_replace_expr_double(__dredd_replace_binary_operator_Add_double_double(__dredd_replace_expr_double(__dredd_replace_expr_double_lvalue(&(z), 38), 40) , __dredd_replace_expr_double(__dredd_replace_expr_double_lvalue(&(x), 43), 45), 48), 53); }
+  double a = __dredd_replace_expr_double_one(1.0, 0);
+  double x = __dredd_replace_expr_double(5.32, 2);
+  if (!__dredd_enabled_mutation(12)) { __dredd_replace_binary_operator_AddAssign_double_double(&(x) , __dredd_replace_expr_double(0.5, 5), 8); }
+  float y = __dredd_replace_expr_double(64343.7, 13);
+  if (!__dredd_enabled_mutation(23)) { __dredd_replace_binary_operator_SubAssign_float_double(&(y) , __dredd_replace_expr_double(1.2, 16), 19); }
+  double z = __dredd_replace_expr_double(__dredd_replace_binary_operator_Mul_double_double(__dredd_replace_expr_double(__dredd_replace_expr_double_lvalue(&(x), 24), 26) , __dredd_replace_expr_double(5.5, 29), 32), 37);
+  if (!__dredd_enabled_mutation(58)) { return __dredd_replace_expr_double(__dredd_replace_binary_operator_Add_double_double(__dredd_replace_expr_double(__dredd_replace_expr_double_lvalue(&(z), 40), 42) , __dredd_replace_expr_double(__dredd_replace_expr_double_lvalue(&(x), 45), 47), 50), 55); }
 }

--- a/test/single_file/floats.c.noopt.expected
+++ b/test/single_file/floats.c.noopt.expected
@@ -16,7 +16,7 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
       while(token) {
         int value = atoi(token);
         int local_value = value - 0;
-        if (local_value >= 0 && local_value < 71) {
+        if (local_value >= 0 && local_value < 74) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
           some_mutation_enabled = 1;
         }
@@ -102,10 +102,11 @@ static double __dredd_replace_binary_operator_AddAssign_double_double(double* ar
 }
 
 int main() {
-  double x = __dredd_replace_expr_double(5.32, 0);
-  if (!__dredd_enabled_mutation(13)) { __dredd_replace_expr_double(__dredd_replace_binary_operator_AddAssign_double_double(&(x) , __dredd_replace_expr_double(0.5, 3), 6), 10); }
-  float y = __dredd_replace_expr_float(__dredd_replace_expr_double(64343.7, 14), 17);
-  if (!__dredd_enabled_mutation(30)) { __dredd_replace_expr_float(__dredd_replace_binary_operator_SubAssign_float_double(&(y) , __dredd_replace_expr_double(1.2, 20), 23), 27); }
-  double z = __dredd_replace_expr_double(__dredd_replace_binary_operator_Mul_double_double(__dredd_replace_expr_double(__dredd_replace_expr_double_lvalue(&(x), 31), 33) , __dredd_replace_expr_double(5.5, 36), 39), 44);
-  if (!__dredd_enabled_mutation(70)) { return __dredd_replace_expr_int(__dredd_replace_expr_double(__dredd_replace_binary_operator_Add_double_double(__dredd_replace_expr_double(__dredd_replace_expr_double_lvalue(&(z), 47), 49) , __dredd_replace_expr_double(__dredd_replace_expr_double_lvalue(&(x), 52), 54), 57), 62), 65); }
+  double a = __dredd_replace_expr_double(1.0, 0);
+  double x = __dredd_replace_expr_double(5.32, 3);
+  if (!__dredd_enabled_mutation(16)) { __dredd_replace_expr_double(__dredd_replace_binary_operator_AddAssign_double_double(&(x) , __dredd_replace_expr_double(0.5, 6), 9), 13); }
+  float y = __dredd_replace_expr_float(__dredd_replace_expr_double(64343.7, 17), 20);
+  if (!__dredd_enabled_mutation(33)) { __dredd_replace_expr_float(__dredd_replace_binary_operator_SubAssign_float_double(&(y) , __dredd_replace_expr_double(1.2, 23), 26), 30); }
+  double z = __dredd_replace_expr_double(__dredd_replace_binary_operator_Mul_double_double(__dredd_replace_expr_double(__dredd_replace_expr_double_lvalue(&(x), 34), 36) , __dredd_replace_expr_double(5.5, 39), 42), 47);
+  if (!__dredd_enabled_mutation(73)) { return __dredd_replace_expr_int(__dredd_replace_expr_double(__dredd_replace_binary_operator_Add_double_double(__dredd_replace_expr_double(__dredd_replace_expr_double_lvalue(&(z), 50), 52) , __dredd_replace_expr_double(__dredd_replace_expr_double_lvalue(&(x), 55), 57), 60), 65), 68); }
 }

--- a/test/single_file/floats.cc
+++ b/test/single_file/floats.cc
@@ -1,4 +1,5 @@
 int main() {
+  double a = 1.0;
   double x = 5.32;
   x += 0.5;
   float y = 64343.7;

--- a/test/single_file/floats.cc.expected
+++ b/test/single_file/floats.cc.expected
@@ -18,7 +18,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
         if (!token.empty()) {
           int value = std::stoi(token);
           int local_value = value - 0;
-          if (local_value >= 0 && local_value < 57) {
+          if (local_value >= 0 && local_value < 59) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
             some_mutation_enabled = true;
           }
@@ -51,6 +51,13 @@ static double& __dredd_replace_binary_operator_AddAssign_double_double(std::func
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1() *= arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 3)) return arg1() -= arg2();
   return arg1() += arg2();
+}
+
+static double __dredd_replace_expr_double_one(std::function<double()> arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg();
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return 0.0;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return -1.0;
+  return arg();
 }
 
 static double __dredd_replace_expr_double_lvalue(std::function<double&()> arg, int local_mutation_id) {
@@ -89,10 +96,11 @@ static double __dredd_replace_binary_operator_Add_double_double(std::function<do
 }
 
 int main() {
-  double x = __dredd_replace_expr_double([&]() -> double { return 5.32; }, 0);
-  if (!__dredd_enabled_mutation(10)) { __dredd_replace_binary_operator_AddAssign_double_double([&]() -> double& { return static_cast<double&>(x); } , [&]() -> double { return static_cast<double>(__dredd_replace_expr_double([&]() -> double { return 0.5; }, 3)); }, 6); }
-  float y = __dredd_replace_expr_double([&]() -> double { return 64343.7; }, 11);
-  if (!__dredd_enabled_mutation(21)) { __dredd_replace_binary_operator_SubAssign_float_double([&]() -> float& { return static_cast<float&>(y); } , [&]() -> double { return static_cast<double>(__dredd_replace_expr_double([&]() -> double { return 1.2; }, 14)); }, 17); }
-  double z = __dredd_replace_expr_double([&]() -> double { return static_cast<double>(__dredd_replace_binary_operator_Mul_double_double([&]() -> double { return static_cast<double>(__dredd_replace_expr_double([&]() -> double { return static_cast<double>(__dredd_replace_expr_double_lvalue([&]() -> double& { return static_cast<double&>(x); }, 22)); }, 24)); } , [&]() -> double { return static_cast<double>(__dredd_replace_expr_double([&]() -> double { return 5.5; }, 27)); }, 30)); }, 35);
-  if (!__dredd_enabled_mutation(56)) { return __dredd_replace_expr_double([&]() -> double { return static_cast<double>(__dredd_replace_binary_operator_Add_double_double([&]() -> double { return static_cast<double>(__dredd_replace_expr_double([&]() -> double { return static_cast<double>(__dredd_replace_expr_double_lvalue([&]() -> double& { return static_cast<double&>(z); }, 38)); }, 40)); } , [&]() -> double { return static_cast<double>(__dredd_replace_expr_double([&]() -> double { return static_cast<double>(__dredd_replace_expr_double_lvalue([&]() -> double& { return static_cast<double&>(x); }, 43)); }, 45)); }, 48)); }, 53); }
+  double a = __dredd_replace_expr_double_one([&]() -> double { return 1.0; }, 0);
+  double x = __dredd_replace_expr_double([&]() -> double { return 5.32; }, 2);
+  if (!__dredd_enabled_mutation(12)) { __dredd_replace_binary_operator_AddAssign_double_double([&]() -> double& { return static_cast<double&>(x); } , [&]() -> double { return static_cast<double>(__dredd_replace_expr_double([&]() -> double { return 0.5; }, 5)); }, 8); }
+  float y = __dredd_replace_expr_double([&]() -> double { return 64343.7; }, 13);
+  if (!__dredd_enabled_mutation(23)) { __dredd_replace_binary_operator_SubAssign_float_double([&]() -> float& { return static_cast<float&>(y); } , [&]() -> double { return static_cast<double>(__dredd_replace_expr_double([&]() -> double { return 1.2; }, 16)); }, 19); }
+  double z = __dredd_replace_expr_double([&]() -> double { return static_cast<double>(__dredd_replace_binary_operator_Mul_double_double([&]() -> double { return static_cast<double>(__dredd_replace_expr_double([&]() -> double { return static_cast<double>(__dredd_replace_expr_double_lvalue([&]() -> double& { return static_cast<double&>(x); }, 24)); }, 26)); } , [&]() -> double { return static_cast<double>(__dredd_replace_expr_double([&]() -> double { return 5.5; }, 29)); }, 32)); }, 37);
+  if (!__dredd_enabled_mutation(58)) { return __dredd_replace_expr_double([&]() -> double { return static_cast<double>(__dredd_replace_binary_operator_Add_double_double([&]() -> double { return static_cast<double>(__dredd_replace_expr_double([&]() -> double { return static_cast<double>(__dredd_replace_expr_double_lvalue([&]() -> double& { return static_cast<double&>(z); }, 40)); }, 42)); } , [&]() -> double { return static_cast<double>(__dredd_replace_expr_double([&]() -> double { return static_cast<double>(__dredd_replace_expr_double_lvalue([&]() -> double& { return static_cast<double&>(x); }, 45)); }, 47)); }, 50)); }, 55); }
 }

--- a/test/single_file/floats.cc.noopt.expected
+++ b/test/single_file/floats.cc.noopt.expected
@@ -18,7 +18,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
         if (!token.empty()) {
           int value = std::stoi(token);
           int local_value = value - 0;
-          if (local_value >= 0 && local_value < 65) {
+          if (local_value >= 0 && local_value < 68) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
             some_mutation_enabled = true;
           }
@@ -107,10 +107,11 @@ static double __dredd_replace_binary_operator_Add_double_double(std::function<do
 }
 
 int main() {
-  double x = __dredd_replace_expr_double([&]() -> double { return 5.32; }, 0);
-  if (!__dredd_enabled_mutation(10)) { __dredd_replace_binary_operator_AddAssign_double_double([&]() -> double& { return static_cast<double&>(x); } , [&]() -> double { return static_cast<double>(__dredd_replace_expr_double([&]() -> double { return 0.5; }, 3)); }, 6); }
-  float y = __dredd_replace_expr_float([&]() -> float { return __dredd_replace_expr_double([&]() -> double { return 64343.7; }, 11); }, 14);
-  if (!__dredd_enabled_mutation(24)) { __dredd_replace_binary_operator_SubAssign_float_double([&]() -> float& { return static_cast<float&>(y); } , [&]() -> double { return static_cast<double>(__dredd_replace_expr_double([&]() -> double { return 1.2; }, 17)); }, 20); }
-  double z = __dredd_replace_expr_double([&]() -> double { return static_cast<double>(__dredd_replace_binary_operator_Mul_double_double([&]() -> double { return static_cast<double>(__dredd_replace_expr_double([&]() -> double { return static_cast<double>(__dredd_replace_expr_double_lvalue([&]() -> double& { return static_cast<double&>(x); }, 25)); }, 27)); } , [&]() -> double { return static_cast<double>(__dredd_replace_expr_double([&]() -> double { return 5.5; }, 30)); }, 33)); }, 38);
-  if (!__dredd_enabled_mutation(64)) { return __dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_double([&]() -> double { return static_cast<double>(__dredd_replace_binary_operator_Add_double_double([&]() -> double { return static_cast<double>(__dredd_replace_expr_double([&]() -> double { return static_cast<double>(__dredd_replace_expr_double_lvalue([&]() -> double& { return static_cast<double&>(z); }, 41)); }, 43)); } , [&]() -> double { return static_cast<double>(__dredd_replace_expr_double([&]() -> double { return static_cast<double>(__dredd_replace_expr_double_lvalue([&]() -> double& { return static_cast<double&>(x); }, 46)); }, 48)); }, 51)); }, 56)); }, 59); }
+  double a = __dredd_replace_expr_double([&]() -> double { return 1.0; }, 0);
+  double x = __dredd_replace_expr_double([&]() -> double { return 5.32; }, 3);
+  if (!__dredd_enabled_mutation(13)) { __dredd_replace_binary_operator_AddAssign_double_double([&]() -> double& { return static_cast<double&>(x); } , [&]() -> double { return static_cast<double>(__dredd_replace_expr_double([&]() -> double { return 0.5; }, 6)); }, 9); }
+  float y = __dredd_replace_expr_float([&]() -> float { return __dredd_replace_expr_double([&]() -> double { return 64343.7; }, 14); }, 17);
+  if (!__dredd_enabled_mutation(27)) { __dredd_replace_binary_operator_SubAssign_float_double([&]() -> float& { return static_cast<float&>(y); } , [&]() -> double { return static_cast<double>(__dredd_replace_expr_double([&]() -> double { return 1.2; }, 20)); }, 23); }
+  double z = __dredd_replace_expr_double([&]() -> double { return static_cast<double>(__dredd_replace_binary_operator_Mul_double_double([&]() -> double { return static_cast<double>(__dredd_replace_expr_double([&]() -> double { return static_cast<double>(__dredd_replace_expr_double_lvalue([&]() -> double& { return static_cast<double&>(x); }, 28)); }, 30)); } , [&]() -> double { return static_cast<double>(__dredd_replace_expr_double([&]() -> double { return 5.5; }, 33)); }, 36)); }, 41);
+  if (!__dredd_enabled_mutation(67)) { return __dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_double([&]() -> double { return static_cast<double>(__dredd_replace_binary_operator_Add_double_double([&]() -> double { return static_cast<double>(__dredd_replace_expr_double([&]() -> double { return static_cast<double>(__dredd_replace_expr_double_lvalue([&]() -> double& { return static_cast<double&>(z); }, 44)); }, 46)); } , [&]() -> double { return static_cast<double>(__dredd_replace_expr_double([&]() -> double { return static_cast<double>(__dredd_replace_expr_double_lvalue([&]() -> double& { return static_cast<double&>(x); }, 49)); }, 51)); }, 54)); }, 59)); }, 62); }
 }

--- a/test/single_file/initializer_list.cc.expected
+++ b/test/single_file/initializer_list.cc.expected
@@ -20,7 +20,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
         if (!token.empty()) {
           int value = std::stoi(token);
           int local_value = value - 0;
-          if (local_value >= 0 && local_value < 9) {
+          if (local_value >= 0 && local_value < 7) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
             some_mutation_enabled = true;
           }
@@ -37,12 +37,11 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }
 
-static int __dredd_replace_expr_int_uoi_optimised(std::function<int()> arg, int local_mutation_id) {
+static int __dredd_replace_expr_int_uoi_optimised_zero(std::function<int()> arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg());
-  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 0;
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 1;
-  if (__dredd_enabled_mutation(local_mutation_id + 3)) return -1;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
   return arg();
 }
 
@@ -54,5 +53,5 @@ struct A {
 void foo(A arg);
 
 void bar() {
-  if (!__dredd_enabled_mutation(8)) { foo({static_cast<unsigned long>(__dredd_replace_expr_int_uoi_optimised([&]() -> int { return 0; }, 0)), static_cast<unsigned long>(__dredd_replace_expr_int_uoi_optimised([&]() -> int { return 0; }, 4))}); }
+  if (!__dredd_enabled_mutation(6)) { foo({static_cast<unsigned long>(__dredd_replace_expr_int_uoi_optimised_zero([&]() -> int { return 0; }, 0)), static_cast<unsigned long>(__dredd_replace_expr_int_uoi_optimised_zero([&]() -> int { return 0; }, 3))}); }
 }

--- a/test/single_file/left_shift_opt.c.expected
+++ b/test/single_file/left_shift_opt.c.expected
@@ -16,7 +16,7 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
       while(token) {
         int value = atoi(token);
         int local_value = value - 0;
-        if (local_value >= 0 && local_value < 12) {
+        if (local_value >= 0 && local_value < 9) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
           some_mutation_enabled = 1;
         }
@@ -30,15 +30,22 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
   return enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64));
 }
 
-static int __dredd_replace_expr_int_uoi_optimised(int arg, int local_mutation_id) {
+static int __dredd_replace_expr_int_uoi_optimised_zero(int arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
+  return arg;
+}
+
+static int __dredd_replace_expr_int_uoi_optimised_one(int arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg);
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return 0;
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 1;
-  if (__dredd_enabled_mutation(local_mutation_id + 3)) return -1;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
   return arg;
 }
 
 int main() {
-  int x = __dredd_replace_expr_int_uoi_optimised(__dredd_replace_expr_int_uoi_optimised(0, 0) << __dredd_replace_expr_int_uoi_optimised(1, 4), 8);
+  int x = __dredd_replace_expr_int_uoi_optimised_zero(__dredd_replace_expr_int_uoi_optimised_zero(0, 0) << __dredd_replace_expr_int_uoi_optimised_one(1, 3), 6);
 }

--- a/test/single_file/left_shift_opt.cc.expected
+++ b/test/single_file/left_shift_opt.cc.expected
@@ -18,7 +18,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
         if (!token.empty()) {
           int value = std::stoi(token);
           int local_value = value - 0;
-          if (local_value >= 0 && local_value < 12) {
+          if (local_value >= 0 && local_value < 9) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
             some_mutation_enabled = true;
           }
@@ -35,15 +35,22 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }
 
-static int __dredd_replace_expr_int_uoi_optimised(std::function<int()> arg, int local_mutation_id) {
+static int __dredd_replace_expr_int_uoi_optimised_zero(std::function<int()> arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg();
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg());
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
+  return arg();
+}
+
+static int __dredd_replace_expr_int_uoi_optimised_one(std::function<int()> arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg());
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return 0;
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 1;
-  if (__dredd_enabled_mutation(local_mutation_id + 3)) return -1;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
   return arg();
 }
 
 int main() {
-  int x = __dredd_replace_expr_int_uoi_optimised([&]() -> int { return __dredd_replace_expr_int_uoi_optimised([&]() -> int { return 0; }, 0) << __dredd_replace_expr_int_uoi_optimised([&]() -> int { return 1; }, 4); }, 8);
+  int x = __dredd_replace_expr_int_uoi_optimised_zero([&]() -> int { return __dredd_replace_expr_int_uoi_optimised_zero([&]() -> int { return 0; }, 0) << __dredd_replace_expr_int_uoi_optimised_one([&]() -> int { return 1; }, 3); }, 6);
 }

--- a/test/single_file/negative_switch_case.c.expected
+++ b/test/single_file/negative_switch_case.c.expected
@@ -16,7 +16,7 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
       while(token) {
         int value = atoi(token);
         int local_value = value - 0;
-        if (local_value >= 0 && local_value < 5) {
+        if (local_value >= 0 && local_value < 4) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
           some_mutation_enabled = 1;
         }
@@ -30,17 +30,16 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
   return enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64));
 }
 
-static int __dredd_replace_expr_int_uoi_optimised(int arg, int local_mutation_id) {
+static int __dredd_replace_expr_int_uoi_optimised_zero(int arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg);
-  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 0;
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 1;
-  if (__dredd_enabled_mutation(local_mutation_id + 3)) return -1;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
   return arg;
 }
 
 int main() {
-  if (!__dredd_enabled_mutation(4)) { switch(__dredd_replace_expr_int_uoi_optimised(0, 0)) {
+  if (!__dredd_enabled_mutation(3)) { switch(__dredd_replace_expr_int_uoi_optimised_zero(0, 0)) {
   case -1:
     break;
   default:

--- a/test/single_file/static_initializer.cc.expected
+++ b/test/single_file/static_initializer.cc.expected
@@ -18,7 +18,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
         if (!token.empty()) {
           int value = std::stoi(token);
           int local_value = value - 0;
-          if (local_value >= 0 && local_value < 33) {
+          if (local_value >= 0 && local_value < 31) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
             some_mutation_enabled = true;
           }
@@ -35,12 +35,11 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }
 
-static int __dredd_replace_expr_int_uoi_optimised(std::function<int()> arg, int local_mutation_id) {
+static int __dredd_replace_expr_int_uoi_optimised_zero(std::function<int()> arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg());
-  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 0;
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 1;
-  if (__dredd_enabled_mutation(local_mutation_id + 3)) return -1;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
   return arg();
 }
 
@@ -73,7 +72,7 @@ static int __dredd_replace_binary_operator_Add_int_int(std::function<int()> arg1
 }
 
 void foo() {
-  int b = __dredd_replace_expr_int_uoi_optimised([&]() -> int { return 0; }, 0);
-  int c = __dredd_replace_expr_int_uoi_optimised([&]() -> int { return 0; }, 4);
-  static int a = __dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_binary_operator_Add_int_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int_lvalue([&]() -> int& { return static_cast<int&>(b); }, 8)); }, 10)); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int_lvalue([&]() -> int& { return static_cast<int&>(c); }, 15)); }, 17)); }, 22)); }, 28);
+  int b = __dredd_replace_expr_int_uoi_optimised_zero([&]() -> int { return 0; }, 0);
+  int c = __dredd_replace_expr_int_uoi_optimised_zero([&]() -> int { return 0; }, 3);
+  static int a = __dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_binary_operator_Add_int_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int_lvalue([&]() -> int& { return static_cast<int&>(b); }, 6)); }, 8)); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int_lvalue([&]() -> int& { return static_cast<int&>(c); }, 13)); }, 15)); }, 20)); }, 26);
 }

--- a/test/single_file/template_instantiation.cc.expected
+++ b/test/single_file/template_instantiation.cc.expected
@@ -18,7 +18,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
         if (!token.empty()) {
           int value = std::stoi(token);
           int local_value = value - 0;
-          if (local_value >= 0 && local_value < 5) {
+          if (local_value >= 0 && local_value < 4) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
             some_mutation_enabled = true;
           }
@@ -35,19 +35,18 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }
 
-static int __dredd_replace_expr_int_uoi_optimised(std::function<int()> arg, int local_mutation_id) {
+static int __dredd_replace_expr_int_uoi_optimised_zero(std::function<int()> arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg());
-  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 0;
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 1;
-  if (__dredd_enabled_mutation(local_mutation_id + 3)) return -1;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
   return arg();
 }
 
 template<int N> void foo() {
-  int A[N] = {__dredd_replace_expr_int_uoi_optimised([&]() -> int { return 0; }, 0)};
+  int A[N] = {__dredd_replace_expr_int_uoi_optimised_zero([&]() -> int { return 0; }, 0)};
 }
 
 int main() {
-  if (!__dredd_enabled_mutation(4)) { foo<1 + 2>(); }
+  if (!__dredd_enabled_mutation(3)) { foo<1 + 2>(); }
 }

--- a/test/single_file/unary_logical_not.c.expected
+++ b/test/single_file/unary_logical_not.c.expected
@@ -18,7 +18,7 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
       while(token) {
         int value = atoi(token);
         int local_value = value - 0;
-        if (local_value >= 0 && local_value < 15) {
+        if (local_value >= 0 && local_value < 14) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
           some_mutation_enabled = 1;
         }
@@ -39,12 +39,11 @@ static int __dredd_replace_unary_operator_LNot__Bool(_Bool arg, int local_mutati
   return !arg;
 }
 
-static int __dredd_replace_expr_int_uoi_optimised(int arg, int local_mutation_id) {
+static int __dredd_replace_expr_int_uoi_optimised_one(int arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg);
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return 0;
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 1;
-  if (__dredd_enabled_mutation(local_mutation_id + 3)) return -1;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
   return arg;
 }
 
@@ -67,6 +66,6 @@ static _Bool __dredd_replace_expr__Bool(_Bool arg, int local_mutation_id) {
 }
 
 int main() {
-  bool y = __dredd_replace_expr_int_uoi_optimised(true, 0);
-  if (!__dredd_enabled_mutation(14)) { return __dredd_replace_expr_int(__dredd_replace_unary_operator_LNot__Bool(__dredd_replace_expr__Bool(y, 4), 7), 9); }
+  bool y = __dredd_replace_expr_int_uoi_optimised_one(true, 0);
+  if (!__dredd_enabled_mutation(13)) { return __dredd_replace_expr_int(__dredd_replace_unary_operator_LNot__Bool(__dredd_replace_expr__Bool(y, 3), 6), 8); }
 }

--- a/test/single_file/unary_logical_not.cc.expected
+++ b/test/single_file/unary_logical_not.cc.expected
@@ -18,7 +18,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
         if (!token.empty()) {
           int value = std::stoi(token);
           int local_value = value - 0;
-          if (local_value >= 0 && local_value < 11) {
+          if (local_value >= 0 && local_value < 10) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
             some_mutation_enabled = true;
           }
@@ -42,10 +42,9 @@ static bool __dredd_replace_unary_operator_LNot_bool(std::function<bool()> arg, 
   return !arg();
 }
 
-static bool __dredd_replace_expr_bool_uoi_optimised(std::function<bool()> arg, int local_mutation_id) {
+static bool __dredd_replace_expr_bool_uoi_optimised_one(std::function<bool()> arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg();
-  if (__dredd_enabled_mutation(local_mutation_id + 0)) return true;
-  if (__dredd_enabled_mutation(local_mutation_id + 1)) return false;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return false;
   return arg();
 }
 
@@ -58,6 +57,6 @@ static bool __dredd_replace_expr_bool(std::function<bool()> arg, int local_mutat
 }
 
 int main() {
-  bool y = __dredd_replace_expr_bool_uoi_optimised([&]() -> bool { return true; }, 0);
-  if (!__dredd_enabled_mutation(10)) { return __dredd_replace_expr_bool([&]() -> bool { return static_cast<bool>(__dredd_replace_unary_operator_LNot_bool([&]() -> bool { return static_cast<bool>(__dredd_replace_expr_bool([&]() -> bool { return static_cast<bool>(y); }, 2)); }, 5)); }, 7); }
+  bool y = __dredd_replace_expr_bool_uoi_optimised_one([&]() -> bool { return true; }, 0);
+  if (!__dredd_enabled_mutation(9)) { return __dredd_replace_expr_bool([&]() -> bool { return static_cast<bool>(__dredd_replace_unary_operator_LNot_bool([&]() -> bool { return static_cast<bool>(__dredd_replace_expr_bool([&]() -> bool { return static_cast<bool>(y); }, 1)); }, 4)); }, 6); }
 }

--- a/test/single_file/unary_logical_not.cc.expected
+++ b/test/single_file/unary_logical_not.cc.expected
@@ -42,7 +42,7 @@ static bool __dredd_replace_unary_operator_LNot_bool(std::function<bool()> arg, 
   return !arg();
 }
 
-static bool __dredd_replace_expr_bool_uoi_optimised_one(std::function<bool()> arg, int local_mutation_id) {
+static bool __dredd_replace_expr_bool_uoi_optimised_true(std::function<bool()> arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return false;
   return arg();
@@ -57,6 +57,6 @@ static bool __dredd_replace_expr_bool(std::function<bool()> arg, int local_mutat
 }
 
 int main() {
-  bool y = __dredd_replace_expr_bool_uoi_optimised_one([&]() -> bool { return true; }, 0);
+  bool y = __dredd_replace_expr_bool_uoi_optimised_true([&]() -> bool { return true; }, 0);
   if (!__dredd_enabled_mutation(9)) { return __dredd_replace_expr_bool([&]() -> bool { return static_cast<bool>(__dredd_replace_unary_operator_LNot_bool([&]() -> bool { return static_cast<bool>(__dredd_replace_expr_bool([&]() -> bool { return static_cast<bool>(y); }, 1)); }, 4)); }, 6); }
 }

--- a/test/single_file/unary_minus.c.expected
+++ b/test/single_file/unary_minus.c.expected
@@ -16,7 +16,7 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
       while(token) {
         int value = atoi(token);
         int local_value = value - 0;
-        if (local_value >= 0 && local_value < 19) {
+        if (local_value >= 0 && local_value < 18) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
           some_mutation_enabled = 1;
         }
@@ -37,12 +37,11 @@ static int __dredd_replace_unary_operator_Minus_int(int arg, int local_mutation_
   return -arg;
 }
 
-static int __dredd_replace_expr_int_uoi_optimised(int arg, int local_mutation_id) {
+static int __dredd_replace_expr_int_uoi_optimised_one(int arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg);
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return 0;
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 1;
-  if (__dredd_enabled_mutation(local_mutation_id + 3)) return -1;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
   return arg;
 }
 
@@ -64,6 +63,6 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
 }
 
 int main() {
-  int x = __dredd_replace_expr_int_uoi_optimised(1, 0);
-  if (!__dredd_enabled_mutation(18)) { return __dredd_replace_expr_int(__dredd_replace_unary_operator_Minus_int(__dredd_replace_expr_int(__dredd_replace_expr_int_lvalue(&(x), 4), 6), 11), 13); }
+  int x = __dredd_replace_expr_int_uoi_optimised_one(1, 0);
+  if (!__dredd_enabled_mutation(17)) { return __dredd_replace_expr_int(__dredd_replace_unary_operator_Minus_int(__dredd_replace_expr_int(__dredd_replace_expr_int_lvalue(&(x), 3), 5), 10), 12); }
 }

--- a/test/single_file/unary_minus.cc.expected
+++ b/test/single_file/unary_minus.cc.expected
@@ -18,7 +18,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
         if (!token.empty()) {
           int value = std::stoi(token);
           int local_value = value - 0;
-          if (local_value >= 0 && local_value < 19) {
+          if (local_value >= 0 && local_value < 18) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
             some_mutation_enabled = true;
           }
@@ -42,12 +42,11 @@ static int __dredd_replace_unary_operator_Minus_int(std::function<int()> arg, in
   return -arg();
 }
 
-static int __dredd_replace_expr_int_uoi_optimised(std::function<int()> arg, int local_mutation_id) {
+static int __dredd_replace_expr_int_uoi_optimised_one(std::function<int()> arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg());
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return 0;
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 1;
-  if (__dredd_enabled_mutation(local_mutation_id + 3)) return -1;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
   return arg();
 }
 
@@ -69,6 +68,6 @@ static int __dredd_replace_expr_int(std::function<int()> arg, int local_mutation
 }
 
 int main() {
-  int x = __dredd_replace_expr_int_uoi_optimised([&]() -> int { return 1; }, 0);
-  if (!__dredd_enabled_mutation(18)) { return __dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_unary_operator_Minus_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int_lvalue([&]() -> int& { return static_cast<int&>(x); }, 4)); }, 6)); }, 11)); }, 13); }
+  int x = __dredd_replace_expr_int_uoi_optimised_one([&]() -> int { return 1; }, 0);
+  if (!__dredd_enabled_mutation(17)) { return __dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_unary_operator_Minus_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int_lvalue([&]() -> int& { return static_cast<int&>(x); }, 3)); }, 5)); }, 10)); }, 12); }
 }

--- a/test/single_file/unary_operator_opt.c.expected
+++ b/test/single_file/unary_operator_opt.c.expected
@@ -16,7 +16,7 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
       while(token) {
         int value = atoi(token);
         int local_value = value - 0;
-        if (local_value >= 0 && local_value < 30) {
+        if (local_value >= 0 && local_value < 26) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
           some_mutation_enabled = 1;
         }
@@ -42,12 +42,28 @@ static int __dredd_replace_unary_operator_Not_int_one(int arg, int local_mutatio
   return ~arg;
 }
 
-static int __dredd_replace_expr_int_uoi_optimised(int arg, int local_mutation_id) {
+static int __dredd_replace_expr_int_uoi_optimised_zero(int arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
+  return arg;
+}
+
+static int __dredd_replace_expr_int_uoi_optimised_one(int arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg);
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return 0;
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 1;
-  if (__dredd_enabled_mutation(local_mutation_id + 3)) return -1;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
+  return arg;
+}
+
+static int __dredd_replace_expr_int_minus_one(int arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 0;
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 1;
   return arg;
 }
 
@@ -62,7 +78,7 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
 }
 
 int main() {
-  int x = __dredd_replace_expr_int(__dredd_replace_unary_operator_Not_int_zero(__dredd_replace_expr_int_uoi_optimised(0, 0), 4), 5);
-  int y = __dredd_replace_expr_int(__dredd_replace_unary_operator_Not_int_one(__dredd_replace_expr_int_uoi_optimised(1, 10), 14), 15);
-  int z = __dredd_replace_expr_int(__dredd_replace_unary_operator_Not_int_one(__dredd_replace_expr_int_uoi_optimised(1, 20), 24), 25);
+  int x = __dredd_replace_expr_int_minus_one(__dredd_replace_unary_operator_Not_int_zero(__dredd_replace_expr_int_uoi_optimised_zero(0, 0), 3), 4);
+  int y = __dredd_replace_expr_int(__dredd_replace_unary_operator_Not_int_one(__dredd_replace_expr_int_uoi_optimised_one(1, 8), 11), 12);
+  int z = __dredd_replace_expr_int(__dredd_replace_unary_operator_Not_int_one(__dredd_replace_expr_int_uoi_optimised_one(1, 17), 20), 21);
 }

--- a/test/single_file/unsigned_int.c.expected
+++ b/test/single_file/unsigned_int.c.expected
@@ -16,7 +16,7 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
       while(token) {
         int value = atoi(token);
         int local_value = value - 0;
-        if (local_value >= 0 && local_value < 22) {
+        if (local_value >= 0 && local_value < 20) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
           some_mutation_enabled = 1;
         }
@@ -44,12 +44,19 @@ static int __dredd_replace_unary_operator_LNot_int_zero(int arg, int local_mutat
   return !arg;
 }
 
-static int __dredd_replace_expr_int_uoi_optimised(int arg, int local_mutation_id) {
+static int __dredd_replace_expr_int_uoi_optimised_zero(int arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
+  return arg;
+}
+
+static int __dredd_replace_expr_int_uoi_optimised_one(int arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg);
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return 0;
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 1;
-  if (__dredd_enabled_mutation(local_mutation_id + 3)) return -1;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
   return arg;
 }
 
@@ -64,6 +71,6 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
 }
 
 int main() {
-  unsigned int x = __dredd_replace_expr_int_uoi_optimised(__dredd_replace_unary_operator_LNot_int_zero(__dredd_replace_expr_int_uoi_optimised(0, 0), 4), 6);
-  unsigned int y = __dredd_replace_expr_int(__dredd_replace_unary_operator_Not_int(__dredd_replace_expr_int(7, 10), 15), 17);
+  unsigned int x = __dredd_replace_expr_int_uoi_optimised_one(__dredd_replace_unary_operator_LNot_int_zero(__dredd_replace_expr_int_uoi_optimised_zero(0, 0), 3), 5);
+  unsigned int y = __dredd_replace_expr_int(__dredd_replace_unary_operator_Not_int(__dredd_replace_expr_int(7, 8), 13), 15);
 }

--- a/test/single_file/unsigned_int.cc.expected
+++ b/test/single_file/unsigned_int.cc.expected
@@ -67,13 +67,13 @@ static bool __dredd_replace_unary_operator_LNot_bool_zero(std::function<bool()> 
   return !arg();
 }
 
-static bool __dredd_replace_expr_bool_uoi_optimised_one(std::function<bool()> arg, int local_mutation_id) {
+static bool __dredd_replace_expr_bool_uoi_optimised_true(std::function<bool()> arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return false;
   return arg();
 }
 
 int main() {
-  unsigned int x = __dredd_replace_expr_bool_uoi_optimised_one([&]() -> bool { return __dredd_replace_unary_operator_LNot_bool_zero([&]() -> bool { return __dredd_replace_expr_int_uoi_optimised_zero([&]() -> int { return 0; }, 0); }, 3); }, 5);
+  unsigned int x = __dredd_replace_expr_bool_uoi_optimised_true([&]() -> bool { return __dredd_replace_unary_operator_LNot_bool_zero([&]() -> bool { return __dredd_replace_expr_int_uoi_optimised_zero([&]() -> int { return 0; }, 0); }, 3); }, 5);
   unsigned int y = __dredd_replace_expr_int([&]() -> int { return __dredd_replace_unary_operator_Not_int([&]() -> int { return __dredd_replace_expr_int([&]() -> int { return 7; }, 6); }, 11); }, 13);
 }

--- a/test/single_file/unsigned_int.cc.expected
+++ b/test/single_file/unsigned_int.cc.expected
@@ -18,7 +18,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
         if (!token.empty()) {
           int value = std::stoi(token);
           int local_value = value - 0;
-          if (local_value >= 0 && local_value < 20) {
+          if (local_value >= 0 && local_value < 18) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
             some_mutation_enabled = true;
           }
@@ -42,12 +42,11 @@ static int __dredd_replace_unary_operator_Not_int(std::function<int()> arg, int 
   return ~arg();
 }
 
-static int __dredd_replace_expr_int_uoi_optimised(std::function<int()> arg, int local_mutation_id) {
+static int __dredd_replace_expr_int_uoi_optimised_zero(std::function<int()> arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg());
-  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 0;
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 1;
-  if (__dredd_enabled_mutation(local_mutation_id + 3)) return -1;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
   return arg();
 }
 
@@ -68,14 +67,13 @@ static bool __dredd_replace_unary_operator_LNot_bool_zero(std::function<bool()> 
   return !arg();
 }
 
-static bool __dredd_replace_expr_bool_uoi_optimised(std::function<bool()> arg, int local_mutation_id) {
+static bool __dredd_replace_expr_bool_uoi_optimised_one(std::function<bool()> arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg();
-  if (__dredd_enabled_mutation(local_mutation_id + 0)) return true;
-  if (__dredd_enabled_mutation(local_mutation_id + 1)) return false;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return false;
   return arg();
 }
 
 int main() {
-  unsigned int x = __dredd_replace_expr_bool_uoi_optimised([&]() -> bool { return __dredd_replace_unary_operator_LNot_bool_zero([&]() -> bool { return __dredd_replace_expr_int_uoi_optimised([&]() -> int { return 0; }, 0); }, 4); }, 6);
-  unsigned int y = __dredd_replace_expr_int([&]() -> int { return __dredd_replace_unary_operator_Not_int([&]() -> int { return __dredd_replace_expr_int([&]() -> int { return 7; }, 8); }, 13); }, 15);
+  unsigned int x = __dredd_replace_expr_bool_uoi_optimised_one([&]() -> bool { return __dredd_replace_unary_operator_LNot_bool_zero([&]() -> bool { return __dredd_replace_expr_int_uoi_optimised_zero([&]() -> int { return 0; }, 0); }, 3); }, 5);
+  unsigned int y = __dredd_replace_expr_int([&]() -> int { return __dredd_replace_unary_operator_Not_int([&]() -> int { return __dredd_replace_expr_int([&]() -> int { return 7; }, 6); }, 11); }, 13);
 }


### PR DESCRIPTION
Use constant folding to avoid replacing an expression with a constant when the expression already evaluates to that value. For example, if an expression e evaluates to 0, avoid replacing e with the constant 0.

Fixes #91.