### PR TITLE
Add unary and binary operators to protobufs

### DIFF
--- a/src/libdredd/include/libdredd/mutation_replace_binary_operator.h
+++ b/src/libdredd/include/libdredd/mutation_replace_binary_operator.h
@@ -118,6 +118,10 @@ class MutationReplaceBinaryOperator : public Mutation {
   [[nodiscard]] static protobufs::MutationReplaceBinaryOperatorAction
   OperatorKindToAction(clang::BinaryOperatorKind operator_kind);
 
+  [[nodiscard]] static protobufs::BinaryOperator
+  ClangOperatorKindToProtobufOperatorKind(
+      clang::BinaryOperatorKind operator_kind);
+
   const clang::BinaryOperator& binary_operator_;
   const InfoForSourceRange info_for_overall_expr_;
   const InfoForSourceRange info_for_lhs_;

--- a/src/libdredd/include/libdredd/mutation_replace_unary_operator.h
+++ b/src/libdredd/include/libdredd/mutation_replace_unary_operator.h
@@ -82,6 +82,10 @@ class MutationReplaceUnaryOperator : public Mutation {
   [[nodiscard]] static protobufs::MutationReplaceUnaryOperatorAction
   OperatorKindToAction(clang::UnaryOperatorKind operator_kind);
 
+  [[nodiscard]] static protobufs::UnaryOperator
+  ClangOperatorKindToProtobufOperatorKind(
+      clang::UnaryOperatorKind operator_kind);
+
   const clang::UnaryOperator& unary_operator_;
   const InfoForSourceRange info_for_overall_expr_;
   const InfoForSourceRange info_for_sub_expr_;

--- a/src/libdredd/include/libdredd/protobufs/dredd.proto
+++ b/src/libdredd/include/libdredd/protobufs/dredd.proto
@@ -114,8 +114,39 @@ message MutationReplaceBinaryOperatorInstance {
   int32 mutation_id = 2;
 }
 
+enum BinaryOperator {
+  Mul = 0;
+  Div = 1;
+  Rem = 2;
+  Add = 3;
+  Sub = 4;
+  Shl = 5;
+  Shr = 6;
+  LT = 7;
+  GT = 8;
+  LE = 9;
+  GE = 10;
+  EQ = 11;
+  NE = 12;
+  And = 13;
+  Xor = 14;
+  Or = 15;
+  LAnd = 16;
+  LOr = 17;
+  Assign = 18;
+  MulAssign = 19;
+  DivAssign = 20;
+  RemAssign = 21;
+  AddAssign = 22;
+  SubAssign = 23;
+  ShlAssign = 24;
+  ShrAssign = 25;
+  AndAssign = 26;
+  XorAssign = 27;
+  OrAssign = 28;
+}
+
 message MutationReplaceBinaryOperator {
-  enum BinaryOperator { PLACEHOLDER = 0; }
   SourceLocation expr_start = 1;
   SourceLocation expr_end = 2;
   SourceLocation lhs_start = 3;
@@ -145,8 +176,17 @@ message MutationReplaceUnaryOperatorInstance {
   int32 mutation_id = 2;
 }
 
+enum UnaryOperator {
+  PostInc = 0;
+  PostDec = 1;
+  PreInc = 2;
+  PreDec = 3;
+  Minus = 4;
+  Not = 5;
+  LNot = 6;
+}
+
 message MutationReplaceUnaryOperator {
-  enum UnaryOperator { PLACEHOLDER = 0; }
   SourceLocation expr_start = 1;
   SourceLocation expr_end = 2;
   SourceLocation operand_start = 3;

--- a/src/libdredd/src/mutation_replace_binary_operator.cc
+++ b/src/libdredd/src/mutation_replace_binary_operator.cc
@@ -492,6 +492,9 @@ protobufs::MutationGroup MutationReplaceBinaryOperator::Apply(
   // MutationGroup.
   protobufs::MutationReplaceBinaryOperator inner_result;
 
+  inner_result.set_operator_(
+      ClangOperatorKindToProtobufOperatorKind(binary_operator_.getOpcode()));
+
   inner_result.mutable_expr_start()->set_line(
       info_for_overall_expr_.GetStartLine());
   inner_result.mutable_expr_start()->set_column(
@@ -926,6 +929,74 @@ MutationReplaceBinaryOperator::OperatorKindToAction(
     default:
       assert(false && "Unknown operator kind.");
       return protobufs::MutationReplaceBinaryOperatorAction_MAX;
+  }
+}
+
+protobufs::BinaryOperator
+MutationReplaceBinaryOperator::ClangOperatorKindToProtobufOperatorKind(
+    clang::BinaryOperatorKind operator_kind) {
+  switch (operator_kind) {
+    case clang::BinaryOperatorKind::BO_Mul:
+      return protobufs::BinaryOperator::Mul;
+    case clang::BinaryOperatorKind::BO_Div:
+      return protobufs::BinaryOperator::Div;
+    case clang::BinaryOperatorKind::BO_Rem:
+      return protobufs::BinaryOperator::Rem;
+    case clang::BinaryOperatorKind::BO_Add:
+      return protobufs::BinaryOperator::Add;
+    case clang::BinaryOperatorKind::BO_Sub:
+      return protobufs::BinaryOperator::Sub;
+    case clang::BinaryOperatorKind::BO_Shl:
+      return protobufs::BinaryOperator::Shl;
+    case clang::BinaryOperatorKind::BO_Shr:
+      return protobufs::BinaryOperator::Shr;
+    case clang::BinaryOperatorKind::BO_LT:
+      return protobufs::BinaryOperator::LT;
+    case clang::BinaryOperatorKind::BO_GT:
+      return protobufs::BinaryOperator::GT;
+    case clang::BinaryOperatorKind::BO_LE:
+      return protobufs::BinaryOperator::LE;
+    case clang::BinaryOperatorKind::BO_GE:
+      return protobufs::BinaryOperator::GE;
+    case clang::BinaryOperatorKind::BO_EQ:
+      return protobufs::BinaryOperator::EQ;
+    case clang::BinaryOperatorKind::BO_NE:
+      return protobufs::BinaryOperator::NE;
+    case clang::BinaryOperatorKind::BO_And:
+      return protobufs::BinaryOperator::And;
+    case clang::BinaryOperatorKind::BO_Xor:
+      return protobufs::BinaryOperator::Xor;
+    case clang::BinaryOperatorKind::BO_Or:
+      return protobufs::BinaryOperator::Or;
+    case clang::BinaryOperatorKind::BO_LAnd:
+      return protobufs::BinaryOperator::LAnd;
+    case clang::BinaryOperatorKind::BO_LOr:
+      return protobufs::BinaryOperator::LOr;
+    case clang::BinaryOperatorKind::BO_Assign:
+      return protobufs::BinaryOperator::Assign;
+    case clang::BinaryOperatorKind::BO_MulAssign:
+      return protobufs::BinaryOperator::MulAssign;
+    case clang::BinaryOperatorKind::BO_DivAssign:
+      return protobufs::BinaryOperator::DivAssign;
+    case clang::BinaryOperatorKind::BO_RemAssign:
+      return protobufs::BinaryOperator::RemAssign;
+    case clang::BinaryOperatorKind::BO_AddAssign:
+      return protobufs::BinaryOperator::AddAssign;
+    case clang::BinaryOperatorKind::BO_SubAssign:
+      return protobufs::BinaryOperator::SubAssign;
+    case clang::BinaryOperatorKind::BO_ShlAssign:
+      return protobufs::BinaryOperator::ShlAssign;
+    case clang::BinaryOperatorKind::BO_ShrAssign:
+      return protobufs::BinaryOperator::ShrAssign;
+    case clang::BinaryOperatorKind::BO_AndAssign:
+      return protobufs::BinaryOperator::AndAssign;
+    case clang::BinaryOperatorKind::BO_XorAssign:
+      return protobufs::BinaryOperator::XorAssign;
+    case clang::BinaryOperatorKind::BO_OrAssign:
+      return protobufs::BinaryOperator::OrAssign;
+    default:
+      assert(false && "Unknown operator.");
+      return protobufs::BinaryOperator_MAX;
   }
 }
 

--- a/src/libdredd/src/mutation_replace_unary_operator.cc
+++ b/src/libdredd/src/mutation_replace_unary_operator.cc
@@ -351,6 +351,9 @@ protobufs::MutationGroup MutationReplaceUnaryOperator::Apply(
   // MutationGroup.
   protobufs::MutationReplaceUnaryOperator inner_result;
 
+  inner_result.set_operator_(
+      ClangOperatorKindToProtobufOperatorKind(unary_operator_.getOpcode()));
+
   inner_result.mutable_expr_start()->set_line(
       info_for_overall_expr_.GetStartLine());
   inner_result.mutable_expr_start()->set_column(
@@ -492,6 +495,30 @@ MutationReplaceUnaryOperator::OperatorKindToAction(
       return protobufs::MutationReplaceUnaryOperatorAction::ReplaceWithLNot;
     default:
       return protobufs::MutationReplaceUnaryOperatorAction_MAX;
+  }
+}
+
+protobufs::UnaryOperator
+MutationReplaceUnaryOperator::ClangOperatorKindToProtobufOperatorKind(
+    clang::UnaryOperatorKind operator_kind) {
+  switch (operator_kind) {
+    case clang::UnaryOperatorKind::UO_PostInc:
+      return protobufs::UnaryOperator::PostInc;
+    case clang::UnaryOperatorKind::UO_PostDec:
+      return protobufs::UnaryOperator::PostDec;
+    case clang::UnaryOperatorKind::UO_PreInc:
+      return protobufs::UnaryOperator::PreInc;
+    case clang::UnaryOperatorKind::UO_PreDec:
+      return protobufs::UnaryOperator::PreDec;
+    case clang::UnaryOperatorKind::UO_Minus:
+      return protobufs::UnaryOperator::Minus;
+    case clang::UnaryOperatorKind::UO_Not:
+      return protobufs::UnaryOperator::Not;
+    case clang::UnaryOperatorKind::UO_LNot:
+      return protobufs::UnaryOperator::LNot;
+    default:
+      assert(false && "Unknown operator.");
+      return protobufs::UnaryOperator_MAX;
   }
 }
 


### PR DESCRIPTION
Allows recording the unary/binary operator associated with a mutated expression in the corresponding protobuf message.