### PR TITLE
Do not remove self-inverse unary operators

### DIFF
--- a/src/libdredd/include/libdredd/mutation_replace_unary_operator.h
+++ b/src/libdredd/include/libdredd/mutation_replace_unary_operator.h
@@ -18,7 +18,6 @@
 #include <sstream>
 #include <string>
 #include <unordered_set>
-#include <vector>
 
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Expr.h"

--- a/src/libdredd/include/libdredd/mutation_replace_unary_operator.h
+++ b/src/libdredd/include/libdredd/mutation_replace_unary_operator.h
@@ -59,6 +59,8 @@ class MutationReplaceUnaryOperator : public Mutation {
       clang::UnaryOperatorKind operator_kind,
       clang::ASTContext& ast_context) const;
 
+  [[nodiscard]] bool IsOperatorSelfInverse() const;
+
   // This returns a string corresponding to the non-mutated expression.
   std::string GetExpr(clang::ASTContext& ast_context) const;
 
@@ -69,7 +71,6 @@ class MutationReplaceUnaryOperator : public Mutation {
   void GenerateUnaryOperatorReplacement(
       const std::string& arg_evaluated, clang::ASTContext& ast_context,
       bool optimise_mutations, int mutation_id_base,
-      const std::vector<clang::UnaryOperatorKind>& operators,
       std::stringstream& new_function, int& mutation_id_offset,
       protobufs::MutationReplaceUnaryOperator& protobuf_message) const;
 

--- a/src/libdreddtest/src/mutation_replace_unary_operator_test.cc
+++ b/src/libdreddtest/src/mutation_replace_unary_operator_test.cc
@@ -72,10 +72,28 @@ void TestReplacement(const std::string& original, const std::string& expected,
 
 TEST(MutationReplaceUnaryOperatorTest, MutateMinus) {
   std::string original = "void foo() { -2; }";
-  std::string expected =
+  std::string expected_opt =
       "void foo() { __dredd_replace_unary_operator_Minus_int([&]() -> int { "
       "return 2; }, 0); }";
-  std::string expected_dredd_declaration =
+  std::string expected_dredd_declaration_opt =
+      R"(static int __dredd_replace_unary_operator_Minus_int(std::function<int()> arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return -arg();
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~arg();
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return !arg();
+  return -arg();
+}
+
+)";
+  const int kNumReplacementsOpt = 2;
+
+  // Test with optimisations
+  TestReplacement(original, expected_opt, kNumReplacementsOpt, true,
+                  expected_dredd_declaration_opt);
+
+  std::string expected_no_opt =
+      "void foo() { __dredd_replace_unary_operator_Minus_int([&]() -> int { "
+      "return 2; }, 0); }";
+  std::string expected_dredd_declaration_no_opt =
       R"(static int __dredd_replace_unary_operator_Minus_int(std::function<int()> arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return -arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~arg();
@@ -85,10 +103,11 @@ TEST(MutationReplaceUnaryOperatorTest, MutateMinus) {
 }
 
 )";
-  const int kNumReplacements = 3;
+  const int kNumReplacementsNoOpt = 3;
+
   // Test without optimisations
-  TestReplacement(original, expected, kNumReplacements, false,
-                  expected_dredd_declaration);
+  TestReplacement(original, expected_no_opt, kNumReplacementsNoOpt, false,
+                  expected_dredd_declaration_no_opt);
 }
 
 TEST(MutationReplaceUnaryOperatorTest, MutateNot) {
@@ -97,13 +116,34 @@ TEST(MutationReplaceUnaryOperatorTest, MutateNot) {
   !f;
 }
 )";
-  std::string expected =
+  std::string expected_opt =
       R"(void foo() {
   bool f = false;
   __dredd_replace_unary_operator_LNot_bool([&]() -> bool { return static_cast<bool>(f); }, 0);
 }
 )";
-  std::string expected_dredd_declaration =
+  std::string expected_dredd_declaration_opt =
+      R"(static bool __dredd_replace_unary_operator_LNot_bool(std::function<bool()> arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return !arg();
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~arg();
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return -arg();
+  return !arg();
+}
+
+)";
+  const int kNumReplacementsOpt = 2;
+
+  // Test with optimisations
+  TestReplacement(original, expected_opt, kNumReplacementsOpt, true,
+                  expected_dredd_declaration_opt);
+
+  std::string expected_no_opt =
+      R"(void foo() {
+  bool f = false;
+  __dredd_replace_unary_operator_LNot_bool([&]() -> bool { return static_cast<bool>(f); }, 0);
+}
+)";
+  std::string expected_dredd_declaration_no_opt =
       R"(static bool __dredd_replace_unary_operator_LNot_bool(std::function<bool()> arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return !arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~arg();
@@ -113,10 +153,11 @@ TEST(MutationReplaceUnaryOperatorTest, MutateNot) {
 }
 
 )";
-  const int kNumReplacements = 3;
+  const int kNumReplacementsNoOpt = 3;
+
   // Test without optimisations
-  TestReplacement(original, expected, kNumReplacements, false,
-                  expected_dredd_declaration);
+  TestReplacement(original, expected_no_opt, kNumReplacementsNoOpt, false,
+                  expected_dredd_declaration_no_opt);
 }
 
 TEST(MutationReplaceUnaryOperatorTest, MutateIncrement) {
@@ -125,13 +166,13 @@ TEST(MutationReplaceUnaryOperatorTest, MutateIncrement) {
   ++x;
 }
 )";
-  std::string expected =
+  std::string expected_opt =
       R"(void foo() {
   double x = 5.364;
   __dredd_replace_unary_operator_PreInc_double([&]() -> double& { return static_cast<double&>(x); }, 0);
 }
 )";
-  std::string expected_dredd_declaration =
+  std::string expected_dredd_declaration_opt =
       R"(static double& __dredd_replace_unary_operator_PreInc_double(std::function<double&()> arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return ++arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return --arg();
@@ -140,10 +181,32 @@ TEST(MutationReplaceUnaryOperatorTest, MutateIncrement) {
 }
 
 )";
-  const int kNumReplacements = 2;
+  const int kNumReplacementsOpt = 2;
+
+  // Test with optimisations
+  TestReplacement(original, expected_opt, kNumReplacementsOpt, true,
+                  expected_dredd_declaration_opt);
+
+  std::string expected_no_opt =
+      R"(void foo() {
+  double x = 5.364;
+  __dredd_replace_unary_operator_PreInc_double([&]() -> double& { return static_cast<double&>(x); }, 0);
+}
+)";
+  std::string expected_dredd_declaration_noopt =
+      R"(static double& __dredd_replace_unary_operator_PreInc_double(std::function<double&()> arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return ++arg();
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return --arg();
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg();
+  return ++arg();
+}
+
+)";
+  const int kNumReplacementsNoOpt = 2;
+
   // Test without optimisations
-  TestReplacement(original, expected, kNumReplacements, false,
-                  expected_dredd_declaration);
+  TestReplacement(original, expected_no_opt, kNumReplacementsNoOpt, false,
+                  expected_dredd_declaration_noopt);
 }
 
 TEST(MutationReplaceUnaryOperatorTest, MutateDecrement) {
@@ -152,13 +215,13 @@ TEST(MutationReplaceUnaryOperatorTest, MutateDecrement) {
   x--;
 }
 )";
-  std::string expected =
+  std::string expected_opt =
       R"(void foo() {
   int x = 2;
   __dredd_replace_unary_operator_PostDec_int([&]() -> int& { return static_cast<int&>(x); }, 0);
 }
 )";
-  std::string expected_dredd_declaration =
+  std::string expected_dredd_declaration_opt =
       R"(static int __dredd_replace_unary_operator_PostDec_int(std::function<int&()> arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg()--;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg()++;
@@ -170,10 +233,35 @@ TEST(MutationReplaceUnaryOperatorTest, MutateDecrement) {
 }
 
 )";
-  const int kNumReplacements = 5;
+  const int kNumReplacementsOpt = 5;
+
+  // Test with optimisations
+  TestReplacement(original, expected_opt, kNumReplacementsOpt, true,
+                  expected_dredd_declaration_opt);
+
+  std::string expected_no_opt =
+      R"(void foo() {
+  int x = 2;
+  __dredd_replace_unary_operator_PostDec_int([&]() -> int& { return static_cast<int&>(x); }, 0);
+}
+)";
+  std::string expected_dredd_declaration_no_opt =
+      R"(static int __dredd_replace_unary_operator_PostDec_int(std::function<int&()> arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg()--;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg()++;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~arg();
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -arg();
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return !arg();
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return arg();
+  return arg()--;
+}
+
+)";
+  const int kNumReplacementsNoOpt = 5;
+
   // Test without optimisations
-  TestReplacement(original, expected, kNumReplacements, false,
-                  expected_dredd_declaration);
+  TestReplacement(original, expected_no_opt, kNumReplacementsNoOpt, false,
+                  expected_dredd_declaration_no_opt);
 }
 
 TEST(MutationReplaceUnaryOperatorTest, MutateDecrementAssign) {
@@ -182,13 +270,13 @@ TEST(MutationReplaceUnaryOperatorTest, MutateDecrementAssign) {
   --x = 2;
 }
 )";
-  std::string expected =
+  std::string expected_opt =
       R"(void foo() {
   int x = 5;
   __dredd_replace_unary_operator_PreDec_int([&]() -> int& { return static_cast<int&>(x); }, 0) = 2;
 }
 )";
-  std::string expected_dredd_declaration =
+  std::string expected_dredd_declaration_opt =
       R"(static int& __dredd_replace_unary_operator_PreDec_int(std::function<int&()> arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return --arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ++arg();
@@ -197,10 +285,32 @@ TEST(MutationReplaceUnaryOperatorTest, MutateDecrementAssign) {
 }
 
 )";
-  const int kNumReplacements = 2;
+  const int kNumReplacementsOpt = 2;
+
+  // Test with optimisations
+  TestReplacement(original, expected_opt, kNumReplacementsOpt, true,
+                  expected_dredd_declaration_opt);
+
+  std::string expected_no_opt =
+      R"(void foo() {
+  int x = 5;
+  __dredd_replace_unary_operator_PreDec_int([&]() -> int& { return static_cast<int&>(x); }, 0) = 2;
+}
+)";
+  std::string expected_dredd_declaration_no_opt =
+      R"(static int& __dredd_replace_unary_operator_PreDec_int(std::function<int&()> arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return --arg();
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return ++arg();
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg();
+  return --arg();
+}
+
+)";
+  const int kNumReplacementsNoOpt = 2;
+
   // Test without optimisations
-  TestReplacement(original, expected, kNumReplacements, false,
-                  expected_dredd_declaration);
+  TestReplacement(original, expected_no_opt, kNumReplacementsNoOpt, false,
+                  expected_dredd_declaration_no_opt);
 }
 
 }  // namespace

--- a/test/single_file/post_inc_volatile.c.expected
+++ b/test/single_file/post_inc_volatile.c.expected
@@ -16,7 +16,7 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
       while(token) {
         int value = atoi(token);
         int local_value = value - 0;
-        if (local_value >= 0 && local_value < 62) {
+        if (local_value >= 0 && local_value < 64) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
           some_mutation_enabled = 1;
         }
@@ -36,6 +36,7 @@ static int __dredd_replace_unary_operator_PostInc_volatile_int(volatile int* arg
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~(*arg);
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return -(*arg);
   if (__dredd_enabled_mutation(local_mutation_id + 3)) return !(*arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return (*arg);
   return (*arg)++;
 }
 
@@ -97,6 +98,6 @@ int main() {
   volatile int x = __dredd_replace_expr_int_constant(9, 0);
   volatile int y = __dredd_replace_expr_int_constant(43, 5);
   int z;
-  if (!__dredd_enabled_mutation(52)) { __dredd_replace_binary_operator_Assign_int_int(&(z) , __dredd_replace_expr_int(__dredd_replace_binary_operator_Add_int_int(__dredd_replace_expr_int(__dredd_replace_unary_operator_PostInc_volatile_int(&(x), 10), 14) , __dredd_replace_expr_int(__dredd_replace_unary_operator_PostInc_volatile_int(&(y), 20), 24), 30), 36), 42); }
-  if (!__dredd_enabled_mutation(61)) { return __dredd_replace_expr_int(__dredd_replace_expr_int_lvalue(&(z), 53), 55); }
+  if (!__dredd_enabled_mutation(54)) { __dredd_replace_binary_operator_Assign_int_int(&(z) , __dredd_replace_expr_int(__dredd_replace_binary_operator_Add_int_int(__dredd_replace_expr_int(__dredd_replace_unary_operator_PostInc_volatile_int(&(x), 10), 15) , __dredd_replace_expr_int(__dredd_replace_unary_operator_PostInc_volatile_int(&(y), 21), 26), 32), 38), 44); }
+  if (!__dredd_enabled_mutation(63)) { return __dredd_replace_expr_int(__dredd_replace_expr_int_lvalue(&(z), 55), 57); }
 }

--- a/test/single_file/post_inc_volatile.cc.expected
+++ b/test/single_file/post_inc_volatile.cc.expected
@@ -18,7 +18,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
         if (!token.empty()) {
           int value = std::stoi(token);
           int local_value = value - 0;
-          if (local_value >= 0 && local_value < 62) {
+          if (local_value >= 0 && local_value < 64) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
             some_mutation_enabled = true;
           }
@@ -56,6 +56,7 @@ static int __dredd_replace_unary_operator_PostInc_volatile_int(std::function<vol
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~arg();
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return -arg();
   if (__dredd_enabled_mutation(local_mutation_id + 3)) return !arg();
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return arg();
   return arg()++;
 }
 
@@ -102,6 +103,6 @@ int main() {
   volatile int x = __dredd_replace_expr_int_constant([&]() -> int { return 9; }, 0);
   volatile int y = __dredd_replace_expr_int_constant([&]() -> int { return 43; }, 5);
   int z;
-  if (!__dredd_enabled_mutation(52)) { __dredd_replace_binary_operator_Assign_int_int([&]() -> int& { return static_cast<int&>(z); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_binary_operator_Add_int_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_unary_operator_PostInc_volatile_int([&]() -> volatile int& { return static_cast<volatile int&>(x); }, 10)); }, 14)); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_unary_operator_PostInc_volatile_int([&]() -> volatile int& { return static_cast<volatile int&>(y); }, 20)); }, 24)); }, 30)); }, 36)); }, 42); }
-  if (!__dredd_enabled_mutation(61)) { return __dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int_lvalue([&]() -> int& { return static_cast<int&>(z); }, 53)); }, 55); }
+  if (!__dredd_enabled_mutation(54)) { __dredd_replace_binary_operator_Assign_int_int([&]() -> int& { return static_cast<int&>(z); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_binary_operator_Add_int_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_unary_operator_PostInc_volatile_int([&]() -> volatile int& { return static_cast<volatile int&>(x); }, 10)); }, 15)); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_unary_operator_PostInc_volatile_int([&]() -> volatile int& { return static_cast<volatile int&>(y); }, 21)); }, 26)); }, 32)); }, 38)); }, 44); }
+  if (!__dredd_enabled_mutation(63)) { return __dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int_lvalue([&]() -> int& { return static_cast<int&>(z); }, 55)); }, 57); }
 }

--- a/test/single_file/pre_dec_assign.cc.expected
+++ b/test/single_file/pre_dec_assign.cc.expected
@@ -18,7 +18,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
         if (!token.empty()) {
           int value = std::stoi(token);
           int local_value = value - 0;
-          if (local_value >= 0 && local_value < 53) {
+          if (local_value >= 0 && local_value < 55) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
             some_mutation_enabled = true;
           }
@@ -38,6 +38,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
 static volatile int& __dredd_replace_unary_operator_PreDec_volatile_int(std::function<volatile int&()> arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return --arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ++arg();
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg();
   return --arg();
 }
 
@@ -59,6 +60,7 @@ static volatile int& __dredd_replace_binary_operator_Assign_volatile_int_int(std
 static int& __dredd_replace_unary_operator_PreDec_int(std::function<int&()> arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return --arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ++arg();
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg();
   return --arg();
 }
 
@@ -107,8 +109,8 @@ static int __dredd_replace_expr_int(std::function<int()> arg, int local_mutation
 
 int main() {
   int x = __dredd_replace_expr_int_constant([&]() -> int { return 5; }, 0);
-  if (!__dredd_enabled_mutation(21)) { __dredd_replace_binary_operator_Assign_int_int([&]() -> int& { return static_cast<int&>(__dredd_replace_unary_operator_PreDec_int([&]() -> int& { return static_cast<int&>(x); }, 5)); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int_constant([&]() -> int { return 2; }, 6)); }, 11); }
-  volatile int y = __dredd_replace_expr_int_constant([&]() -> int { return 8; }, 22);
-  if (!__dredd_enabled_mutation(43)) { __dredd_replace_binary_operator_Assign_volatile_int_int([&]() -> volatile int& { return static_cast<volatile int&>(__dredd_replace_unary_operator_PreDec_volatile_int([&]() -> volatile int& { return static_cast<volatile int&>(y); }, 27)); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int_constant([&]() -> int { return 6; }, 28)); }, 33); }
-  if (!__dredd_enabled_mutation(52)) { return __dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int_lvalue([&]() -> int& { return static_cast<int&>(x); }, 44)); }, 46); }
+  if (!__dredd_enabled_mutation(22)) { __dredd_replace_binary_operator_Assign_int_int([&]() -> int& { return static_cast<int&>(__dredd_replace_unary_operator_PreDec_int([&]() -> int& { return static_cast<int&>(x); }, 5)); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int_constant([&]() -> int { return 2; }, 7)); }, 12); }
+  volatile int y = __dredd_replace_expr_int_constant([&]() -> int { return 8; }, 23);
+  if (!__dredd_enabled_mutation(45)) { __dredd_replace_binary_operator_Assign_volatile_int_int([&]() -> volatile int& { return static_cast<volatile int&>(__dredd_replace_unary_operator_PreDec_volatile_int([&]() -> volatile int& { return static_cast<volatile int&>(y); }, 28)); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int_constant([&]() -> int { return 6; }, 30)); }, 35); }
+  if (!__dredd_enabled_mutation(54)) { return __dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int_lvalue([&]() -> int& { return static_cast<int&>(x); }, 46)); }, 48); }
 }

--- a/test/single_file/unary.c.expected
+++ b/test/single_file/unary.c.expected
@@ -4,7 +4,7 @@
 static int __dredd_some_mutation_enabled = 1;
 static int __dredd_enabled_mutation(int local_mutation_id) {
   static int initialized = 0;
-  static uint64_t enabled_bitset[1];
+  static uint64_t enabled_bitset[2];
   if (!initialized) {
     int some_mutation_enabled = 0;
     const char* dredd_environment_variable = getenv("DREDD_ENABLED_MUTATION");
@@ -16,7 +16,7 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
       while(token) {
         int value = atoi(token);
         int local_value = value - 0;
-        if (local_value >= 0 && local_value < 62) {
+        if (local_value >= 0 && local_value < 70) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
           some_mutation_enabled = 1;
         }
@@ -36,6 +36,7 @@ static int __dredd_replace_unary_operator_PreInc_int(int* arg, int local_mutatio
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~(*arg);
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return -(*arg);
   if (__dredd_enabled_mutation(local_mutation_id + 3)) return !(*arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return (*arg);
   return ++(*arg);
 }
 
@@ -45,6 +46,7 @@ static int __dredd_replace_unary_operator_PreDec_int(int* arg, int local_mutatio
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~(*arg);
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return -(*arg);
   if (__dredd_enabled_mutation(local_mutation_id + 3)) return !(*arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return (*arg);
   return --(*arg);
 }
 
@@ -54,6 +56,7 @@ static int __dredd_replace_unary_operator_PostInc_int(int* arg, int local_mutati
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~(*arg);
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return -(*arg);
   if (__dredd_enabled_mutation(local_mutation_id + 3)) return !(*arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return (*arg);
   return (*arg)++;
 }
 
@@ -63,6 +66,7 @@ static int __dredd_replace_unary_operator_PostDec_int(int* arg, int local_mutati
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~(*arg);
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return -(*arg);
   if (__dredd_enabled_mutation(local_mutation_id + 3)) return !(*arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return (*arg);
   return (*arg)--;
 }
 
@@ -106,6 +110,7 @@ static float __dredd_replace_unary_operator_PreInc_float(float* arg, int local_m
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return --(*arg);
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return -(*arg);
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return !(*arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return (*arg);
   return ++(*arg);
 }
 
@@ -114,6 +119,7 @@ static float __dredd_replace_unary_operator_PreDec_float(float* arg, int local_m
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ++(*arg);
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return -(*arg);
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return !(*arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return (*arg);
   return --(*arg);
 }
 
@@ -122,6 +128,7 @@ static float __dredd_replace_unary_operator_PostInc_float(float* arg, int local_
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return (*arg)--;
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return -(*arg);
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return !(*arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return (*arg);
   return (*arg)++;
 }
 
@@ -130,6 +137,7 @@ static float __dredd_replace_unary_operator_PostDec_float(float* arg, int local_
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return (*arg)++;
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return -(*arg);
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return !(*arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return (*arg);
   return (*arg)--;
 }
 
@@ -145,13 +153,13 @@ static float __dredd_replace_expr_float(float arg, int local_mutation_id) {
 int main() {
   int x = __dredd_replace_expr_int_constant(3, 0);
   float y = __dredd_replace_expr_float(3.532, 5);
-  if (!__dredd_enabled_mutation(13)) { __dredd_replace_unary_operator_PostInc_int(&(x), 9); }
-  if (!__dredd_enabled_mutation(17)) { __dredd_replace_unary_operator_PostInc_float(&(y), 14); }
-  if (!__dredd_enabled_mutation(22)) { __dredd_replace_unary_operator_PreInc_int(&(x), 18); }
-  if (!__dredd_enabled_mutation(26)) { __dredd_replace_unary_operator_PreInc_float(&(y), 23); }
-  if (!__dredd_enabled_mutation(31)) { __dredd_replace_unary_operator_PreDec_int(&(x), 27); }
-  if (!__dredd_enabled_mutation(35)) { __dredd_replace_unary_operator_PreDec_float(&(y), 32); }
-  if (!__dredd_enabled_mutation(40)) { __dredd_replace_unary_operator_PostDec_int(&(x), 36); }
-  if (!__dredd_enabled_mutation(44)) { __dredd_replace_unary_operator_PostDec_float(&(y), 41); }
-  if (!__dredd_enabled_mutation(61)) { return __dredd_replace_expr_int(__dredd_replace_unary_operator_Minus_int(__dredd_replace_expr_int(__dredd_replace_expr_int_lvalue(&(x), 45), 47), 53), 55); }
+  if (!__dredd_enabled_mutation(14)) { __dredd_replace_unary_operator_PostInc_int(&(x), 9); }
+  if (!__dredd_enabled_mutation(19)) { __dredd_replace_unary_operator_PostInc_float(&(y), 15); }
+  if (!__dredd_enabled_mutation(25)) { __dredd_replace_unary_operator_PreInc_int(&(x), 20); }
+  if (!__dredd_enabled_mutation(30)) { __dredd_replace_unary_operator_PreInc_float(&(y), 26); }
+  if (!__dredd_enabled_mutation(36)) { __dredd_replace_unary_operator_PreDec_int(&(x), 31); }
+  if (!__dredd_enabled_mutation(41)) { __dredd_replace_unary_operator_PreDec_float(&(y), 37); }
+  if (!__dredd_enabled_mutation(47)) { __dredd_replace_unary_operator_PostDec_int(&(x), 42); }
+  if (!__dredd_enabled_mutation(52)) { __dredd_replace_unary_operator_PostDec_float(&(y), 48); }
+  if (!__dredd_enabled_mutation(69)) { return __dredd_replace_expr_int(__dredd_replace_unary_operator_Minus_int(__dredd_replace_expr_int(__dredd_replace_expr_int_lvalue(&(x), 53), 55), 61), 63); }
 }

--- a/test/single_file/unary.cc.expected
+++ b/test/single_file/unary.cc.expected
@@ -18,7 +18,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
         if (!token.empty()) {
           int value = std::stoi(token);
           int local_value = value - 0;
-          if (local_value >= 0 && local_value < 52) {
+          if (local_value >= 0 && local_value < 60) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
             some_mutation_enabled = true;
           }
@@ -38,12 +38,14 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
 static int& __dredd_replace_unary_operator_PreInc_int(std::function<int&()> arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return ++arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return --arg();
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg();
   return ++arg();
 }
 
 static int& __dredd_replace_unary_operator_PreDec_int(std::function<int&()> arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return --arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ++arg();
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg();
   return --arg();
 }
 
@@ -53,6 +55,7 @@ static int __dredd_replace_unary_operator_PostInc_int(std::function<int&()> arg,
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~arg();
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return -arg();
   if (__dredd_enabled_mutation(local_mutation_id + 3)) return !arg();
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return arg();
   return arg()++;
 }
 
@@ -62,6 +65,7 @@ static int __dredd_replace_unary_operator_PostDec_int(std::function<int&()> arg,
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~arg();
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return -arg();
   if (__dredd_enabled_mutation(local_mutation_id + 3)) return !arg();
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return arg();
   return arg()--;
 }
 
@@ -103,12 +107,14 @@ static int __dredd_replace_expr_int(std::function<int()> arg, int local_mutation
 static float& __dredd_replace_unary_operator_PreInc_float(std::function<float&()> arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return ++arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return --arg();
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg();
   return ++arg();
 }
 
 static float& __dredd_replace_unary_operator_PreDec_float(std::function<float&()> arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return --arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ++arg();
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg();
   return --arg();
 }
 
@@ -117,6 +123,7 @@ static float __dredd_replace_unary_operator_PostInc_float(std::function<float&()
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg()--;
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return -arg();
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return !arg();
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return arg();
   return arg()++;
 }
 
@@ -125,6 +132,7 @@ static float __dredd_replace_unary_operator_PostDec_float(std::function<float&()
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg()++;
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return -arg();
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return !arg();
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return arg();
   return arg()--;
 }
 
@@ -140,13 +148,13 @@ static float __dredd_replace_expr_float(std::function<float()> arg, int local_mu
 int main() {
   int x = __dredd_replace_expr_int_constant([&]() -> int { return 3; }, 0);
   float y = __dredd_replace_expr_float([&]() -> float { return 3.532; }, 5);
-  if (!__dredd_enabled_mutation(13)) { __dredd_replace_unary_operator_PostInc_int([&]() -> int& { return static_cast<int&>(x); }, 9); }
-  if (!__dredd_enabled_mutation(17)) { __dredd_replace_unary_operator_PostInc_float([&]() -> float& { return static_cast<float&>(y); }, 14); }
-  if (!__dredd_enabled_mutation(19)) { __dredd_replace_unary_operator_PreInc_int([&]() -> int& { return static_cast<int&>(x); }, 18); }
-  if (!__dredd_enabled_mutation(21)) { __dredd_replace_unary_operator_PreInc_float([&]() -> float& { return static_cast<float&>(y); }, 20); }
-  if (!__dredd_enabled_mutation(23)) { __dredd_replace_unary_operator_PreDec_int([&]() -> int& { return static_cast<int&>(x); }, 22); }
-  if (!__dredd_enabled_mutation(25)) { __dredd_replace_unary_operator_PreDec_float([&]() -> float& { return static_cast<float&>(y); }, 24); }
-  if (!__dredd_enabled_mutation(30)) { __dredd_replace_unary_operator_PostDec_int([&]() -> int& { return static_cast<int&>(x); }, 26); }
-  if (!__dredd_enabled_mutation(34)) { __dredd_replace_unary_operator_PostDec_float([&]() -> float& { return static_cast<float&>(y); }, 31); }
-  if (!__dredd_enabled_mutation(51)) { return __dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_unary_operator_Minus_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int_lvalue([&]() -> int& { return static_cast<int&>(x); }, 35)); }, 37)); }, 43)); }, 45); }
+  if (!__dredd_enabled_mutation(14)) { __dredd_replace_unary_operator_PostInc_int([&]() -> int& { return static_cast<int&>(x); }, 9); }
+  if (!__dredd_enabled_mutation(19)) { __dredd_replace_unary_operator_PostInc_float([&]() -> float& { return static_cast<float&>(y); }, 15); }
+  if (!__dredd_enabled_mutation(22)) { __dredd_replace_unary_operator_PreInc_int([&]() -> int& { return static_cast<int&>(x); }, 20); }
+  if (!__dredd_enabled_mutation(25)) { __dredd_replace_unary_operator_PreInc_float([&]() -> float& { return static_cast<float&>(y); }, 23); }
+  if (!__dredd_enabled_mutation(28)) { __dredd_replace_unary_operator_PreDec_int([&]() -> int& { return static_cast<int&>(x); }, 26); }
+  if (!__dredd_enabled_mutation(31)) { __dredd_replace_unary_operator_PreDec_float([&]() -> float& { return static_cast<float&>(y); }, 29); }
+  if (!__dredd_enabled_mutation(37)) { __dredd_replace_unary_operator_PostDec_int([&]() -> int& { return static_cast<int&>(x); }, 32); }
+  if (!__dredd_enabled_mutation(42)) { __dredd_replace_unary_operator_PostDec_float([&]() -> float& { return static_cast<float&>(y); }, 38); }
+  if (!__dredd_enabled_mutation(59)) { return __dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_unary_operator_Minus_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int_lvalue([&]() -> int& { return static_cast<int&>(x); }, 43)); }, 45)); }, 51)); }, 53); }
 }

--- a/test/single_file/unary_operator_opt.c.expected
+++ b/test/single_file/unary_operator_opt.c.expected
@@ -16,7 +16,7 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
       while(token) {
         int value = atoi(token);
         int local_value = value - 0;
-        if (local_value >= 0 && local_value < 21) {
+        if (local_value >= 0 && local_value < 20) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
           some_mutation_enabled = 1;
         }
@@ -33,7 +33,6 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
 static int __dredd_replace_unary_operator_Not_int_minus_one(int arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return ~arg;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return !arg;
-  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg;
   return ~arg;
 }
 
@@ -72,5 +71,5 @@ static int __dredd_replace_expr_int_constant(int arg, int local_mutation_id) {
 int main() {
   int x = __dredd_replace_expr_int_minus_one(~__dredd_replace_expr_int_zero(0, 0), 2);
   int y = __dredd_replace_expr_int_constant(~__dredd_replace_expr_int_one(1, 4), 7);
-  int z = __dredd_replace_expr_int_zero(__dredd_replace_unary_operator_Not_int_minus_one((__dredd_replace_expr_int_minus_one(-__dredd_replace_expr_int_one(1, 12), 15)), 17), 19);
+  int z = __dredd_replace_expr_int_zero(__dredd_replace_unary_operator_Not_int_minus_one((__dredd_replace_expr_int_minus_one(-__dredd_replace_expr_int_one(1, 12), 15)), 17), 18);
 }

--- a/test/single_file/unsigned_int.c.expected
+++ b/test/single_file/unsigned_int.c.expected
@@ -16,7 +16,7 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
       while(token) {
         int value = atoi(token);
         int local_value = value - 0;
-        if (local_value >= 0 && local_value < 16) {
+        if (local_value >= 0 && local_value < 15) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
           some_mutation_enabled = 1;
         }
@@ -55,7 +55,6 @@ static int __dredd_replace_unary_operator_Not_int(int arg, int local_mutation_id
 static int __dredd_replace_unary_operator_LNot_int_zero(int arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return !arg;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~arg;
-  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg;
   return !arg;
 }
 
@@ -77,6 +76,6 @@ static int __dredd_replace_expr_int_constant(int arg, int local_mutation_id) {
 }
 
 int main() {
-  unsigned int x = __dredd_replace_expr_unsigned_int_one(__dredd_replace_unary_operator_LNot_int_zero(__dredd_replace_expr_int_zero(0, 0), 2), 4);
-  unsigned int y = __dredd_replace_expr_unsigned_int_constant(__dredd_replace_unary_operator_Not_int(__dredd_replace_expr_int_constant(7, 6), 11), 13);
+  unsigned int x = __dredd_replace_expr_unsigned_int_one(__dredd_replace_unary_operator_LNot_int_zero(__dredd_replace_expr_int_zero(0, 0), 2), 3);
+  unsigned int y = __dredd_replace_expr_unsigned_int_constant(__dredd_replace_unary_operator_Not_int(__dredd_replace_expr_int_constant(7, 5), 10), 12);
 }

--- a/test/single_file/unsigned_int.cc.expected
+++ b/test/single_file/unsigned_int.cc.expected
@@ -18,7 +18,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
         if (!token.empty()) {
           int value = std::stoi(token);
           int local_value = value - 0;
-          if (local_value >= 0 && local_value < 15) {
+          if (local_value >= 0 && local_value < 14) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
             some_mutation_enabled = true;
           }
@@ -70,7 +70,6 @@ static int __dredd_replace_expr_int_constant(std::function<int()> arg, int local
 static bool __dredd_replace_unary_operator_LNot_bool_zero(std::function<bool()> arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return !arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~arg();
-  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg();
   return !arg();
 }
 
@@ -81,6 +80,6 @@ static bool __dredd_replace_expr_bool_false(std::function<bool()> arg, int local
 }
 
 int main() {
-  unsigned int x = __dredd_replace_expr_unsigned_int_one([&]() -> unsigned int { return __dredd_replace_unary_operator_LNot_bool_zero([&]() -> bool { return __dredd_replace_expr_bool_false([&]() -> bool { return 0; }, 0); }, 1); }, 3);
-  unsigned int y = __dredd_replace_expr_unsigned_int_constant([&]() -> unsigned int { return __dredd_replace_unary_operator_Not_int([&]() -> int { return __dredd_replace_expr_int_constant([&]() -> int { return 7; }, 5); }, 10); }, 12);
+  unsigned int x = __dredd_replace_expr_unsigned_int_one([&]() -> unsigned int { return __dredd_replace_unary_operator_LNot_bool_zero([&]() -> bool { return __dredd_replace_expr_bool_false([&]() -> bool { return 0; }, 0); }, 1); }, 2);
+  unsigned int y = __dredd_replace_expr_unsigned_int_constant([&]() -> unsigned int { return __dredd_replace_unary_operator_Not_int([&]() -> int { return __dredd_replace_expr_int_constant([&]() -> int { return 7; }, 4); }, 9); }, 11);
 }


### PR DESCRIPTION
Self-inverse unary operator removal is equivalent to insertion of another instance of the unary operator, so is is redundant to perform both mutations.

This change avoids the need for some checks to decide when operator removal was redudant due to expressions having constant values. That code had been identified to be buggy, which its removal also fixes.

Fixes #97.
Fixes #158.