### PR TITLE
Fix issue with C/C++ apps in CI

### DIFF
--- a/.github/workflows/c_apps.sh
+++ b/.github/workflows/c_apps.sh
@@ -95,10 +95,7 @@ pushd curl
       FILES+=("${f}")
   done
 
-  # TODO remove
-  echo ${DREDD_ROOT}
-
-  "${DREDD_EXECUTABLE}" --mutation-info-file temp.json -p "build/compile_commands.json" ${FILES}
+  "${DREDD_EXECUTABLE}" --mutation-info-file temp.json -p "build/compile_commands.json" "${FILES[@]}"
   pushd build
     ninja
     # TODO: run some tests
@@ -127,7 +124,7 @@ pushd zstd
   do
     FILES+=("${f}")
   done
-  "${DREDD_EXECUTABLE}" --mutation-info-file temp.json -p "zstd/temp/compile_commands.json" ${FILES}
+  "${DREDD_EXECUTABLE}" --mutation-info-file temp.json -p "zstd/temp/compile_commands.json" "${FILES[@]}"
   # Build mutated zstd
   make clean
   CFLAGS=-O0 make zstd-release

--- a/.github/workflows/c_apps.sh
+++ b/.github/workflows/c_apps.sh
@@ -59,7 +59,9 @@ pushd ./third_party/clang+llvm
   rm clang+llvm.tar.xz
 popd
 
-export PATH="./third_party/clang+llvm/bin:$PATH"
+DREDD_ROOT=$(pwd)
+
+export PATH="${DREDD_ROOT}/third_party/clang+llvm/bin:$PATH"
 
 export CC=clang
 export CXX=clang++
@@ -75,7 +77,6 @@ pushd build
 popd
 
 # Check that dredd works on some projects
-DREDD_ROOT=$(pwd)
 DREDD_EXECUTABLE="${DREDD_ROOT}/third_party/clang+llvm/bin/dredd"
 cp "${DREDD_ROOT}/build/src/dredd/dredd" "${DREDD_EXECUTABLE}"
 
@@ -124,7 +125,7 @@ pushd zstd
   do
     FILES+=("${f}")
   done
-  "${DREDD_EXECUTABLE}" --mutation-info-file temp.json -p "zstd/temp/compile_commands.json" "${FILES[@]}"
+  "${DREDD_EXECUTABLE}" --mutation-info-file temp.json -p "temp/compile_commands.json" "${FILES[@]}"
   # Build mutated zstd
   make clean
   CFLAGS=-O0 make zstd-release

--- a/.github/workflows/cxx_apps.sh
+++ b/.github/workflows/cxx_apps.sh
@@ -119,7 +119,7 @@ do
   [[ -e "$f" ]] || break
   FILES+=("${DREDD_ROOT}/${f}")
 done
-${DREDD_EXECUTABLE} --mutation-info-file temp.json -p "${DREDD_ROOT}/SPIRV-Tools/build/compile_commands.json" ${FILES}
+${DREDD_EXECUTABLE} --mutation-info-file temp.json -p "${DREDD_ROOT}/SPIRV-Tools/build/compile_commands.json" "${FILES[@]}"
 pushd SPIRV-Tools/build
   ninja test_val_abcde test_val_capability test_val_fghijklmnop test_val_limits test_val_stuvw
   ./test/val/test_val_abcde
@@ -147,7 +147,7 @@ do
   [[ -e "$f" ]] || break
   FILES+=("${DREDD_ROOT}/${f}")
 done
-${DREDD_EXECUTABLE} --mutation-info-file temp.json -p "${DREDD_ROOT}/llvm-project/build/compile_commands.json" ${FILES}
+${DREDD_EXECUTABLE} --mutation-info-file temp.json -p "${DREDD_ROOT}/llvm-project/build/compile_commands.json" "${FILES[@]}"
 pushd llvm-project/build
   ninja LLVMInstCombine
 popd

--- a/.github/workflows/cxx_apps.sh
+++ b/.github/workflows/cxx_apps.sh
@@ -59,7 +59,9 @@ pushd ./third_party/clang+llvm
   rm clang+llvm.tar.xz
 popd
 
-export PATH="./third_party/clang+llvm/bin:$PATH"
+DREDD_ROOT=$(pwd)
+
+export PATH="${DREDD_ROOT}/third_party/clang+llvm/bin:$PATH"
 
 export CC=clang
 export CXX=clang++
@@ -75,7 +77,6 @@ pushd build
 popd
 
 # Check that dredd works on some projects
-DREDD_ROOT=$(pwd)
 DREDD_EXECUTABLE="${DREDD_ROOT}/third_party/clang+llvm/bin/dredd"
 cp "${DREDD_ROOT}/build/src/dredd/dredd" "${DREDD_EXECUTABLE}"
 


### PR DESCRIPTION
A bash mistake meant that Dredd was only being applied to one file per project.