### PR TITLE
Favour mutating outside vs. inside casts

### DIFF
--- a/test/single_file/add_float.c.expected
+++ b/test/single_file/add_float.c.expected
@@ -72,17 +72,9 @@ static float __dredd_replace_binary_operator_Add_float_float(float arg1, float a
   return arg1 + arg2;
 }
 
-static double __dredd_replace_expr_double(double arg, int local_mutation_id) {
-  if (!__dredd_some_mutation_enabled) return arg;
-  if (__dredd_enabled_mutation(local_mutation_id + 0)) return 0.0;
-  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 1.0;
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1.0;
-  return arg;
-}
-
 int main() {
-  float x = __dredd_replace_expr_double(5.235, 0);
-  float y = __dredd_replace_expr_double(754.34623, 3);
+  float x = __dredd_replace_expr_float(5.235, 0);
+  float y = __dredd_replace_expr_float(754.34623, 3);
   float z;
   if (!__dredd_enabled_mutation(28)) { __dredd_replace_binary_operator_Assign_float_float(&(z) , __dredd_replace_expr_float(__dredd_replace_binary_operator_Add_float_float(__dredd_replace_expr_float(__dredd_replace_expr_float_lvalue(&(x), 6), 8) , __dredd_replace_expr_float(__dredd_replace_expr_float_lvalue(&(y), 11), 13), 16), 21), 24); }
   if (!__dredd_enabled_mutation(32)) { return __dredd_replace_expr_int_uoi_optimised_zero(0, 29); }

--- a/test/single_file/add_float.cc.expected
+++ b/test/single_file/add_float.cc.expected
@@ -77,17 +77,9 @@ static float __dredd_replace_binary_operator_Add_float_float(std::function<float
   return arg1() + arg2();
 }
 
-static double __dredd_replace_expr_double(std::function<double()> arg, int local_mutation_id) {
-  if (!__dredd_some_mutation_enabled) return arg();
-  if (__dredd_enabled_mutation(local_mutation_id + 0)) return 0.0;
-  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 1.0;
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1.0;
-  return arg();
-}
-
 int main() {
-  float x = __dredd_replace_expr_double([&]() -> double { return 5.235; }, 0);
-  float y = __dredd_replace_expr_double([&]() -> double { return 754.34623; }, 3);
+  float x = __dredd_replace_expr_float([&]() -> float { return 5.235; }, 0);
+  float y = __dredd_replace_expr_float([&]() -> float { return 754.34623; }, 3);
   float z;
   if (!__dredd_enabled_mutation(28)) { __dredd_replace_binary_operator_Assign_float_float([&]() -> float& { return static_cast<float&>(z); } , [&]() -> float { return static_cast<float>(__dredd_replace_expr_float([&]() -> float { return static_cast<float>(__dredd_replace_binary_operator_Add_float_float([&]() -> float { return static_cast<float>(__dredd_replace_expr_float([&]() -> float { return static_cast<float>(__dredd_replace_expr_float_lvalue([&]() -> float& { return static_cast<float&>(x); }, 6)); }, 8)); } , [&]() -> float { return static_cast<float>(__dredd_replace_expr_float([&]() -> float { return static_cast<float>(__dredd_replace_expr_float_lvalue([&]() -> float& { return static_cast<float&>(y); }, 11)); }, 13)); }, 16)); }, 21)); }, 24); }
   if (!__dredd_enabled_mutation(32)) { return __dredd_replace_expr_int_uoi_optimised_zero([&]() -> int { return 0; }, 29); }

--- a/test/single_file/enum.c.expected
+++ b/test/single_file/enum.c.expected
@@ -1,48 +1,8 @@
-#include <inttypes.h>
-#include <stdlib.h>
-#include <string.h>
-static int __dredd_some_mutation_enabled = 1;
-static int __dredd_enabled_mutation(int local_mutation_id) {
-  static int initialized = 0;
-  static uint64_t enabled_bitset[1];
-  if (!initialized) {
-    int some_mutation_enabled = 0;
-    const char* dredd_environment_variable = getenv("DREDD_ENABLED_MUTATION");
-    if (dredd_environment_variable) {
-      char* temp = malloc(strlen(dredd_environment_variable) + 1);
-      strcpy(temp, dredd_environment_variable);
-      char* token;
-      token = strtok(temp, ",");
-      while(token) {
-        int value = atoi(token);
-        int local_value = value - 0;
-        if (local_value >= 0 && local_value < 3) {
-          enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
-          some_mutation_enabled = 1;
-        }
-        token = strtok(NULL, ",");
-      }
-      free(temp);
-    }
-    initialized = 1;
-    __dredd_some_mutation_enabled = some_mutation_enabled;
-  }
-  return enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64));
-}
-
-static int __dredd_replace_expr_int_uoi_optimised_zero(int arg, int local_mutation_id) {
-  if (!__dredd_some_mutation_enabled) return arg;
-  if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg);
-  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 1;
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
-  return arg;
-}
-
 enum A {
   X,
   Y
 };
 
 void foo() {
-  enum A myA = __dredd_replace_expr_int_uoi_optimised_zero(X, 0);
+  enum A myA = X;
 }

--- a/test/single_file/floats.c.expected
+++ b/test/single_file/floats.c.expected
@@ -16,7 +16,7 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
       while(token) {
         int value = atoi(token);
         int local_value = value - 0;
-        if (local_value >= 0 && local_value < 59) {
+        if (local_value >= 0 && local_value < 61) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
           some_mutation_enabled = 1;
         }
@@ -28,6 +28,24 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
     __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64));
+}
+
+static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 0;
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return -1;
+  return arg;
+}
+
+static float __dredd_replace_expr_float(float arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return 0.0;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 1.0;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1.0;
+  return arg;
 }
 
 static float __dredd_replace_binary_operator_SubAssign_float_double(float* arg1, double arg2, int local_mutation_id) {
@@ -94,8 +112,8 @@ int main() {
   double a = __dredd_replace_expr_double_one(1.0, 0);
   double x = __dredd_replace_expr_double(5.32, 2);
   if (!__dredd_enabled_mutation(12)) { __dredd_replace_binary_operator_AddAssign_double_double(&(x) , __dredd_replace_expr_double(0.5, 5), 8); }
-  float y = __dredd_replace_expr_double(64343.7, 13);
+  float y = __dredd_replace_expr_float(64343.7, 13);
   if (!__dredd_enabled_mutation(23)) { __dredd_replace_binary_operator_SubAssign_float_double(&(y) , __dredd_replace_expr_double(1.2, 16), 19); }
   double z = __dredd_replace_expr_double(__dredd_replace_binary_operator_Mul_double_double(__dredd_replace_expr_double(__dredd_replace_expr_double_lvalue(&(x), 24), 26) , __dredd_replace_expr_double(5.5, 29), 32), 37);
-  if (!__dredd_enabled_mutation(58)) { return __dredd_replace_expr_double(__dredd_replace_binary_operator_Add_double_double(__dredd_replace_expr_double(__dredd_replace_expr_double_lvalue(&(z), 40), 42) , __dredd_replace_expr_double(__dredd_replace_expr_double_lvalue(&(x), 45), 47), 50), 55); }
+  if (!__dredd_enabled_mutation(60)) { return __dredd_replace_expr_int(__dredd_replace_binary_operator_Add_double_double(__dredd_replace_expr_double(__dredd_replace_expr_double_lvalue(&(z), 40), 42) , __dredd_replace_expr_double(__dredd_replace_expr_double_lvalue(&(x), 45), 47), 50), 55); }
 }

--- a/test/single_file/floats.cc.expected
+++ b/test/single_file/floats.cc.expected
@@ -18,7 +18,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
         if (!token.empty()) {
           int value = std::stoi(token);
           int local_value = value - 0;
-          if (local_value >= 0 && local_value < 59) {
+          if (local_value >= 0 && local_value < 61) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
             some_mutation_enabled = true;
           }
@@ -35,6 +35,16 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }
 
+static int __dredd_replace_expr_int(std::function<int()> arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg();
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg());
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~(arg());
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 0;
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return -1;
+  return arg();
+}
+
 static float& __dredd_replace_binary_operator_SubAssign_float_double(std::function<float&()> arg1, std::function<double()> arg2, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg1() -= arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() += arg2();
@@ -42,6 +52,14 @@ static float& __dredd_replace_binary_operator_SubAssign_float_double(std::functi
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1() /= arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 3)) return arg1() *= arg2();
   return arg1() -= arg2();
+}
+
+static float __dredd_replace_expr_float(std::function<float()> arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg();
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return 0.0;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 1.0;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1.0;
+  return arg();
 }
 
 static double& __dredd_replace_binary_operator_AddAssign_double_double(std::function<double&()> arg1, std::function<double()> arg2, int local_mutation_id) {
@@ -99,8 +117,8 @@ int main() {
   double a = __dredd_replace_expr_double_one([&]() -> double { return 1.0; }, 0);
   double x = __dredd_replace_expr_double([&]() -> double { return 5.32; }, 2);
   if (!__dredd_enabled_mutation(12)) { __dredd_replace_binary_operator_AddAssign_double_double([&]() -> double& { return static_cast<double&>(x); } , [&]() -> double { return static_cast<double>(__dredd_replace_expr_double([&]() -> double { return 0.5; }, 5)); }, 8); }
-  float y = __dredd_replace_expr_double([&]() -> double { return 64343.7; }, 13);
+  float y = __dredd_replace_expr_float([&]() -> float { return 64343.7; }, 13);
   if (!__dredd_enabled_mutation(23)) { __dredd_replace_binary_operator_SubAssign_float_double([&]() -> float& { return static_cast<float&>(y); } , [&]() -> double { return static_cast<double>(__dredd_replace_expr_double([&]() -> double { return 1.2; }, 16)); }, 19); }
   double z = __dredd_replace_expr_double([&]() -> double { return static_cast<double>(__dredd_replace_binary_operator_Mul_double_double([&]() -> double { return static_cast<double>(__dredd_replace_expr_double([&]() -> double { return static_cast<double>(__dredd_replace_expr_double_lvalue([&]() -> double& { return static_cast<double&>(x); }, 24)); }, 26)); } , [&]() -> double { return static_cast<double>(__dredd_replace_expr_double([&]() -> double { return 5.5; }, 29)); }, 32)); }, 37);
-  if (!__dredd_enabled_mutation(58)) { return __dredd_replace_expr_double([&]() -> double { return static_cast<double>(__dredd_replace_binary_operator_Add_double_double([&]() -> double { return static_cast<double>(__dredd_replace_expr_double([&]() -> double { return static_cast<double>(__dredd_replace_expr_double_lvalue([&]() -> double& { return static_cast<double&>(z); }, 40)); }, 42)); } , [&]() -> double { return static_cast<double>(__dredd_replace_expr_double([&]() -> double { return static_cast<double>(__dredd_replace_expr_double_lvalue([&]() -> double& { return static_cast<double&>(x); }, 45)); }, 47)); }, 50)); }, 55); }
+  if (!__dredd_enabled_mutation(60)) { return __dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_binary_operator_Add_double_double([&]() -> double { return static_cast<double>(__dredd_replace_expr_double([&]() -> double { return static_cast<double>(__dredd_replace_expr_double_lvalue([&]() -> double& { return static_cast<double&>(z); }, 40)); }, 42)); } , [&]() -> double { return static_cast<double>(__dredd_replace_expr_double([&]() -> double { return static_cast<double>(__dredd_replace_expr_double_lvalue([&]() -> double& { return static_cast<double&>(x); }, 45)); }, 47)); }, 50)); }, 55); }
 }

--- a/test/single_file/initializer_list.cc.expected
+++ b/test/single_file/initializer_list.cc.expected
@@ -20,7 +20,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
         if (!token.empty()) {
           int value = std::stoi(token);
           int local_value = value - 0;
-          if (local_value >= 0 && local_value < 7) {
+          if (local_value >= 0 && local_value < 1) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
             some_mutation_enabled = true;
           }
@@ -37,14 +37,6 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }
 
-static int __dredd_replace_expr_int_uoi_optimised_zero(std::function<int()> arg, int local_mutation_id) {
-  if (!__dredd_some_mutation_enabled) return arg();
-  if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg());
-  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 1;
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
-  return arg();
-}
-
 struct A {
   size_t x;
   size_t y;
@@ -53,5 +45,5 @@ struct A {
 void foo(A arg);
 
 void bar() {
-  if (!__dredd_enabled_mutation(6)) { foo({static_cast<unsigned long>(__dredd_replace_expr_int_uoi_optimised_zero([&]() -> int { return 0; }, 0)), static_cast<unsigned long>(__dredd_replace_expr_int_uoi_optimised_zero([&]() -> int { return 0; }, 3))}); }
+  if (!__dredd_enabled_mutation(0)) { foo({0, 0}); }
 }

--- a/test/single_file/positive_int_as_minus_one.c.expected
+++ b/test/single_file/positive_int_as_minus_one.c.expected
@@ -16,7 +16,7 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
       while(token) {
         int value = atoi(token);
         int local_value = value - 0;
-        if (local_value >= 0 && local_value < 26) {
+        if (local_value >= 0 && local_value < 25) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
           some_mutation_enabled = 1;
         }
@@ -57,16 +57,6 @@ static unsigned int __dredd_replace_binary_operator_Sub_unsigned_int_unsigned_in
   return arg1 - arg2;
 }
 
-static long __dredd_replace_expr_long(long arg, int local_mutation_id) {
-  if (!__dredd_some_mutation_enabled) return arg;
-  if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg);
-  if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~(arg);
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 0;
-  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 1;
-  if (__dredd_enabled_mutation(local_mutation_id + 4)) return -1;
-  return arg;
-}
-
 static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg);
@@ -78,6 +68,6 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
 }
 
 int main() {
-  unsigned int x = __dredd_replace_expr_long(4294967295, 0);
-  int y = __dredd_replace_expr_unsigned_int(__dredd_replace_binary_operator_Sub_unsigned_int_unsigned_int(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 5), 7) , __dredd_replace_expr_int(20, 11), 16), 22);
+  unsigned int x = __dredd_replace_expr_unsigned_int(4294967295, 0);
+  int y = __dredd_replace_expr_int(__dredd_replace_binary_operator_Sub_unsigned_int_unsigned_int(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 4), 6) , __dredd_replace_expr_unsigned_int(20, 10), 14), 20);
 }

--- a/test/single_file/positive_int_as_minus_one.cc.expected
+++ b/test/single_file/positive_int_as_minus_one.cc.expected
@@ -18,7 +18,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
         if (!token.empty()) {
           int value = std::stoi(token);
           int local_value = value - 0;
-          if (local_value >= 0 && local_value < 26) {
+          if (local_value >= 0 && local_value < 25) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
             some_mutation_enabled = true;
           }
@@ -62,16 +62,6 @@ static unsigned int __dredd_replace_binary_operator_Sub_unsigned_int_unsigned_in
   return arg1() - arg2();
 }
 
-static long __dredd_replace_expr_long(std::function<long()> arg, int local_mutation_id) {
-  if (!__dredd_some_mutation_enabled) return arg();
-  if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg());
-  if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~(arg());
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 0;
-  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 1;
-  if (__dredd_enabled_mutation(local_mutation_id + 4)) return -1;
-  return arg();
-}
-
 static int __dredd_replace_expr_int(std::function<int()> arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg());
@@ -83,6 +73,6 @@ static int __dredd_replace_expr_int(std::function<int()> arg, int local_mutation
 }
 
 int main() {
-  unsigned int x = __dredd_replace_expr_long([&]() -> long { return 4294967295; }, 0);
-  int y = __dredd_replace_expr_unsigned_int([&]() -> unsigned int { return static_cast<unsigned int>(__dredd_replace_binary_operator_Sub_unsigned_int_unsigned_int([&]() -> unsigned int { return static_cast<unsigned int>(__dredd_replace_expr_unsigned_int([&]() -> unsigned int { return static_cast<unsigned int>(__dredd_replace_expr_unsigned_int_lvalue([&]() -> unsigned int& { return static_cast<unsigned int&>(x); }, 5)); }, 7)); } , [&]() -> unsigned int { return static_cast<unsigned int>(__dredd_replace_expr_int([&]() -> int { return 20; }, 11)); }, 16)); }, 22);
+  unsigned int x = __dredd_replace_expr_unsigned_int([&]() -> unsigned int { return 4294967295; }, 0);
+  int y = __dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_binary_operator_Sub_unsigned_int_unsigned_int([&]() -> unsigned int { return static_cast<unsigned int>(__dredd_replace_expr_unsigned_int([&]() -> unsigned int { return static_cast<unsigned int>(__dredd_replace_expr_unsigned_int_lvalue([&]() -> unsigned int& { return static_cast<unsigned int&>(x); }, 4)); }, 6)); } , [&]() -> unsigned int { return static_cast<unsigned int>(__dredd_replace_expr_unsigned_int([&]() -> unsigned int { return 20; }, 10)); }, 14)); }, 20);
 }

--- a/test/single_file/unary.c.expected
+++ b/test/single_file/unary.c.expected
@@ -122,7 +122,7 @@ static float __dredd_replace_unary_operator_PostDec_float(float* arg, int local_
   return (*arg)--;
 }
 
-static double __dredd_replace_expr_double(double arg, int local_mutation_id) {
+static float __dredd_replace_expr_float(float arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return 0.0;
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return 1.0;
@@ -132,7 +132,7 @@ static double __dredd_replace_expr_double(double arg, int local_mutation_id) {
 
 int main() {
   int x = __dredd_replace_expr_int(3, 0);
-  float y = __dredd_replace_expr_double(3.532, 5);
+  float y = __dredd_replace_expr_float(3.532, 5);
   if (!__dredd_enabled_mutation(12)) { __dredd_replace_unary_operator_PostInc_int(&(x), 8); }
   if (!__dredd_enabled_mutation(16)) { __dredd_replace_unary_operator_PostInc_float(&(y), 13); }
   if (!__dredd_enabled_mutation(21)) { __dredd_replace_unary_operator_PreInc_int(&(x), 17); }

--- a/test/single_file/unary.cc.expected
+++ b/test/single_file/unary.cc.expected
@@ -117,7 +117,7 @@ static float __dredd_replace_unary_operator_PostDec_float(std::function<float&()
   return arg()--;
 }
 
-static double __dredd_replace_expr_double(std::function<double()> arg, int local_mutation_id) {
+static float __dredd_replace_expr_float(std::function<float()> arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return 0.0;
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return 1.0;
@@ -127,7 +127,7 @@ static double __dredd_replace_expr_double(std::function<double()> arg, int local
 
 int main() {
   int x = __dredd_replace_expr_int([&]() -> int { return 3; }, 0);
-  float y = __dredd_replace_expr_double([&]() -> double { return 3.532; }, 5);
+  float y = __dredd_replace_expr_float([&]() -> float { return 3.532; }, 5);
   if (!__dredd_enabled_mutation(12)) { __dredd_replace_unary_operator_PostInc_int([&]() -> int& { return static_cast<int&>(x); }, 8); }
   if (!__dredd_enabled_mutation(16)) { __dredd_replace_unary_operator_PostInc_float([&]() -> float& { return static_cast<float&>(y); }, 13); }
   if (!__dredd_enabled_mutation(18)) { __dredd_replace_unary_operator_PreInc_int([&]() -> int& { return static_cast<int&>(x); }, 17); }

--- a/test/single_file/unary_logical_not.c.expected
+++ b/test/single_file/unary_logical_not.c.expected
@@ -18,7 +18,7 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
       while(token) {
         int value = atoi(token);
         int local_value = value - 0;
-        if (local_value >= 0 && local_value < 14) {
+        if (local_value >= 0 && local_value < 12) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
           some_mutation_enabled = 1;
         }
@@ -39,14 +39,6 @@ static int __dredd_replace_unary_operator_LNot__Bool(_Bool arg, int local_mutati
   return !arg;
 }
 
-static int __dredd_replace_expr_int_uoi_optimised_one(int arg, int local_mutation_id) {
-  if (!__dredd_some_mutation_enabled) return arg;
-  if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg);
-  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 0;
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
-  return arg;
-}
-
 static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg);
@@ -54,6 +46,12 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return 0;
   if (__dredd_enabled_mutation(local_mutation_id + 3)) return 1;
   if (__dredd_enabled_mutation(local_mutation_id + 4)) return -1;
+  return arg;
+}
+
+static _Bool __dredd_replace_expr__Bool_uoi_optimised_true(_Bool arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return 0;
   return arg;
 }
 
@@ -66,6 +64,6 @@ static _Bool __dredd_replace_expr__Bool(_Bool arg, int local_mutation_id) {
 }
 
 int main() {
-  bool y = __dredd_replace_expr_int_uoi_optimised_one(true, 0);
-  if (!__dredd_enabled_mutation(13)) { return __dredd_replace_expr_int(__dredd_replace_unary_operator_LNot__Bool(__dredd_replace_expr__Bool(y, 3), 6), 8); }
+  bool y = __dredd_replace_expr__Bool_uoi_optimised_true(true, 0);
+  if (!__dredd_enabled_mutation(11)) { return __dredd_replace_expr_int(__dredd_replace_unary_operator_LNot__Bool(__dredd_replace_expr__Bool(y, 1), 4), 6); }
 }

--- a/test/single_file/unary_logical_not.cc.expected
+++ b/test/single_file/unary_logical_not.cc.expected
@@ -18,7 +18,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
         if (!token.empty()) {
           int value = std::stoi(token);
           int local_value = value - 0;
-          if (local_value >= 0 && local_value < 10) {
+          if (local_value >= 0 && local_value < 12) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
             some_mutation_enabled = true;
           }
@@ -33,6 +33,16 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
     __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
+}
+
+static int __dredd_replace_expr_int(std::function<int()> arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg();
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg());
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~(arg());
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 0;
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return -1;
+  return arg();
 }
 
 static bool __dredd_replace_unary_operator_LNot_bool(std::function<bool()> arg, int local_mutation_id) {
@@ -58,5 +68,5 @@ static bool __dredd_replace_expr_bool(std::function<bool()> arg, int local_mutat
 
 int main() {
   bool y = __dredd_replace_expr_bool_uoi_optimised_true([&]() -> bool { return true; }, 0);
-  if (!__dredd_enabled_mutation(9)) { return __dredd_replace_expr_bool([&]() -> bool { return static_cast<bool>(__dredd_replace_unary_operator_LNot_bool([&]() -> bool { return static_cast<bool>(__dredd_replace_expr_bool([&]() -> bool { return static_cast<bool>(y); }, 1)); }, 4)); }, 6); }
+  if (!__dredd_enabled_mutation(11)) { return __dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_unary_operator_LNot_bool([&]() -> bool { return static_cast<bool>(__dredd_replace_expr_bool([&]() -> bool { return static_cast<bool>(y); }, 1)); }, 4)); }, 6); }
 }

--- a/test/single_file/unsigned_int.c.expected
+++ b/test/single_file/unsigned_int.c.expected
@@ -16,7 +16,7 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
       while(token) {
         int value = atoi(token);
         int local_value = value - 0;
-        if (local_value >= 0 && local_value < 20) {
+        if (local_value >= 0 && local_value < 18) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
           some_mutation_enabled = 1;
         }
@@ -28,6 +28,22 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
     __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64));
+}
+
+static unsigned int __dredd_replace_expr_unsigned_int_uoi_optimised_one(unsigned int arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 0;
+  return arg;
+}
+
+static unsigned int __dredd_replace_expr_unsigned_int(unsigned int arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 0;
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 1;
+  return arg;
 }
 
 static int __dredd_replace_unary_operator_Not_int(int arg, int local_mutation_id) {
@@ -52,14 +68,6 @@ static int __dredd_replace_expr_int_uoi_optimised_zero(int arg, int local_mutati
   return arg;
 }
 
-static int __dredd_replace_expr_int_uoi_optimised_one(int arg, int local_mutation_id) {
-  if (!__dredd_some_mutation_enabled) return arg;
-  if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg);
-  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 0;
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
-  return arg;
-}
-
 static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg);
@@ -71,6 +79,6 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
 }
 
 int main() {
-  unsigned int x = __dredd_replace_expr_int_uoi_optimised_one(__dredd_replace_unary_operator_LNot_int_zero(__dredd_replace_expr_int_uoi_optimised_zero(0, 0), 3), 5);
-  unsigned int y = __dredd_replace_expr_int(__dredd_replace_unary_operator_Not_int(__dredd_replace_expr_int(7, 8), 13), 15);
+  unsigned int x = __dredd_replace_expr_unsigned_int_uoi_optimised_one(__dredd_replace_unary_operator_LNot_int_zero(__dredd_replace_expr_int_uoi_optimised_zero(0, 0), 3), 5);
+  unsigned int y = __dredd_replace_expr_unsigned_int(__dredd_replace_unary_operator_Not_int(__dredd_replace_expr_int(7, 7), 12), 14);
 }

--- a/test/single_file/unsigned_int.cc.expected
+++ b/test/single_file/unsigned_int.cc.expected
@@ -18,7 +18,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
         if (!token.empty()) {
           int value = std::stoi(token);
           int local_value = value - 0;
-          if (local_value >= 0 && local_value < 18) {
+          if (local_value >= 0 && local_value < 16) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
             some_mutation_enabled = true;
           }
@@ -35,19 +35,27 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }
 
+static unsigned int __dredd_replace_expr_unsigned_int_uoi_optimised_one(std::function<unsigned int()> arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg();
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg());
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 0;
+  return arg();
+}
+
+static unsigned int __dredd_replace_expr_unsigned_int(std::function<unsigned int()> arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg();
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg());
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~(arg());
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 0;
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 1;
+  return arg();
+}
+
 static int __dredd_replace_unary_operator_Not_int(std::function<int()> arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return ~arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return -arg();
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return !arg();
   return ~arg();
-}
-
-static int __dredd_replace_expr_int_uoi_optimised_zero(std::function<int()> arg, int local_mutation_id) {
-  if (!__dredd_some_mutation_enabled) return arg();
-  if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg());
-  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 1;
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
-  return arg();
 }
 
 static int __dredd_replace_expr_int(std::function<int()> arg, int local_mutation_id) {
@@ -67,13 +75,13 @@ static bool __dredd_replace_unary_operator_LNot_bool_zero(std::function<bool()> 
   return !arg();
 }
 
-static bool __dredd_replace_expr_bool_uoi_optimised_true(std::function<bool()> arg, int local_mutation_id) {
+static bool __dredd_replace_expr_bool_uoi_optimised_false(std::function<bool()> arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg();
-  if (__dredd_enabled_mutation(local_mutation_id + 0)) return false;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return true;
   return arg();
 }
 
 int main() {
-  unsigned int x = __dredd_replace_expr_bool_uoi_optimised_true([&]() -> bool { return __dredd_replace_unary_operator_LNot_bool_zero([&]() -> bool { return __dredd_replace_expr_int_uoi_optimised_zero([&]() -> int { return 0; }, 0); }, 3); }, 5);
-  unsigned int y = __dredd_replace_expr_int([&]() -> int { return __dredd_replace_unary_operator_Not_int([&]() -> int { return __dredd_replace_expr_int([&]() -> int { return 7; }, 6); }, 11); }, 13);
+  unsigned int x = __dredd_replace_expr_unsigned_int_uoi_optimised_one([&]() -> unsigned int { return __dredd_replace_unary_operator_LNot_bool_zero([&]() -> bool { return __dredd_replace_expr_bool_uoi_optimised_false([&]() -> bool { return 0; }, 0); }, 1); }, 3);
+  unsigned int y = __dredd_replace_expr_unsigned_int([&]() -> unsigned int { return __dredd_replace_unary_operator_Not_int([&]() -> int { return __dredd_replace_expr_int([&]() -> int { return 7; }, 5); }, 10); }, 12);
 }


### PR DESCRIPTION
This change means that only the outermost expression in a nest of casts will be mutated, rather than the target of the innermost cast. In an l-value to r-value cast, both the result of the cast and the cast operand are still mutated.

Fixes #115.