### PR TITLE
Revert to older version of Clang/LLVM

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -25,8 +25,6 @@ help | head
 
 uname
 
-DREDD_LLVM_TAG=$(./scripts/llvm_tag.sh)
-
 case "$(uname)" in
 "Linux")
   NINJA_OS="linux"
@@ -63,9 +61,11 @@ esac
 
 # Install clang.
 pushd ./third_party/clang+llvm
-curl -fsSL -o clang+llvm.zip "https://github.com/mc-imperial/build-clang/releases/download/llvmorg-${DREDD_LLVM_TAG}/build-clang-llvmorg-${DREDD_LLVM_TAG}-${LLVM_RELEASE_OS}_x64_Release.zip"
-unzip clang+llvm.zip
-rm clang+llvm.zip
+curl -Lo clang+llvm.tar.xz https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.1/clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04.tar.xz
+tar xf clang+llvm.tar.xz
+mv clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04/* .
+rmdir mv clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04
+rm clang+llvm.tar.xz
 popd
 
 export PATH="${HOME}/bin:$PATH"

--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -61,11 +61,11 @@ esac
 
 # Install clang.
 pushd ./third_party/clang+llvm
-curl -Lo clang+llvm.tar.xz https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.1/clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04.tar.xz
-tar xf clang+llvm.tar.xz
-mv clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04/* .
-rmdir mv clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04
-rm clang+llvm.tar.xz
+  curl -Lo clang+llvm.tar.xz https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.1/clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04.tar.xz
+  tar xf clang+llvm.tar.xz
+  mv clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04/* .
+  rmdir mv clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04
+  rm clang+llvm.tar.xz
 popd
 
 export PATH="${HOME}/bin:$PATH"

--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -64,7 +64,7 @@ pushd ./third_party/clang+llvm
   curl -Lo clang+llvm.tar.xz https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.1/clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04.tar.xz
   tar xf clang+llvm.tar.xz
   mv clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04/* .
-  rmdir mv clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04
+  rmdir clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04
   rm clang+llvm.tar.xz
 popd
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,9 +23,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - windows-latest
-          - macOS-latest
         config:
           - Release
         # Manually list various Linux configurations.

--- a/.github/workflows/c_apps.sh
+++ b/.github/workflows/c_apps.sh
@@ -50,13 +50,13 @@ pushd "${HOME}/bin"
   ls
 popd
 
-DREDD_LLVM_TAG=$(./scripts/llvm_tag.sh)
-
 # Install clang.
 pushd ./third_party/clang+llvm
-curl -fsSL -o clang+llvm.zip "https://github.com/mc-imperial/build-clang/releases/download/llvmorg-${DREDD_LLVM_TAG}/build-clang-llvmorg-${DREDD_LLVM_TAG}-ubuntu-20.04_x64_Release.zip"
-unzip clang+llvm.zip
-rm clang+llvm.zip
+curl -Lo clang+llvm.tar.xz https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.1/clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04.tar.xz
+tar xf clang+llvm.tar.xz
+mv clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04/* .
+rmdir mv clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04
+rm clang+llvm.tar.xz
 popd
 
 export PATH="./third_party/clang+llvm/bin:$PATH"

--- a/.github/workflows/c_apps.sh
+++ b/.github/workflows/c_apps.sh
@@ -55,7 +55,7 @@ pushd ./third_party/clang+llvm
   curl -Lo clang+llvm.tar.xz https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.1/clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04.tar.xz
   tar xf clang+llvm.tar.xz
   mv clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04/* .
-  rmdir mv clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04
+  rmdir clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04
   rm clang+llvm.tar.xz
 popd
 

--- a/.github/workflows/c_apps.sh
+++ b/.github/workflows/c_apps.sh
@@ -52,11 +52,11 @@ popd
 
 # Install clang.
 pushd ./third_party/clang+llvm
-curl -Lo clang+llvm.tar.xz https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.1/clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04.tar.xz
-tar xf clang+llvm.tar.xz
-mv clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04/* .
-rmdir mv clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04
-rm clang+llvm.tar.xz
+  curl -Lo clang+llvm.tar.xz https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.1/clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04.tar.xz
+  tar xf clang+llvm.tar.xz
+  mv clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04/* .
+  rmdir mv clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04
+  rm clang+llvm.tar.xz
 popd
 
 export PATH="./third_party/clang+llvm/bin:$PATH"

--- a/.github/workflows/cxx_apps.sh
+++ b/.github/workflows/cxx_apps.sh
@@ -50,13 +50,13 @@ pushd "${HOME}/bin"
   ls
 popd
 
-DREDD_LLVM_TAG=$(./scripts/llvm_tag.sh)
-
 # Install clang.
 pushd ./third_party/clang+llvm
-curl -fsSL -o clang+llvm.zip "https://github.com/mc-imperial/build-clang/releases/download/llvmorg-${DREDD_LLVM_TAG}/build-clang-llvmorg-${DREDD_LLVM_TAG}-ubuntu-20.04_x64_Release.zip"
-unzip clang+llvm.zip
-rm clang+llvm.zip
+curl -Lo clang+llvm.tar.xz https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.1/clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04.tar.xz
+tar xf clang+llvm.tar.xz
+mv clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04/* .
+rmdir mv clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04
+rm clang+llvm.tar.xz
 popd
 
 export PATH="./third_party/clang+llvm/bin:$PATH"

--- a/.github/workflows/cxx_apps.sh
+++ b/.github/workflows/cxx_apps.sh
@@ -55,7 +55,7 @@ pushd ./third_party/clang+llvm
   curl -Lo clang+llvm.tar.xz https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.1/clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04.tar.xz
   tar xf clang+llvm.tar.xz
   mv clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04/* .
-  rmdir mv clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04
+  rmdir clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04
   rm clang+llvm.tar.xz
 popd
 

--- a/.github/workflows/cxx_apps.sh
+++ b/.github/workflows/cxx_apps.sh
@@ -52,11 +52,11 @@ popd
 
 # Install clang.
 pushd ./third_party/clang+llvm
-curl -Lo clang+llvm.tar.xz https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.1/clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04.tar.xz
-tar xf clang+llvm.tar.xz
-mv clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04/* .
-rmdir mv clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04
-rm clang+llvm.tar.xz
+  curl -Lo clang+llvm.tar.xz https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.1/clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04.tar.xz
+  tar xf clang+llvm.tar.xz
+  mv clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04/* .
+  rmdir mv clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04
+  rm clang+llvm.tar.xz
 popd
 
 export PATH="./third_party/clang+llvm/bin:$PATH"

--- a/.github/workflows/dev_build.sh
+++ b/.github/workflows/dev_build.sh
@@ -53,13 +53,13 @@ pushd "${HOME}/bin"
   ls
 popd
 
-DREDD_LLVM_TAG=$(./scripts/llvm_tag.sh)
-
 # Install clang.
 pushd ./third_party/clang+llvm
-curl -fsSL -o clang+llvm.zip "https://github.com/mc-imperial/build-clang/releases/download/llvmorg-${DREDD_LLVM_TAG}/build-clang-llvmorg-${DREDD_LLVM_TAG}-ubuntu-20.04_x64_Release.zip"
-unzip clang+llvm.zip
-rm clang+llvm.zip
+curl -Lo clang+llvm.tar.xz https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.1/clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04.tar.xz
+tar xf clang+llvm.tar.xz
+mv clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04/* .
+rmdir mv clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04
+rm clang+llvm.tar.xz
 popd
 
 # Source the dev shell to download clang-tidy and other tools.

--- a/.github/workflows/dev_build.sh
+++ b/.github/workflows/dev_build.sh
@@ -53,9 +53,6 @@ pushd "${HOME}/bin"
   ls
 popd
 
-echo $(pwd)
-ls
-
 # Install clang.
   pushd ./third_party/clang+llvm
   curl -Lo clang+llvm.tar.xz https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.1/clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04.tar.xz

--- a/.github/workflows/dev_build.sh
+++ b/.github/workflows/dev_build.sh
@@ -53,13 +53,16 @@ pushd "${HOME}/bin"
   ls
 popd
 
+echo $(pwd)
+ls
+
 # Install clang.
-pushd ./third_party/clang+llvm
-curl -Lo clang+llvm.tar.xz https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.1/clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04.tar.xz
-tar xf clang+llvm.tar.xz
-mv clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04/* .
-rmdir mv clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04
-rm clang+llvm.tar.xz
+  pushd ./third_party/clang+llvm
+  curl -Lo clang+llvm.tar.xz https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.1/clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04.tar.xz
+  tar xf clang+llvm.tar.xz
+  mv clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04/* .
+  rmdir mv clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04
+  rm clang+llvm.tar.xz
 popd
 
 # Source the dev shell to download clang-tidy and other tools.

--- a/.github/workflows/dev_build.sh
+++ b/.github/workflows/dev_build.sh
@@ -58,7 +58,7 @@ popd
   curl -Lo clang+llvm.tar.xz https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.1/clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04.tar.xz
   tar xf clang+llvm.tar.xz
   mv clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04/* .
-  rmdir mv clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04
+  rmdir clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04
   rm clang+llvm.tar.xz
 popd
 

--- a/.github/workflows/release.sh
+++ b/.github/workflows/release.sh
@@ -65,9 +65,11 @@ esac
 
 # Install clang.
 pushd ./third_party/clang+llvm
-curl -fsSL -o clang+llvm.zip "https://github.com/mc-imperial/build-clang/releases/download/llvmorg-${DREDD_LLVM_TAG}/build-clang-llvmorg-${DREDD_LLVM_TAG}-${LLVM_RELEASE_OS}_x64_Release.zip"
-unzip clang+llvm.zip
-rm clang+llvm.zip
+curl -Lo clang+llvm.tar.xz https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.1/clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04.tar.xz
+tar xf clang+llvm.tar.xz
+mv clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04/* .
+rmdir mv clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04
+rm clang+llvm.tar.xz
 popd
 
 export PATH="$(pwd)/third_party/clang+llvm/bin:${HOME}/bin:$PATH"

--- a/.github/workflows/release.sh
+++ b/.github/workflows/release.sh
@@ -65,11 +65,11 @@ esac
 
 # Install clang.
 pushd ./third_party/clang+llvm
-curl -Lo clang+llvm.tar.xz https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.1/clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04.tar.xz
-tar xf clang+llvm.tar.xz
-mv clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04/* .
-rmdir mv clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04
-rm clang+llvm.tar.xz
+  curl -Lo clang+llvm.tar.xz https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.1/clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04.tar.xz
+  tar xf clang+llvm.tar.xz
+  mv clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04/* .
+  rmdir mv clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04
+  rm clang+llvm.tar.xz
 popd
 
 export PATH="$(pwd)/third_party/clang+llvm/bin:${HOME}/bin:$PATH"

--- a/.github/workflows/release.sh
+++ b/.github/workflows/release.sh
@@ -68,7 +68,7 @@ pushd ./third_party/clang+llvm
   curl -Lo clang+llvm.tar.xz https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.1/clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04.tar.xz
   tar xf clang+llvm.tar.xz
   mv clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04/* .
-  rmdir mv clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04
+  rmdir clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04
   rm clang+llvm.tar.xz
 popd
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,6 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - windows-latest
-          - macOS-latest
           - ubuntu-18.04
           - ubuntu-20.04
           - ubuntu-22.04

--- a/README.md
+++ b/README.md
@@ -195,11 +195,13 @@ Dredd builds against various Clang and LLVM libraries. Rather than including Cla
 From the root of the repository, execute the following commands:
 
 ```
-DREDD_LLVM_TAG=$(./scripts/llvm_tag.sh)
+cd third_party
 # The release file is pretty large, so this download may take a while
-curl -Lo clang+llvm.zip https://github.com/mc-imperial/build-clang/releases/download/llvmorg-${DREDD_LLVM_TAG}/build-clang-llvmorg-${DREDD_LLVM_TAG}-Linux_x64_Release.zip
-unzip clang+llvm.zip -d third_party/clang+llvm
-rm clang+llvm.zip
+curl -Lo clang+llvm.tar.xz https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.1/clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04.tar.xz
+tar xf clang+llvm.tar.xz
+mv clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04 clang+llvm
+rm clang+llvm.tar.xz
+cd ..
 ```
 
 ### Build steps

--- a/dev_shell.sh.template
+++ b/dev_shell.sh.template
@@ -83,7 +83,7 @@ export CPPLINT_PY
 
 # Get include what you use.
 
-IWYU_VERSION="0.18"
+IWYU_VERSION="0.17"
 IWYU_OUT="iwyu-${IWYU_VERSION}"
 
 if test ! -f "${IWYU_OUT}.touch"; then

--- a/scripts/llvm_tag.sh
+++ b/scripts/llvm_tag.sh
@@ -18,4 +18,4 @@ set -e
 set -u
 set -x
 
-echo "14.0.6"
+echo "13.0.1"

--- a/third_party/.gitignore
+++ b/third_party/.gitignore
@@ -1,6 +1,3 @@
-# The Clang/LLVM distribution one needs to download to use Dredd
-clang+llvm
-
 # Projects built by Dredd's CI, which it can be convenient to
 # check out locally.
 curl


### PR DESCRIPTION
Due to problems getting stable releases of Clang/LLVM via the
build-clang repo, reverting to an older version that is available for
Linux in pre-built form via the LLVM GitHub project.
