### PR TITLE
Fix protobuf issues

### DIFF
--- a/src/dredd/src/main.cc
+++ b/src/dredd/src/main.cc
@@ -103,6 +103,7 @@ int main(int argc, const char** argv) {
     std::string json_string;
     auto json_options = google::protobuf::util::JsonOptions();
     json_options.add_whitespace = true;
+    json_options.always_print_primitive_fields = true;
     auto json_generation_status = google::protobuf::util::MessageToJsonString(
         mutation_info, &json_string, json_options);
     if (json_generation_status.ok()) {

--- a/src/libdredd/src/mutation_replace_expr.cc
+++ b/src/libdredd/src/mutation_replace_expr.cc
@@ -270,8 +270,6 @@ void MutationReplaceExpr::GenerateFloatConstantReplacement(
       // Replace floating point expression with 0.0
       new_function << "  if (__dredd_enabled_mutation(local_mutation_id + "
                    << mutation_id_offset << ")) return 0.0;\n";
-      protobuf_message.add_instances()->set_mutation_id(mutation_id_base +
-                                                        mutation_id_offset);
       AddMutationInstance(
           mutation_id_base,
           protobufs::MutationReplaceExprAction::ReplaceWithZeroFloat,
@@ -313,8 +311,6 @@ void MutationReplaceExpr::GenerateIntegerConstantReplacement(
       // Replace expression with 0
       new_function << "  if (__dredd_enabled_mutation(local_mutation_id + "
                    << mutation_id_offset << ")) return 0;\n";
-      protobuf_message.add_instances()->set_mutation_id(mutation_id_base +
-                                                        mutation_id_offset);
       AddMutationInstance(
           mutation_id_base,
           protobufs::MutationReplaceExprAction::ReplaceWithZeroInt,


### PR DESCRIPTION
Fixes a problem where too many 'instance' entries were being added for certain mutations, and changes protobuf JSON export so that primitive values are always represented even if they are zero.