### PR TITLE
Update CMake formatting to include googletest

### DIFF
--- a/scripts/dredd_cmake_files.sh
+++ b/scripts/dredd_cmake_files.sh
@@ -22,3 +22,4 @@ test -d src/
 
 find ./src/ -iname 'CMakeLists.txt' -print
 echo ./CMakeLists.txt
+echo ./third_party/googletest/CMakeLists.txt

--- a/third_party/googletest/CMakeLists.txt
+++ b/third_party/googletest/CMakeLists.txt
@@ -14,42 +14,36 @@
 
 cmake_minimum_required(VERSION 3.13)
 
-##
-## Project: googletest-distribution
-##
-## Provides targets: gtest, gtest_main.
-##
+#
+# Project: googletest-distribution
+#
+# Provides targets: gtest, gtest_main.
+#
 if(NOT TARGET gtest)
-    if(NOT IS_DIRECTORY ${DREDD_GOOGLETEST_REPO_DIR})
-        message(
-            FATAL_ERROR
-            "Could not find googletest-distribution at ${DREDD_GOOGLETEST_REPO_DIR}. "
-            "Try fetching submodules or set DREDD_GOOGLETEST_REPO_DIR.")
-    endif()
+  if(NOT IS_DIRECTORY ${DREDD_GOOGLETEST_REPO_DIR})
+    message(
+      FATAL_ERROR
+        "Could not find googletest-distribution at ${DREDD_GOOGLETEST_REPO_DIR}. "
+        "Try fetching submodules or set DREDD_GOOGLETEST_REPO_DIR.")
+  endif()
 
-    set(
-        BUILD_GMOCK
-        OFF
-        CACHE
-        BOOL
-        "Builds the googlemock subproject"
-    )
+  set(BUILD_GMOCK
+      OFF
+      CACHE BOOL "Builds the googlemock subproject")
 
-    set(
-        INSTALL_GTEST
-        OFF
-        CACHE
+  set(INSTALL_GTEST
+      OFF
+      CACHE
         BOOL
         "Enable installation of googletest. (Projects embedding googletest may want to turn this OFF.)"
-    )
+  )
 
-    set(
-        gtest_force_shared_crt
-        ON
-        CACHE
+  set(gtest_force_shared_crt
+      ON
+      CACHE
         BOOL
         "Use shared (DLL) run-time lib even when Google Test is built as static lib."
-    )
+  )
 
-    add_subdirectory(${DREDD_GOOGLETEST_REPO_DIR} EXCLUDE_FROM_ALL)
+  add_subdirectory(${DREDD_GOOGLETEST_REPO_DIR} EXCLUDE_FROM_ALL)
 endif()

--- a/third_party/googletest/CMakeLists.txt
+++ b/third_party/googletest/CMakeLists.txt
@@ -23,7 +23,8 @@ if(NOT TARGET gtest)
   if(NOT IS_DIRECTORY ${DREDD_GOOGLETEST_REPO_DIR})
     message(
       FATAL_ERROR
-        "Could not find googletest-distribution at ${DREDD_GOOGLETEST_REPO_DIR}. "
+        "Could not find googletest-distribution at \
+${DREDD_GOOGLETEST_REPO_DIR}. "
         "Try fetching submodules or set DREDD_GOOGLETEST_REPO_DIR.")
   endif()
 
@@ -33,17 +34,14 @@ if(NOT TARGET gtest)
 
   set(INSTALL_GTEST
       OFF
-      CACHE
-        BOOL
-        "Enable installation of googletest. (Projects embedding googletest may want to turn this OFF.)"
-  )
+      CACHE BOOL "Enable installation of googletest. \
+(Projects embedding googletest may want to turn this OFF.)")
 
+  # cmake-lint: disable=C0103
   set(gtest_force_shared_crt
       ON
-      CACHE
-        BOOL
-        "Use shared (DLL) run-time lib even when Google Test is built as static lib."
-  )
+      CACHE BOOL "Use shared (DLL) run-time lib even when Google Test \
+is built as static lib.")
 
   add_subdirectory(${DREDD_GOOGLETEST_REPO_DIR} EXCLUDE_FROM_ALL)
 endif()


### PR DESCRIPTION
Includes the intermediate CMakeLists.txt file for the googletest third party repo in the files that are checked for formatting requirements.