### PR TITLE
Rename MutationRemoveStatement to MutationRemoveStmt

### DIFF
--- a/src/libdredd/CMakeLists.txt
+++ b/src/libdredd/CMakeLists.txt
@@ -18,7 +18,7 @@ add_library(
   libdredd STATIC
   include/libdredd/mutation.h
   include/libdredd/mutation_info.h
-  include/libdredd/mutation_remove_statement.h
+  include/libdredd/mutation_remove_stmt.h
   include/libdredd/mutation_replace_binary_operator.h
   include/libdredd/mutation_replace_expr.h
   include/libdredd/mutation_replace_unary_operator.h
@@ -31,7 +31,7 @@ add_library(
   src/mutate_visitor.cc
   src/mutation.cc
   src/mutation_info.cc
-  src/mutation_remove_statement.cc
+  src/mutation_remove_stmt.cc
   src/mutation_replace_binary_operator.cc
   src/mutation_replace_expr.cc
   src/mutation_replace_unary_operator.cc

--- a/src/libdredd/include/libdredd/mutation_remove_stmt.h
+++ b/src/libdredd/include/libdredd/mutation_remove_stmt.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBDREDD_MUTATION_REMOVE_STATEMENT_H
-#define LIBDREDD_MUTATION_REMOVE_STATEMENT_H
+#ifndef LIBDREDD_MUTATION_REMOVE_STMT_H
+#define LIBDREDD_MUTATION_REMOVE_STMT_H
 
 #include <string>
 #include <unordered_set>
@@ -26,9 +26,9 @@
 
 namespace dredd {
 
-class MutationRemoveStatement : public Mutation {
+class MutationRemoveStmt : public Mutation {
  public:
-  explicit MutationRemoveStatement(const clang::Stmt& statement);
+  explicit MutationRemoveStmt(const clang::Stmt& stmt);
 
   void Apply(
       clang::ASTContext& ast_context, const clang::Preprocessor& preprocessor,
@@ -37,9 +37,9 @@ class MutationRemoveStatement : public Mutation {
       std::unordered_set<std::string>& dredd_declarations) const override;
 
  private:
-  const clang::Stmt& statement_;
+  const clang::Stmt& stmt_;
 };
 
 }  // namespace dredd
 
-#endif  // LIBDREDD_MUTATION_REMOVE_STATEMENT_H
+#endif  // LIBDREDD_MUTATION_REMOVE_STMT_H

--- a/src/libdredd/src/mutate_visitor.cc
+++ b/src/libdredd/src/mutate_visitor.cc
@@ -38,7 +38,7 @@
 #include "clang/Basic/SourceManager.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "libdredd/mutation.h"
-#include "libdredd/mutation_remove_statement.h"
+#include "libdredd/mutation_remove_stmt.h"
 #include "libdredd/mutation_replace_binary_operator.h"
 #include "libdredd/mutation_replace_expr.h"
 #include "libdredd/mutation_replace_unary_operator.h"
@@ -483,7 +483,7 @@ bool MutateVisitor::TraverseCompoundStmt(clang::CompoundStmt* compound_stmt) {
            "Statements can only be removed if they are nested in some "
            "declaration.");
     mutation_tree_path_.back()->AddMutation(
-        std::make_unique<MutationRemoveStatement>(*stmt));
+        std::make_unique<MutationRemoveStmt>(*stmt));
   }
   return true;
 }

--- a/src/libdredd/src/mutation_remove_stmt.cc
+++ b/src/libdredd/src/mutation_remove_stmt.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "libdredd/mutation_remove_statement.h"
+#include "libdredd/mutation_remove_stmt.h"
 
 #include <cassert>
 #include <string>
@@ -29,10 +29,9 @@
 
 namespace dredd {
 
-MutationRemoveStatement::MutationRemoveStatement(const clang::Stmt& statement)
-    : statement_(statement) {}
+MutationRemoveStmt::MutationRemoveStmt(const clang::Stmt& stmt) : stmt_(stmt) {}
 
-void MutationRemoveStatement::Apply(
+void MutationRemoveStmt::Apply(
     clang::ASTContext& ast_context, const clang::Preprocessor& preprocessor,
     bool optimise_mutations, int first_mutation_id_in_file, int& mutation_id,
     clang::Rewriter& rewriter,
@@ -40,7 +39,7 @@ void MutationRemoveStatement::Apply(
   (void)dredd_declarations;  // Unused.
   (void)optimise_mutations;  // Unused.
   clang::CharSourceRange source_range = clang::CharSourceRange::getTokenRange(
-      GetSourceRangeInMainFile(preprocessor, statement_));
+      GetSourceRangeInMainFile(preprocessor, stmt_));
 
   // If the statement is followed immediately by a semi-colon, possibly with
   // intervening comments, that semi-colon should be part of the code that is

--- a/src/libdreddtest/CMakeLists.txt
+++ b/src/libdreddtest/CMakeLists.txt
@@ -22,11 +22,9 @@ endif()
 
 add_executable(
   libdreddtest
-  include_private/include/libdreddtest/gtest.h
-  src/mutation_remove_statement_test.cc
+  include_private/include/libdreddtest/gtest.h src/mutation_remove_stmt_test.cc
   src/mutation_replace_binary_operator_test.cc
-  src/mutation_replace_expression_test.cc
-  src/mutation_replace_unary_operator_test.cc)
+  src/mutation_replace_expr_test.cc src/mutation_replace_unary_operator_test.cc)
 
 target_link_libraries(libdreddtest PRIVATE libdredd gtest_main)
 target_include_directories(libdreddtest PRIVATE include_private/include)

--- a/src/libdreddtest/src/mutation_remove_stmt_test.cc
+++ b/src/libdreddtest/src/mutation_remove_stmt_test.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "libdredd/mutation_remove_statement.h"
+#include "libdredd/mutation_remove_stmt.h"
 
 #include <functional>
 #include <memory>
@@ -36,9 +36,9 @@
 namespace dredd {
 namespace {
 
-void TestRemoval(const std::string& original, const std::string& expected,
-                 std::function<MutationRemoveStatement(clang::ASTContext&)>
-                     mutation_supplier) {
+void TestRemoval(
+    const std::string& original, const std::string& expected,
+    std::function<MutationRemoveStmt(clang::ASTContext&)> mutation_supplier) {
   auto ast_unit = clang::tooling::buildASTFromCodeWithArgs(original, {"-w"});
   ASSERT_FALSE(ast_unit->getDiagnostics().hasErrorOccurred());
   clang::Rewriter rewriter(ast_unit->getSourceManager(),
@@ -56,124 +56,120 @@ void TestRemoval(const std::string& original, const std::string& expected,
   ASSERT_EQ(expected, rewritten_text);
 }
 
-TEST(MutationRemoveStatementTest, BasicTest) {
+TEST(MutationRemoveStmtTest, BasicTest) {
   std::string original = "void foo() { 1 + 2; }";
   std::string expected =
       R"(void foo() { if (!__dredd_enabled_mutation(0)) { 1 + 2; } })";
-  std::function<MutationRemoveStatement(clang::ASTContext&)> mutation_supplier =
-      [](clang::ASTContext& ast_context) -> MutationRemoveStatement {
+  std::function<MutationRemoveStmt(clang::ASTContext&)> mutation_supplier =
+      [](clang::ASTContext& ast_context) -> MutationRemoveStmt {
     auto statement = clang::ast_matchers::match(
         clang::ast_matchers::binaryOperator().bind("op"), ast_context);
     EXPECT_EQ(1, statement.size());
-    return MutationRemoveStatement(
+    return MutationRemoveStmt(
         *statement[0].getNodeAs<clang::BinaryOperator>("op"));
   };
   TestRemoval(original, expected, mutation_supplier);
 }
 
-TEST(MutationRemoveStatementTest, RemoveIfStatement) {
+TEST(MutationRemoveStmtTest, RemoveIfStatement) {
   std::string original = "void foo() { if (true) { } }";
   std::string expected =
       R"(void foo() { if (!__dredd_enabled_mutation(0)) { if (true) { } } })";
-  std::function<MutationRemoveStatement(clang::ASTContext&)> mutation_supplier =
-      [](clang::ASTContext& ast_context) -> MutationRemoveStatement {
+  std::function<MutationRemoveStmt(clang::ASTContext&)> mutation_supplier =
+      [](clang::ASTContext& ast_context) -> MutationRemoveStmt {
     auto statement = clang::ast_matchers::match(
         clang::ast_matchers::ifStmt().bind("if"), ast_context);
     EXPECT_EQ(1, statement.size());
-    return MutationRemoveStatement(
-        *statement[0].getNodeAs<clang::IfStmt>("if"));
+    return MutationRemoveStmt(*statement[0].getNodeAs<clang::IfStmt>("if"));
   };
   TestRemoval(original, expected, mutation_supplier);
 }
 
-TEST(MutationRemoveStatementTest, RemoveIfStatementWithTrailingSemi) {
+TEST(MutationRemoveStmtTest, RemoveIfStatementWithTrailingSemi) {
   std::string original = "void foo() { if (true) { }; }";
   std::string expected =
       R"(void foo() { if (!__dredd_enabled_mutation(0)) { if (true) { }; } })";
-  std::function<MutationRemoveStatement(clang::ASTContext&)> mutation_supplier =
-      [](clang::ASTContext& ast_context) -> MutationRemoveStatement {
+  std::function<MutationRemoveStmt(clang::ASTContext&)> mutation_supplier =
+      [](clang::ASTContext& ast_context) -> MutationRemoveStmt {
     auto statement = clang::ast_matchers::match(
         clang::ast_matchers::ifStmt().bind("if"), ast_context);
     EXPECT_EQ(1, statement.size());
-    return MutationRemoveStatement(
-        *statement[0].getNodeAs<clang::IfStmt>("if"));
+    return MutationRemoveStmt(*statement[0].getNodeAs<clang::IfStmt>("if"));
   };
   TestRemoval(original, expected, mutation_supplier);
 }
 
-TEST(MutationRemoveStatementTest, RemoveIfStatementWithTrailingSemis) {
+TEST(MutationRemoveStmtTest, RemoveIfStatementWithTrailingSemis) {
   std::string original = "void foo() { if (true) { };; }";
   std::string expected =
       R"(void foo() { if (!__dredd_enabled_mutation(0)) { if (true) { }; }; })";
-  std::function<MutationRemoveStatement(clang::ASTContext&)> mutation_supplier =
-      [](clang::ASTContext& ast_context) -> MutationRemoveStatement {
+  std::function<MutationRemoveStmt(clang::ASTContext&)> mutation_supplier =
+      [](clang::ASTContext& ast_context) -> MutationRemoveStmt {
     auto statement = clang::ast_matchers::match(
         clang::ast_matchers::ifStmt().bind("if"), ast_context);
     EXPECT_EQ(1, statement.size());
-    return MutationRemoveStatement(
-        *statement[0].getNodeAs<clang::IfStmt>("if"));
+    return MutationRemoveStmt(*statement[0].getNodeAs<clang::IfStmt>("if"));
   };
   TestRemoval(original, expected, mutation_supplier);
 }
 
-TEST(MutationRemoveStatementTest, RemoveIfStatementWithoutBraces) {
+TEST(MutationRemoveStmtTest, RemoveIfStatementWithoutBraces) {
   std::string original = "void foo() { if (true) return; }";
   std::string expected =
       R"(void foo() { if (!__dredd_enabled_mutation(0)) { if (true) return; } })";
-  std::function<MutationRemoveStatement(clang::ASTContext&)> mutation_supplier =
-      [](clang::ASTContext& ast_context) -> MutationRemoveStatement {
+  std::function<MutationRemoveStmt(clang::ASTContext&)> mutation_supplier =
+      [](clang::ASTContext& ast_context) -> MutationRemoveStmt {
     auto statement = clang::ast_matchers::match(
         clang::ast_matchers::ifStmt().bind("if"), ast_context);
     EXPECT_EQ(1, statement.size());
-    return MutationRemoveStatement(
-        *statement[0].getNodeAs<clang::IfStmt>("if"));
+    return MutationRemoveStmt(*statement[0].getNodeAs<clang::IfStmt>("if"));
   };
   TestRemoval(original, expected, mutation_supplier);
 }
 
-TEST(MutationRemoveStatementTest, RemoveReturnStmt) {
+TEST(MutationRemoveStmtTest, RemoveReturnStmt) {
   std::string original = "void foo() { return; }";
   std::string expected =
       R"(void foo() { if (!__dredd_enabled_mutation(0)) { return; } })";
-  std::function<MutationRemoveStatement(clang::ASTContext&)> mutation_supplier =
-      [](clang::ASTContext& ast_context) -> MutationRemoveStatement {
+  std::function<MutationRemoveStmt(clang::ASTContext&)> mutation_supplier =
+      [](clang::ASTContext& ast_context) -> MutationRemoveStmt {
     auto statement = clang::ast_matchers::match(
         clang::ast_matchers::returnStmt().bind("return"), ast_context);
     EXPECT_EQ(1, statement.size());
-    return MutationRemoveStatement(
+    return MutationRemoveStmt(
         *statement[0].getNodeAs<clang::ReturnStmt>("return"));
   };
   TestRemoval(original, expected, mutation_supplier);
 }
 
-TEST(MutationRemoveStatementTest, RemoveBreakStmt) {
+TEST(MutationRemoveStmtTest, RemoveBreakStmt) {
   std::string original = "void foo() { while (true) { break; } }";
   std::string expected =
       R"(void foo() { while (true) { if (!__dredd_enabled_mutation(0)) { break; } } })";
-  std::function<MutationRemoveStatement(clang::ASTContext&)> mutation_supplier =
-      [](clang::ASTContext& ast_context) -> MutationRemoveStatement {
+  std::function<MutationRemoveStmt(clang::ASTContext&)> mutation_supplier =
+      [](clang::ASTContext& ast_context) -> MutationRemoveStmt {
     auto statement = clang::ast_matchers::match(
         clang::ast_matchers::breakStmt().bind("break"), ast_context);
     EXPECT_EQ(1, statement.size());
-    return MutationRemoveStatement(
+    return MutationRemoveStmt(
         *statement[0].getNodeAs<clang::BreakStmt>("break"));
   };
   TestRemoval(original, expected, mutation_supplier);
 }
 
-TEST(MutationRemoveStatementTest, RemoveMacroStmt) {
+TEST(MutationRemoveStmtTest, RemoveMacroStmt) {
   std::string original =
       "#define ASSIGN(A, B) A = B\n"
       "void foo() { int x; ASSIGN(x, 1); }";
   std::string expected =
       R"(#define ASSIGN(A, B) A = B
 void foo() { int x; if (!__dredd_enabled_mutation(0)) { ASSIGN(x, 1); } })";
-  std::function<MutationRemoveStatement(clang::ASTContext&)> mutation_supplier =
-      [](clang::ASTContext& ast_context) -> MutationRemoveStatement {
+  std::function<MutationRemoveStmt(clang::ASTContext&)> mutation_supplier =
+      [](clang::ASTContext& ast_context) -> MutationRemoveStmt {
     auto statement = clang::ast_matchers::match(
         clang::ast_matchers::binaryOperator().bind("assign"), ast_context);
     EXPECT_EQ(1, statement.size());
-    return MutationRemoveStatement(
+    return MutationRemoveStmt(
         *statement[0].getNodeAs<clang::BinaryOperator>("assign"));
   };
   TestRemoval(original, expected, mutation_supplier);

--- a/src/libdreddtest/src/mutation_replace_expr_test.cc
+++ b/src/libdreddtest/src/mutation_replace_expr_test.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "libdredd/mutation_replace_expr.h"
+
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -27,7 +29,6 @@
 #include "clang/Rewrite/Core/RewriteBuffer.h"
 #include "clang/Rewrite/Core/Rewriter.h"
 #include "clang/Tooling/Tooling.h"
-#include "libdredd/mutation_replace_expr.h"
 #include "libdreddtest/gtest.h"
 #include "llvm/ADT/SmallVector.h"
 
@@ -70,7 +71,7 @@ void TestReplacement(const std::string& original, const std::string& expected,
   ASSERT_EQ(expected, rewritten_text);
 }
 
-TEST(MutationReplaceExpressionTest, MutateSignedConstants) {
+TEST(MutationReplaceExprTest, MutateSignedConstants) {
   std::string original = "void foo() { 2; }";
   std::string expected =
       "void foo() { __dredd_replace_expr_int([&]() -> int { "
@@ -92,7 +93,7 @@ TEST(MutationReplaceExpressionTest, MutateSignedConstants) {
                   expected_dredd_declaration, 0);
 }
 
-TEST(MutationReplaceExpressionTest, MutateUnsignedConstants) {
+TEST(MutationReplaceExprTest, MutateUnsignedConstants) {
   std::string original = "void foo() { unsigned int x = 2; }";
   std::string expected =
       "void foo() { unsigned int x = __dredd_replace_expr_unsigned_int([&]() "
@@ -114,7 +115,7 @@ TEST(MutationReplaceExpressionTest, MutateUnsignedConstants) {
                   expected_dredd_declaration, 0);
 }
 
-TEST(MutationReplaceExpressionTest, MutateFloatConstants) {
+TEST(MutationReplaceExprTest, MutateFloatConstants) {
   std::string original = "void foo() { 2.523; }";
   std::string expected =
       "void foo() { __dredd_replace_expr_double([&]() -> double { "
@@ -134,7 +135,7 @@ TEST(MutationReplaceExpressionTest, MutateFloatConstants) {
                   expected_dredd_declaration, 0);
 }
 
-TEST(MutationReplaceExpressionTest, MutateLValues) {
+TEST(MutationReplaceExprTest, MutateLValues) {
   std::string original =
       R"(void foo() {
   int x;
@@ -161,7 +162,7 @@ TEST(MutationReplaceExpressionTest, MutateLValues) {
                   expected_dredd_declaration, 2);
 }
 
-TEST(MutationReplaceExpressionTest, MutateFunctionArgs) {
+TEST(MutationReplaceExprTest, MutateFunctionArgs) {
   std::string original =
       R"(
 int neg(int x);


### PR DESCRIPTION
In the expression-related mutations, "expr" is used instead of "expression", which matches Clang. This change brings "statement" in to line by changing it to "stmt".