### PR TITLE
Remove unnecessary "unused" casts

### DIFF
--- a/src/libdredd/src/mutation_remove_statement.cc
+++ b/src/libdredd/src/mutation_remove_statement.cc
@@ -37,8 +37,8 @@ void MutationRemoveStatement::Apply(
     bool optimise_mutations, int first_mutation_id_in_file, int& mutation_id,
     clang::Rewriter& rewriter,
     std::unordered_set<std::string>& dredd_declarations) const {
-  (void)dredd_declarations;  // Unused
-  (void)optimise_mutations;  // Unused
+  (void)dredd_declarations;  // Unused.
+  (void)optimise_mutations;  // Unused.
   clang::CharSourceRange source_range = clang::CharSourceRange::getTokenRange(
       GetSourceRangeInMainFile(preprocessor, statement_));
 

--- a/src/libdredd/src/mutation_replace_expr.cc
+++ b/src/libdredd/src/mutation_replace_expr.cc
@@ -360,8 +360,6 @@ void MutationReplaceExpr::Apply(
     bool optimise_mutations, int first_mutation_id_in_file, int& mutation_id,
     clang::Rewriter& rewriter,
     std::unordered_set<std::string>& dredd_declarations) const {
-  (void)optimise_mutations;  // Unused
-
   std::string new_function_name =
       GetFunctionName(optimise_mutations, ast_context);
   std::string result_type = expr_.getType()

--- a/src/libdredd/src/mutation_replace_unary_operator.cc
+++ b/src/libdredd/src/mutation_replace_unary_operator.cc
@@ -337,8 +337,6 @@ void MutationReplaceUnaryOperator::Apply(
     bool optimise_mutations, int first_mutation_id_in_file, int& mutation_id,
     clang::Rewriter& rewriter,
     std::unordered_set<std::string>& dredd_declarations) const {
-  (void)optimise_mutations;  // Unused
-
   std::string new_function_name =
       GetFunctionName(optimise_mutations, ast_context);
   std::string result_type = unary_operator_.getType()

--- a/src/libdredd/src/new_mutate_frontend_action_factory.cc
+++ b/src/libdredd/src/new_mutate_frontend_action_factory.cc
@@ -45,7 +45,7 @@ class MutateFrontendAction : public clang::ASTFrontendAction {
       llvm::StringRef file) override;
 
   bool BeginInvocation(clang::CompilerInstance& compiler_instance) override {
-    (void)compiler_instance;  // Not used.
+    (void)compiler_instance;  // Unused.
     bool input_exists = !getCurrentInput().isEmpty();
     (void)input_exists;  // Keep release-mode compilers happy.
     assert(input_exists && "No current file.");
@@ -102,7 +102,7 @@ NewMutateFrontendActionFactory(bool optimise_mutations, bool dump_asts,
 
 std::unique_ptr<clang::ASTConsumer> MutateFrontendAction::CreateASTConsumer(
     clang::CompilerInstance& compiler_instance, llvm::StringRef file) {
-  (void)file;  // Unused
+  (void)file;  // Unused.
   return std::make_unique<MutateAstConsumer>(compiler_instance,
                                              optimise_mutations_, dump_asts_,
                                              mutation_id_, mutation_info_);


### PR DESCRIPTION
Avoids a couple of (void) casts for parameters that are now used. Tidies up punctuation in related comments.