### PR TITLE
Rename variables

### DIFF
--- a/src/libdredd/src/mutate_ast_consumer.cc
+++ b/src/libdredd/src/mutate_ast_consumer.cc
@@ -100,24 +100,24 @@ void MutateAstConsumer::HandleTranslationUnit(clang::ASTContext& ast_context) {
   sorted_dredd_declarations.insert(dredd_declarations.begin(),
                                    dredd_declarations.end());
   for (const auto& decl : sorted_dredd_declarations) {
-    bool result = rewriter_.InsertTextBefore(
+    bool rewriter_result = rewriter_.InsertTextBefore(
         start_location_of_first_decl_in_source_file, decl);
-    (void)result;  // Keep release-mode compilers happy.
-    assert(!result && "Rewrite failed.\n");
+    (void)rewriter_result;  // Keep release-mode compilers happy.
+    assert(!rewriter_result && "Rewrite failed.\n");
   }
 
   std::string dredd_prelude = compiler_instance_.getLangOpts().CPlusPlus
                                   ? GetDreddPreludeCpp(initial_mutation_id)
                                   : GetDreddPreludeC(initial_mutation_id);
 
-  bool result = rewriter_.InsertTextBefore(
+  bool rewriter_result = rewriter_.InsertTextBefore(
       visitor_->GetStartLocationOfFirstDeclInSourceFile(), dredd_prelude);
-  (void)result;  // Keep release-mode compilers happy.
-  assert(!result && "Rewrite failed.\n");
+  (void)rewriter_result;  // Keep release-mode compilers happy.
+  assert(!rewriter_result && "Rewrite failed.\n");
 
-  result = rewriter_.overwriteChangedFiles();
-  (void)result;  // Keep release mode compilers happy
-  assert(!result && "Something went wrong emitting rewritten files.");
+  rewriter_result = rewriter_.overwriteChangedFiles();
+  (void)rewriter_result;  // Keep release mode compilers happy
+  assert(!rewriter_result && "Something went wrong emitting rewritten files.");
 }
 
 std::string MutateAstConsumer::GetDreddPreludeCpp(

--- a/src/libdredd/src/mutation_remove_statement.cc
+++ b/src/libdredd/src/mutation_remove_statement.cc
@@ -80,11 +80,11 @@ void MutationRemoveStatement::Apply(
   // Subtracting |first_mutation_id_in_file| turns the global mutation id,
   // |mutation_id|, into a file-local mutation id.
   const int local_mutation_id = mutation_id - first_mutation_id_in_file;
-  bool result = rewriter.InsertTextBefore(
+  bool rewriter_result = rewriter.InsertTextBefore(
       source_range.getBegin(), "if (!__dredd_enabled_mutation(" +
                                    std::to_string(local_mutation_id) + ")) { ");
-  assert(!result && "Rewrite failed.\n");
-  result = rewriter.InsertTextAfterToken(
+  assert(!rewriter_result && "Rewrite failed.\n");
+  rewriter_result = rewriter.InsertTextAfterToken(
       source_range.getEnd(),
       // If the source range was extended with a comment but not with a
       // semi-colon, it is possible that the end of the source range is on
@@ -95,8 +95,8 @@ void MutationRemoveStatement::Apply(
       std::string(
           ((is_extended_with_comment && !is_extended_with_semi) ? "\n" : " ")) +
           "}");
-  assert(!result && "Rewrite failed.\n");
-  (void)result;  // Keep release-mode compilers happy.
+  assert(!rewriter_result && "Rewrite failed.\n");
+  (void)rewriter_result;  // Keep release-mode compilers happy.
   mutation_id++;
 }
 

--- a/src/libdredd/src/mutation_replace_binary_operator.cc
+++ b/src/libdredd/src/mutation_replace_binary_operator.cc
@@ -624,19 +624,19 @@ void MutationReplaceBinaryOperator::ReplaceOperator(
     rhs_suffix = ", " + std::to_string(local_mutation_id) + ")";
   }
   // The prefixes and suffixes are ready, so make the relevant insertions.
-  bool result = rewriter.InsertTextBefore(
+  bool rewriter_result = rewriter.InsertTextBefore(
       lhs_source_range_in_main_file.getBegin(), lhs_prefix);
-  assert(!result && "Rewrite failed.\n");
-  result = rewriter.InsertTextAfterToken(lhs_source_range_in_main_file.getEnd(),
-                                         lhs_suffix);
-  assert(!result && "Rewrite failed.\n");
-  result = rewriter.InsertTextBefore(rhs_source_range_in_main_file.getBegin(),
-                                     rhs_prefix);
-  assert(!result && "Rewrite failed.\n");
-  result = rewriter.InsertTextAfterToken(rhs_source_range_in_main_file.getEnd(),
-                                         rhs_suffix);
-  assert(!result && "Rewrite failed.\n");
-  (void)result;  // Keep release-mode compilers happy.
+  assert(!rewriter_result && "Rewrite failed.\n");
+  rewriter_result = rewriter.InsertTextAfterToken(
+      lhs_source_range_in_main_file.getEnd(), lhs_suffix);
+  assert(!rewriter_result && "Rewrite failed.\n");
+  rewriter_result = rewriter.InsertTextBefore(
+      rhs_source_range_in_main_file.getBegin(), rhs_prefix);
+  assert(!rewriter_result && "Rewrite failed.\n");
+  rewriter_result = rewriter.InsertTextAfterToken(
+      rhs_source_range_in_main_file.getEnd(), rhs_suffix);
+  assert(!rewriter_result && "Rewrite failed.\n");
+  (void)rewriter_result;  // Keep release-mode compilers happy.
 }
 
 void MutationReplaceBinaryOperator::HandleCLogicalOperator(

--- a/src/libdredd/src/mutation_replace_unary_operator.cc
+++ b/src/libdredd/src/mutation_replace_unary_operator.cc
@@ -410,13 +410,13 @@ void MutationReplaceUnaryOperator::Apply(
     suffix.append(", " + std::to_string(local_mutation_id) + ")");
   }
   // The prefix and suffix are ready, so make the relevant insertions.
-  bool result = rewriter.InsertTextBefore(
+  bool rewriter_result = rewriter.InsertTextBefore(
       unary_operator_source_range_in_main_file.getBegin(), prefix);
-  assert(!result && "Rewrite failed.\n");
-  result = rewriter.InsertTextAfterToken(
+  assert(!rewriter_result && "Rewrite failed.\n");
+  rewriter_result = rewriter.InsertTextAfterToken(
       unary_operator_source_range_in_main_file.getEnd(), suffix);
-  assert(!result && "Rewrite failed.\n");
-  (void)result;  // Keep release-mode compilers happy.
+  assert(!rewriter_result && "Rewrite failed.\n");
+  (void)rewriter_result;  // Keep release-mode compilers happy.
 
   std::string new_function =
       GenerateMutatorFunction(ast_context, new_function_name, result_type,


### PR DESCRIPTION
Renames the "result" variable used to check the rewriter has succeeded to "rewriter_result", since "result" is usually reserved for a function's result.