### PR TITLE
Do not mutate top-level expressions in blocks

### DIFF
--- a/test/single_file/add_float.c.expected
+++ b/test/single_file/add_float.c.expected
@@ -16,7 +16,7 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
       while(token) {
         int value = atoi(token);
         int local_value = value - 0;
-        if (local_value >= 0 && local_value < 37) {
+        if (local_value >= 0 && local_value < 34) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
           some_mutation_enabled = 1;
         }
@@ -85,6 +85,6 @@ int main() {
   float x = __dredd_replace_expr_double(5.235, 0);
   float y = __dredd_replace_expr_double(754.34623, 3);
   float z;
-  if (!__dredd_enabled_mutation(31)) { __dredd_replace_expr_float(__dredd_replace_binary_operator_Assign_float_float(&(z) , __dredd_replace_expr_float(__dredd_replace_binary_operator_Add_float_float(__dredd_replace_expr_float(__dredd_replace_expr_float_lvalue(&(x), 6), 8) , __dredd_replace_expr_float(__dredd_replace_expr_float_lvalue(&(y), 11), 13), 16), 21), 24), 28); }
-  if (!__dredd_enabled_mutation(36)) { return __dredd_replace_expr_int_uoi_optimised(0, 32); }
+  if (!__dredd_enabled_mutation(28)) { __dredd_replace_binary_operator_Assign_float_float(&(z) , __dredd_replace_expr_float(__dredd_replace_binary_operator_Add_float_float(__dredd_replace_expr_float(__dredd_replace_expr_float_lvalue(&(x), 6), 8) , __dredd_replace_expr_float(__dredd_replace_expr_float_lvalue(&(y), 11), 13), 16), 21), 24); }
+  if (!__dredd_enabled_mutation(33)) { return __dredd_replace_expr_int_uoi_optimised(0, 29); }
 }

--- a/test/single_file/assign.c.expected
+++ b/test/single_file/assign.c.expected
@@ -16,7 +16,7 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
       while(token) {
         int value = atoi(token);
         int local_value = value - 0;
-        if (local_value >= 0 && local_value < 42) {
+        if (local_value >= 0 && local_value < 32) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
           some_mutation_enabled = 1;
         }
@@ -73,6 +73,6 @@ static int __dredd_replace_binary_operator_Assign_int_int(int* arg1, int arg2, i
 int main() {
   int x;
   volatile int y;
-  if (!__dredd_enabled_mutation(20)) { __dredd_replace_expr_int(__dredd_replace_binary_operator_Assign_int_int(&(x) , __dredd_replace_expr_int(2, 0), 5), 15); }
-  if (!__dredd_enabled_mutation(41)) { __dredd_replace_expr_int(__dredd_replace_binary_operator_Assign_volatile_int_int(&(y) , __dredd_replace_expr_int(4, 21), 26), 36); }
+  if (!__dredd_enabled_mutation(15)) { __dredd_replace_binary_operator_Assign_int_int(&(x) , __dredd_replace_expr_int(2, 0), 5); }
+  if (!__dredd_enabled_mutation(31)) { __dredd_replace_binary_operator_Assign_volatile_int_int(&(y) , __dredd_replace_expr_int(4, 16), 21); }
 }

--- a/test/single_file/binary_operands_both_zero.c.expected
+++ b/test/single_file/binary_operands_both_zero.c.expected
@@ -4,7 +4,7 @@
 static int __dredd_some_mutation_enabled = 1;
 static int __dredd_enabled_mutation(int local_mutation_id) {
   static int initialized = 0;
-  static uint64_t enabled_bitset[4];
+  static uint64_t enabled_bitset[3];
   if (!initialized) {
     int some_mutation_enabled = 0;
     const char* dredd_environment_variable = getenv("DREDD_ENABLED_MUTATION");
@@ -16,7 +16,7 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
       while(token) {
         int value = atoi(token);
         int local_value = value - 0;
-        if (local_value >= 0 && local_value < 219) {
+        if (local_value >= 0 && local_value < 189) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
           some_mutation_enabled = 1;
         }
@@ -112,10 +112,10 @@ static int __dredd_replace_binary_operator_Add_int_int_rhs_minus_one_lhs_one(int
 
 int main() {
   int x = __dredd_replace_expr_int_uoi_optimised(__dredd_replace_binary_operator_Add_int_int_rhs_zero_lhs_zero(__dredd_replace_expr_int_uoi_optimised(0, 0) , __dredd_replace_expr_int_uoi_optimised(0, 4), 8), 9);
-  if (!__dredd_enabled_mutation(40)) { __dredd_replace_expr_int(__dredd_replace_binary_operator_Assign_int_int(&(x) , __dredd_replace_expr_int_uoi_optimised(__dredd_replace_expr_int_uoi_optimised(0, 13) + __dredd_replace_expr_int_uoi_optimised(1, 17), 21), 25), 35); }
-  if (!__dredd_enabled_mutation(69)) { __dredd_replace_expr_int(__dredd_replace_binary_operator_Assign_int_int(&(x) , __dredd_replace_expr_int_uoi_optimised(__dredd_replace_binary_operator_Add_int_int_rhs_zero_lhs_one(__dredd_replace_expr_int_uoi_optimised(1, 41) , __dredd_replace_expr_int_uoi_optimised(0, 45), 49), 50), 54), 64); }
-  if (!__dredd_enabled_mutation(106)) { __dredd_replace_expr_int(__dredd_replace_binary_operator_Assign_int_int(&(x) , __dredd_replace_expr_int(__dredd_replace_binary_operator_Add_int_int_rhs_minus_one_lhs_zero(__dredd_replace_expr_int_uoi_optimised(0, 70) , __dredd_replace_expr_int(__dredd_replace_unary_operator_Minus_int_one(__dredd_replace_expr_int_uoi_optimised(1, 74), 78), 80), 85), 86), 91), 101); }
-  if (!__dredd_enabled_mutation(143)) { __dredd_replace_expr_int(__dredd_replace_binary_operator_Assign_int_int(&(x) , __dredd_replace_expr_int(__dredd_replace_binary_operator_Add_int_int_rhs_zero_lhs_minus_one(__dredd_replace_expr_int(__dredd_replace_unary_operator_Minus_int_one(__dredd_replace_expr_int_uoi_optimised(1, 107), 111), 113) , __dredd_replace_expr_int_uoi_optimised(0, 118), 122), 123), 128), 138); }
-  if (!__dredd_enabled_mutation(181)) { __dredd_replace_expr_int(__dredd_replace_binary_operator_Assign_int_int(&(x) , __dredd_replace_expr_int_uoi_optimised(__dredd_replace_binary_operator_Add_int_int_rhs_minus_one_lhs_one(__dredd_replace_expr_int_uoi_optimised(1, 144) , __dredd_replace_expr_int(__dredd_replace_unary_operator_Minus_int_one(__dredd_replace_expr_int_uoi_optimised(1, 148), 152), 154), 159), 162), 166), 176); }
-  if (!__dredd_enabled_mutation(218)) { __dredd_replace_expr_int(__dredd_replace_binary_operator_Assign_int_int(&(x) , __dredd_replace_expr_int_uoi_optimised(__dredd_replace_binary_operator_Add_int_int_rhs_one_lhs_minus_one(__dredd_replace_expr_int(__dredd_replace_unary_operator_Minus_int_one(__dredd_replace_expr_int_uoi_optimised(1, 182), 186), 188) , __dredd_replace_expr_int_uoi_optimised(1, 193), 197), 199), 203), 213); }
+  if (!__dredd_enabled_mutation(35)) { __dredd_replace_binary_operator_Assign_int_int(&(x) , __dredd_replace_expr_int_uoi_optimised(__dredd_replace_expr_int_uoi_optimised(0, 13) + __dredd_replace_expr_int_uoi_optimised(1, 17), 21), 25); }
+  if (!__dredd_enabled_mutation(59)) { __dredd_replace_binary_operator_Assign_int_int(&(x) , __dredd_replace_expr_int_uoi_optimised(__dredd_replace_binary_operator_Add_int_int_rhs_zero_lhs_one(__dredd_replace_expr_int_uoi_optimised(1, 36) , __dredd_replace_expr_int_uoi_optimised(0, 40), 44), 45), 49); }
+  if (!__dredd_enabled_mutation(91)) { __dredd_replace_binary_operator_Assign_int_int(&(x) , __dredd_replace_expr_int(__dredd_replace_binary_operator_Add_int_int_rhs_minus_one_lhs_zero(__dredd_replace_expr_int_uoi_optimised(0, 60) , __dredd_replace_expr_int(__dredd_replace_unary_operator_Minus_int_one(__dredd_replace_expr_int_uoi_optimised(1, 64), 68), 70), 75), 76), 81); }
+  if (!__dredd_enabled_mutation(123)) { __dredd_replace_binary_operator_Assign_int_int(&(x) , __dredd_replace_expr_int(__dredd_replace_binary_operator_Add_int_int_rhs_zero_lhs_minus_one(__dredd_replace_expr_int(__dredd_replace_unary_operator_Minus_int_one(__dredd_replace_expr_int_uoi_optimised(1, 92), 96), 98) , __dredd_replace_expr_int_uoi_optimised(0, 103), 107), 108), 113); }
+  if (!__dredd_enabled_mutation(156)) { __dredd_replace_binary_operator_Assign_int_int(&(x) , __dredd_replace_expr_int_uoi_optimised(__dredd_replace_binary_operator_Add_int_int_rhs_minus_one_lhs_one(__dredd_replace_expr_int_uoi_optimised(1, 124) , __dredd_replace_expr_int(__dredd_replace_unary_operator_Minus_int_one(__dredd_replace_expr_int_uoi_optimised(1, 128), 132), 134), 139), 142), 146); }
+  if (!__dredd_enabled_mutation(188)) { __dredd_replace_binary_operator_Assign_int_int(&(x) , __dredd_replace_expr_int_uoi_optimised(__dredd_replace_binary_operator_Add_int_int_rhs_one_lhs_minus_one(__dredd_replace_expr_int(__dredd_replace_unary_operator_Minus_int_one(__dredd_replace_expr_int_uoi_optimised(1, 157), 161), 163) , __dredd_replace_expr_int_uoi_optimised(1, 168), 172), 174), 178); }
 }

--- a/test/single_file/bitfield.c.expected
+++ b/test/single_file/bitfield.c.expected
@@ -16,7 +16,7 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
       while(token) {
         int value = atoi(token);
         int local_value = value - 0;
-        if (local_value >= 0 && local_value < 23) {
+        if (local_value >= 0 && local_value < 8) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
           some_mutation_enabled = 1;
         }
@@ -47,7 +47,7 @@ struct S {
 
 void foo() {
   struct S myS;
-  if (!__dredd_enabled_mutation(10)) { __dredd_replace_expr_int(myS.a = __dredd_replace_expr_int(myS.b, 0), 5); }
-  if (!__dredd_enabled_mutation(16)) { __dredd_replace_expr_int(myS.a++, 11); }
-  if (!__dredd_enabled_mutation(22)) { __dredd_replace_expr_int(--myS.b, 17); }
+  if (!__dredd_enabled_mutation(5)) { myS.a = __dredd_replace_expr_int(myS.b, 0); }
+  if (!__dredd_enabled_mutation(6)) { myS.a++; }
+  if (!__dredd_enabled_mutation(7)) { --myS.b; }
 }

--- a/test/single_file/bitfield.cc.expected
+++ b/test/single_file/bitfield.cc.expected
@@ -18,7 +18,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
         if (!token.empty()) {
           int value = std::stoi(token);
           int local_value = value - 0;
-          if (local_value >= 0 && local_value < 13) {
+          if (local_value >= 0 && local_value < 8) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
             some_mutation_enabled = true;
           }
@@ -53,6 +53,6 @@ struct S {
 void foo() {
   S myS;
   if (!__dredd_enabled_mutation(5)) { myS.a = __dredd_replace_expr_int([&]() -> int { return static_cast<int>(myS.b); }, 0); }
-  if (!__dredd_enabled_mutation(11)) { __dredd_replace_expr_int([&]() -> int { return static_cast<int>(myS.a++); }, 6); }
-  if (!__dredd_enabled_mutation(12)) { --myS.b; }
+  if (!__dredd_enabled_mutation(6)) { myS.a++; }
+  if (!__dredd_enabled_mutation(7)) { --myS.b; }
 }

--- a/test/single_file/expr_lvalue.c.expected
+++ b/test/single_file/expr_lvalue.c.expected
@@ -16,7 +16,7 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
       while(token) {
         int value = atoi(token);
         int local_value = value - 0;
-        if (local_value >= 0 && local_value < 33) {
+        if (local_value >= 0 && local_value < 28) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
           some_mutation_enabled = 1;
         }
@@ -66,5 +66,5 @@ int main() {
   int x = __dredd_replace_expr_int(5, 0);
   int y = __dredd_replace_expr_int(__dredd_replace_expr_int_lvalue(&(x), 5), 7);
   int z;
-  if (!__dredd_enabled_mutation(32)) { __dredd_replace_expr_int(__dredd_replace_binary_operator_Assign_int_int(&(z) , __dredd_replace_expr_int(6, 12), 17), 27); }
+  if (!__dredd_enabled_mutation(27)) { __dredd_replace_binary_operator_Assign_int_int(&(z) , __dredd_replace_expr_int(6, 12), 17); }
 }

--- a/test/single_file/floats.c.expected
+++ b/test/single_file/floats.c.expected
@@ -16,7 +16,7 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
       while(token) {
         int value = atoi(token);
         int local_value = value - 0;
-        if (local_value >= 0 && local_value < 63) {
+        if (local_value >= 0 && local_value < 57) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
           some_mutation_enabled = 1;
         }
@@ -28,14 +28,6 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
     __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64));
-}
-
-static float __dredd_replace_expr_float(float arg, int local_mutation_id) {
-  if (!__dredd_some_mutation_enabled) return arg;
-  if (__dredd_enabled_mutation(local_mutation_id + 0)) return 0.0;
-  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 1.0;
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1.0;
-  return arg;
 }
 
 static float __dredd_replace_binary_operator_SubAssign_float_double(float* arg1, double arg2, int local_mutation_id) {
@@ -93,9 +85,9 @@ static double __dredd_replace_binary_operator_AddAssign_double_double(double* ar
 
 int main() {
   double x = __dredd_replace_expr_double(5.32, 0);
-  if (!__dredd_enabled_mutation(13)) { __dredd_replace_expr_double(__dredd_replace_binary_operator_AddAssign_double_double(&(x) , __dredd_replace_expr_double(0.5, 3), 6), 10); }
-  float y = __dredd_replace_expr_double(64343.7, 14);
-  if (!__dredd_enabled_mutation(27)) { __dredd_replace_expr_float(__dredd_replace_binary_operator_SubAssign_float_double(&(y) , __dredd_replace_expr_double(1.2, 17), 20), 24); }
-  double z = __dredd_replace_expr_double(__dredd_replace_binary_operator_Mul_double_double(__dredd_replace_expr_double(__dredd_replace_expr_double_lvalue(&(x), 28), 30) , __dredd_replace_expr_double(5.5, 33), 36), 41);
-  if (!__dredd_enabled_mutation(62)) { return __dredd_replace_expr_double(__dredd_replace_binary_operator_Add_double_double(__dredd_replace_expr_double(__dredd_replace_expr_double_lvalue(&(z), 44), 46) , __dredd_replace_expr_double(__dredd_replace_expr_double_lvalue(&(x), 49), 51), 54), 59); }
+  if (!__dredd_enabled_mutation(10)) { __dredd_replace_binary_operator_AddAssign_double_double(&(x) , __dredd_replace_expr_double(0.5, 3), 6); }
+  float y = __dredd_replace_expr_double(64343.7, 11);
+  if (!__dredd_enabled_mutation(21)) { __dredd_replace_binary_operator_SubAssign_float_double(&(y) , __dredd_replace_expr_double(1.2, 14), 17); }
+  double z = __dredd_replace_expr_double(__dredd_replace_binary_operator_Mul_double_double(__dredd_replace_expr_double(__dredd_replace_expr_double_lvalue(&(x), 22), 24) , __dredd_replace_expr_double(5.5, 27), 30), 35);
+  if (!__dredd_enabled_mutation(56)) { return __dredd_replace_expr_double(__dredd_replace_binary_operator_Add_double_double(__dredd_replace_expr_double(__dredd_replace_expr_double_lvalue(&(z), 38), 40) , __dredd_replace_expr_double(__dredd_replace_expr_double_lvalue(&(x), 43), 45), 48), 53); }
 }

--- a/test/single_file/post_inc_volatile.c.expected
+++ b/test/single_file/post_inc_volatile.c.expected
@@ -16,7 +16,7 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
       while(token) {
         int value = atoi(token);
         int local_value = value - 0;
-        if (local_value >= 0 && local_value < 63) {
+        if (local_value >= 0 && local_value < 58) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
           some_mutation_enabled = 1;
         }
@@ -86,6 +86,6 @@ int main() {
   volatile int x = __dredd_replace_expr_int(9, 0);
   volatile int y = __dredd_replace_expr_int(43, 5);
   int z;
-  if (!__dredd_enabled_mutation(54)) { __dredd_replace_expr_int(__dredd_replace_binary_operator_Assign_int_int(&(z) , __dredd_replace_expr_int(__dredd_replace_binary_operator_Add_int_int(__dredd_replace_expr_int(__dredd_replace_unary_operator_PostInc_volatile_int(&(x), 10), 14) , __dredd_replace_expr_int(__dredd_replace_unary_operator_PostInc_volatile_int(&(y), 19), 23), 28), 34), 39), 49); }
-  if (!__dredd_enabled_mutation(62)) { return __dredd_replace_expr_int(__dredd_replace_expr_int_lvalue(&(z), 55), 57); }
+  if (!__dredd_enabled_mutation(49)) { __dredd_replace_binary_operator_Assign_int_int(&(z) , __dredd_replace_expr_int(__dredd_replace_binary_operator_Add_int_int(__dredd_replace_expr_int(__dredd_replace_unary_operator_PostInc_volatile_int(&(x), 10), 14) , __dredd_replace_expr_int(__dredd_replace_unary_operator_PostInc_volatile_int(&(y), 19), 23), 28), 34), 39); }
+  if (!__dredd_enabled_mutation(57)) { return __dredd_replace_expr_int(__dredd_replace_expr_int_lvalue(&(z), 50), 52); }
 }

--- a/test/single_file/printing.c.expected
+++ b/test/single_file/printing.c.expected
@@ -18,7 +18,7 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
       while(token) {
         int value = atoi(token);
         int local_value = value - 0;
-        if (local_value >= 0 && local_value < 42) {
+        if (local_value >= 0 && local_value < 7) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
           some_mutation_enabled = 1;
         }
@@ -32,22 +32,12 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
   return enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64));
 }
 
-static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
-  if (!__dredd_some_mutation_enabled) return arg;
-  if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg);
-  if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~(arg);
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 0;
-  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 1;
-  if (__dredd_enabled_mutation(local_mutation_id + 4)) return -1;
-  return arg;
-}
-
 int main() {
-  if (!__dredd_enabled_mutation(5)) { __dredd_replace_expr_int(printf("%s\n", "A\n"), 0); }
-  if (!__dredd_enabled_mutation(11)) { __dredd_replace_expr_int(printf("%s\n", "B\n"), 6); }
-  if (!__dredd_enabled_mutation(17)) { __dredd_replace_expr_int(printf("%s\n", "C\n"), 12); }
-  if (!__dredd_enabled_mutation(23)) { __dredd_replace_expr_int(printf("%s\n", "D\n"), 18); }
-  if (!__dredd_enabled_mutation(29)) { __dredd_replace_expr_int(printf("%s\n", "E\n"), 24); }
-  if (!__dredd_enabled_mutation(35)) { __dredd_replace_expr_int(printf("%s\n", "F\n"), 30); }
-  if (!__dredd_enabled_mutation(41)) { __dredd_replace_expr_int(printf("%s\n", "G\n"), 36); }
+  if (!__dredd_enabled_mutation(0)) { printf("%s\n", "A\n"); }
+  if (!__dredd_enabled_mutation(1)) { printf("%s\n", "B\n"); }
+  if (!__dredd_enabled_mutation(2)) { printf("%s\n", "C\n"); }
+  if (!__dredd_enabled_mutation(3)) { printf("%s\n", "D\n"); }
+  if (!__dredd_enabled_mutation(4)) { printf("%s\n", "E\n"); }
+  if (!__dredd_enabled_mutation(5)) { printf("%s\n", "F\n"); }
+  if (!__dredd_enabled_mutation(6)) { printf("%s\n", "G\n"); }
 }

--- a/test/single_file/unary.c.expected
+++ b/test/single_file/unary.c.expected
@@ -4,7 +4,7 @@
 static int __dredd_some_mutation_enabled = 1;
 static int __dredd_enabled_mutation(int local_mutation_id) {
   static int initialized = 0;
-  static uint64_t enabled_bitset[2];
+  static uint64_t enabled_bitset[1];
   if (!initialized) {
     int some_mutation_enabled = 0;
     const char* dredd_environment_variable = getenv("DREDD_ENABLED_MUTATION");
@@ -16,7 +16,7 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
       while(token) {
         int value = atoi(token);
         int local_value = value - 0;
-        if (local_value >= 0 && local_value < 91) {
+        if (local_value >= 0 && local_value < 59) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
           some_mutation_enabled = 1;
         }
@@ -122,14 +122,6 @@ static float __dredd_replace_unary_operator_PostDec_float(float* arg, int local_
   return (*arg)--;
 }
 
-static float __dredd_replace_expr_float(float arg, int local_mutation_id) {
-  if (!__dredd_some_mutation_enabled) return arg;
-  if (__dredd_enabled_mutation(local_mutation_id + 0)) return 0.0;
-  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 1.0;
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1.0;
-  return arg;
-}
-
 static double __dredd_replace_expr_double(double arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return 0.0;
@@ -141,13 +133,13 @@ static double __dredd_replace_expr_double(double arg, int local_mutation_id) {
 int main() {
   int x = __dredd_replace_expr_int(3, 0);
   float y = __dredd_replace_expr_double(3.532, 5);
-  if (!__dredd_enabled_mutation(17)) { __dredd_replace_expr_int(__dredd_replace_unary_operator_PostInc_int(&(x), 8), 12); }
-  if (!__dredd_enabled_mutation(24)) { __dredd_replace_expr_float(__dredd_replace_unary_operator_PostInc_float(&(y), 18), 21); }
-  if (!__dredd_enabled_mutation(34)) { __dredd_replace_expr_int(__dredd_replace_unary_operator_PreInc_int(&(x), 25), 29); }
-  if (!__dredd_enabled_mutation(41)) { __dredd_replace_expr_float(__dredd_replace_unary_operator_PreInc_float(&(y), 35), 38); }
-  if (!__dredd_enabled_mutation(51)) { __dredd_replace_expr_int(__dredd_replace_unary_operator_PreDec_int(&(x), 42), 46); }
-  if (!__dredd_enabled_mutation(58)) { __dredd_replace_expr_float(__dredd_replace_unary_operator_PreDec_float(&(y), 52), 55); }
-  if (!__dredd_enabled_mutation(68)) { __dredd_replace_expr_int(__dredd_replace_unary_operator_PostDec_int(&(x), 59), 63); }
-  if (!__dredd_enabled_mutation(75)) { __dredd_replace_expr_float(__dredd_replace_unary_operator_PostDec_float(&(y), 69), 72); }
-  if (!__dredd_enabled_mutation(90)) { return __dredd_replace_expr_int(__dredd_replace_unary_operator_Minus_int(__dredd_replace_expr_int(__dredd_replace_expr_int_lvalue(&(x), 76), 78), 83), 85); }
+  if (!__dredd_enabled_mutation(12)) { __dredd_replace_unary_operator_PostInc_int(&(x), 8); }
+  if (!__dredd_enabled_mutation(16)) { __dredd_replace_unary_operator_PostInc_float(&(y), 13); }
+  if (!__dredd_enabled_mutation(21)) { __dredd_replace_unary_operator_PreInc_int(&(x), 17); }
+  if (!__dredd_enabled_mutation(25)) { __dredd_replace_unary_operator_PreInc_float(&(y), 22); }
+  if (!__dredd_enabled_mutation(30)) { __dredd_replace_unary_operator_PreDec_int(&(x), 26); }
+  if (!__dredd_enabled_mutation(34)) { __dredd_replace_unary_operator_PreDec_float(&(y), 31); }
+  if (!__dredd_enabled_mutation(39)) { __dredd_replace_unary_operator_PostDec_int(&(x), 35); }
+  if (!__dredd_enabled_mutation(43)) { __dredd_replace_unary_operator_PostDec_float(&(y), 40); }
+  if (!__dredd_enabled_mutation(58)) { return __dredd_replace_expr_int(__dredd_replace_unary_operator_Minus_int(__dredd_replace_expr_int(__dredd_replace_expr_int_lvalue(&(x), 44), 46), 51), 53); }
 }

--- a/test/single_file/unary.cc.expected
+++ b/test/single_file/unary.cc.expected
@@ -6,7 +6,7 @@
 static bool __dredd_some_mutation_enabled = true;
 static bool __dredd_enabled_mutation(int local_mutation_id) {
   static bool initialized = false;
-  static uint64_t enabled_bitset[2];
+  static uint64_t enabled_bitset[1];
   if (!initialized) {
     bool some_mutation_enabled = false;
     const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
@@ -18,7 +18,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
         if (!token.empty()) {
           int value = std::stoi(token);
           int local_value = value - 0;
-          if (local_value >= 0 && local_value < 65) {
+          if (local_value >= 0 && local_value < 49) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
             some_mutation_enabled = true;
           }
@@ -117,14 +117,6 @@ static float __dredd_replace_unary_operator_PostDec_float(std::function<float&()
   return arg()--;
 }
 
-static float __dredd_replace_expr_float(std::function<float()> arg, int local_mutation_id) {
-  if (!__dredd_some_mutation_enabled) return arg();
-  if (__dredd_enabled_mutation(local_mutation_id + 0)) return 0.0;
-  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 1.0;
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1.0;
-  return arg();
-}
-
 static double __dredd_replace_expr_double(std::function<double()> arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return 0.0;
@@ -136,13 +128,13 @@ static double __dredd_replace_expr_double(std::function<double()> arg, int local
 int main() {
   int x = __dredd_replace_expr_int([&]() -> int { return 3; }, 0);
   float y = __dredd_replace_expr_double([&]() -> double { return 3.532; }, 5);
-  if (!__dredd_enabled_mutation(17)) { __dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_unary_operator_PostInc_int([&]() -> int& { return static_cast<int&>(x); }, 8)); }, 12); }
-  if (!__dredd_enabled_mutation(24)) { __dredd_replace_expr_float([&]() -> float { return static_cast<float>(__dredd_replace_unary_operator_PostInc_float([&]() -> float& { return static_cast<float&>(y); }, 18)); }, 21); }
-  if (!__dredd_enabled_mutation(26)) { __dredd_replace_unary_operator_PreInc_int([&]() -> int& { return static_cast<int&>(x); }, 25); }
-  if (!__dredd_enabled_mutation(28)) { __dredd_replace_unary_operator_PreInc_float([&]() -> float& { return static_cast<float&>(y); }, 27); }
-  if (!__dredd_enabled_mutation(30)) { __dredd_replace_unary_operator_PreDec_int([&]() -> int& { return static_cast<int&>(x); }, 29); }
-  if (!__dredd_enabled_mutation(32)) { __dredd_replace_unary_operator_PreDec_float([&]() -> float& { return static_cast<float&>(y); }, 31); }
-  if (!__dredd_enabled_mutation(42)) { __dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_unary_operator_PostDec_int([&]() -> int& { return static_cast<int&>(x); }, 33)); }, 37); }
-  if (!__dredd_enabled_mutation(49)) { __dredd_replace_expr_float([&]() -> float { return static_cast<float>(__dredd_replace_unary_operator_PostDec_float([&]() -> float& { return static_cast<float&>(y); }, 43)); }, 46); }
-  if (!__dredd_enabled_mutation(64)) { return __dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_unary_operator_Minus_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int_lvalue([&]() -> int& { return static_cast<int&>(x); }, 50)); }, 52)); }, 57)); }, 59); }
+  if (!__dredd_enabled_mutation(12)) { __dredd_replace_unary_operator_PostInc_int([&]() -> int& { return static_cast<int&>(x); }, 8); }
+  if (!__dredd_enabled_mutation(16)) { __dredd_replace_unary_operator_PostInc_float([&]() -> float& { return static_cast<float&>(y); }, 13); }
+  if (!__dredd_enabled_mutation(18)) { __dredd_replace_unary_operator_PreInc_int([&]() -> int& { return static_cast<int&>(x); }, 17); }
+  if (!__dredd_enabled_mutation(20)) { __dredd_replace_unary_operator_PreInc_float([&]() -> float& { return static_cast<float&>(y); }, 19); }
+  if (!__dredd_enabled_mutation(22)) { __dredd_replace_unary_operator_PreDec_int([&]() -> int& { return static_cast<int&>(x); }, 21); }
+  if (!__dredd_enabled_mutation(24)) { __dredd_replace_unary_operator_PreDec_float([&]() -> float& { return static_cast<float&>(y); }, 23); }
+  if (!__dredd_enabled_mutation(29)) { __dredd_replace_unary_operator_PostDec_int([&]() -> int& { return static_cast<int&>(x); }, 25); }
+  if (!__dredd_enabled_mutation(33)) { __dredd_replace_unary_operator_PostDec_float([&]() -> float& { return static_cast<float&>(y); }, 30); }
+  if (!__dredd_enabled_mutation(48)) { return __dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_unary_operator_Minus_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int_lvalue([&]() -> int& { return static_cast<int&>(x); }, 34)); }, 36)); }, 41)); }, 43); }
 }

--- a/test/single_file/volatile.c.expected
+++ b/test/single_file/volatile.c.expected
@@ -16,7 +16,7 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
       while(token) {
         int value = atoi(token);
         int local_value = value - 0;
-        if (local_value >= 0 && local_value < 21) {
+        if (local_value >= 0 && local_value < 16) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
           some_mutation_enabled = 1;
         }
@@ -57,5 +57,5 @@ static int __dredd_replace_binary_operator_AddAssign_volatile_int_int(volatile i
 
 void foo() {
   volatile int a;
-  if (!__dredd_enabled_mutation(20)) { __dredd_replace_expr_int(__dredd_replace_binary_operator_AddAssign_volatile_int_int(&(a) , __dredd_replace_expr_int(2, 0), 5), 15); }
+  if (!__dredd_enabled_mutation(15)) { __dredd_replace_binary_operator_AddAssign_volatile_int_int(&(a) , __dredd_replace_expr_int(2, 0), 5); }
 }


### PR DESCRIPTION
Avoid applying general expression mutation to top-level expression statements that appear in compound statements, as there is little-to-no value in doing so.

Fixes #93.