### PR TITLE
Resolved issue where no mutation was applied

### DIFF
--- a/test/single_file/misc002.cc
+++ b/test/single_file/misc002.cc
@@ -1,6 +1,4 @@
-#include <inttypes.h>
-
 void f() {
-  if (sizeof(uint32_t) == sizeof(uint64_t))
+  if (8 == 24)
     ;
 }

--- a/test/single_file/misc002.cc
+++ b/test/single_file/misc002.cc
@@ -1,0 +1,6 @@
+#include <inttypes.h>
+
+void f() {
+  if (sizeof(uint32_t) == sizeof(uint64_t))
+    ;
+}

--- a/test/single_file/misc002.cc.expected
+++ b/test/single_file/misc002.cc.expected
@@ -1,0 +1,63 @@
+#include <inttypes.h>
+
+#include <cinttypes>
+#include <cstddef>
+#include <functional>
+#include <string>
+
+static bool __dredd_some_mutation_enabled = true;
+static bool __dredd_enabled_mutation(int local_mutation_id) {
+  static bool initialized = false;
+  static uint64_t enabled_bitset[1];
+  if (!initialized) {
+    bool some_mutation_enabled = false;
+    const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
+    if (dredd_environment_variable != nullptr) {
+      std::string contents(dredd_environment_variable);
+      while (true) {
+        size_t pos = contents.find(",");
+        std::string token = (pos == std::string::npos ? contents : contents.substr(0, pos));
+        if (!token.empty()) {
+          int value = std::stoi(token);
+          int local_value = value - 0;
+          if (local_value >= 0 && local_value < 9) {
+            enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+            some_mutation_enabled = true;
+          }
+        }
+        if (pos == std::string::npos) {
+          break;
+        }
+        contents.erase(0, pos + 1);
+      }
+    }
+    initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
+  }
+  return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
+}
+
+static unsigned long __dredd_replace_expr_unsigned_long_constant(std::function<unsigned long()> arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg();
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg());
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 0;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 1;
+  return arg();
+}
+
+static bool __dredd_replace_expr_bool_false_omit_true(std::function<bool()> arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg();
+  return arg();
+}
+
+static bool __dredd_replace_binary_operator_EQ_unsigned_long_unsigned_long(std::function<unsigned long()> arg1, std::function<unsigned long()> arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1() == arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() >= arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1() <= arg2();
+  return arg1() == arg2();
+}
+
+void f() {
+  if (!__dredd_enabled_mutation(8)) { if (__dredd_replace_expr_bool_false_omit_true([&]() -> bool { return __dredd_replace_binary_operator_EQ_unsigned_long_unsigned_long([&]() -> unsigned long { return static_cast<unsigned long>(__dredd_replace_expr_unsigned_long_constant([&]() -> unsigned long { return sizeof(uint32_t); }, 0)); } , [&]() -> unsigned long { return static_cast<unsigned long>(__dredd_replace_expr_unsigned_long_constant([&]() -> unsigned long { return sizeof(uint64_t); }, 3)); }, 6); }, 8))
+    ; }
+}

--- a/test/single_file/misc002.cc.expected
+++ b/test/single_file/misc002.cc.expected
@@ -1,5 +1,3 @@
-#include <inttypes.h>
-
 #include <cinttypes>
 #include <cstddef>
 #include <functional>
@@ -27,7 +25,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
         if (!token.empty()) {
           int value = std::stoi(token);
           int local_value = value - 0;
-          if (local_value >= 0 && local_value < 9) {
+          if (local_value >= 0 && local_value < 13) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
             some_mutation_enabled = true;
           }
@@ -44,11 +42,13 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }
 
-static unsigned long __dredd_replace_expr_unsigned_long_constant(std::function<unsigned long()> arg, int local_mutation_id) {
+static int __dredd_replace_expr_int_constant(std::function<int()> arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg());
-  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 0;
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return -(arg());
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 0;
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return -1;
   return arg();
 }
 
@@ -57,7 +57,7 @@ static bool __dredd_replace_expr_bool_false_omit_true(std::function<bool()> arg,
   return arg();
 }
 
-static bool __dredd_replace_binary_operator_EQ_unsigned_long_unsigned_long(std::function<unsigned long()> arg1, std::function<unsigned long()> arg2, int local_mutation_id) {
+static bool __dredd_replace_binary_operator_EQ_int_int(std::function<int()> arg1, std::function<int()> arg2, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg1() == arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() >= arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1() <= arg2();
@@ -65,6 +65,6 @@ static bool __dredd_replace_binary_operator_EQ_unsigned_long_unsigned_long(std::
 }
 
 void f() {
-  if (!__dredd_enabled_mutation(8)) { if (__dredd_replace_expr_bool_false_omit_true([&]() -> bool { return __dredd_replace_binary_operator_EQ_unsigned_long_unsigned_long([&]() -> unsigned long { return static_cast<unsigned long>(__dredd_replace_expr_unsigned_long_constant([&]() -> unsigned long { return sizeof(uint32_t); }, 0)); } , [&]() -> unsigned long { return static_cast<unsigned long>(__dredd_replace_expr_unsigned_long_constant([&]() -> unsigned long { return sizeof(uint64_t); }, 3)); }, 6); }, 8))
+  if (!__dredd_enabled_mutation(12)) { if (__dredd_replace_expr_bool_false_omit_true([&]() -> bool { return __dredd_replace_binary_operator_EQ_int_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int_constant([&]() -> int { return 8; }, 0)); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int_constant([&]() -> int { return 24; }, 5)); }, 10); }, 12))
     ; }
 }

--- a/test/single_file/misc002.cc.expected
+++ b/test/single_file/misc002.cc.expected
@@ -5,10 +5,17 @@
 #include <functional>
 #include <string>
 
-static bool __dredd_some_mutation_enabled = true;
+
+#ifdef _MSC_VER
+#define thread_local __declspec(thread)
+#elif __APPLE__
+#define thread_local __thread
+#endif
+
+static thread_local bool __dredd_some_mutation_enabled = true;
 static bool __dredd_enabled_mutation(int local_mutation_id) {
-  static bool initialized = false;
-  static uint64_t enabled_bitset[1];
+  static thread_local bool initialized = false;
+  static thread_local uint64_t enabled_bitset[1];
   if (!initialized) {
     bool some_mutation_enabled = false;
     const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");

--- a/test/single_file/misc002.cc.noopt.expected
+++ b/test/single_file/misc002.cc.noopt.expected
@@ -1,5 +1,3 @@
-#include <inttypes.h>
-
 #include <cinttypes>
 #include <cstddef>
 #include <functional>
@@ -27,7 +25,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
         if (!token.empty()) {
           int value = std::stoi(token);
           int local_value = value - 0;
-          if (local_value >= 0 && local_value < 19) {
+          if (local_value >= 0 && local_value < 23) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
             some_mutation_enabled = true;
           }
@@ -44,12 +42,14 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }
 
-static unsigned long __dredd_replace_expr_unsigned_long(std::function<unsigned long()> arg, int local_mutation_id) {
+static int __dredd_replace_expr_int(std::function<int()> arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg());
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~(arg());
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 0;
-  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -(arg());
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 0;
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
   return arg();
 }
 
@@ -61,7 +61,7 @@ static bool __dredd_replace_expr_bool(std::function<bool()> arg, int local_mutat
   return arg();
 }
 
-static bool __dredd_replace_binary_operator_EQ_unsigned_long_unsigned_long(std::function<unsigned long()> arg1, std::function<unsigned long()> arg2, int local_mutation_id) {
+static bool __dredd_replace_binary_operator_EQ_int_int(std::function<int()> arg1, std::function<int()> arg2, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg1() == arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() != arg2();
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1() >= arg2();
@@ -74,6 +74,6 @@ static bool __dredd_replace_binary_operator_EQ_unsigned_long_unsigned_long(std::
 }
 
 void f() {
-  if (!__dredd_enabled_mutation(18)) { if (__dredd_replace_expr_bool([&]() -> bool { return __dredd_replace_binary_operator_EQ_unsigned_long_unsigned_long([&]() -> unsigned long { return static_cast<unsigned long>(__dredd_replace_expr_unsigned_long([&]() -> unsigned long { return sizeof(uint32_t); }, 0)); } , [&]() -> unsigned long { return static_cast<unsigned long>(__dredd_replace_expr_unsigned_long([&]() -> unsigned long { return sizeof(uint64_t); }, 4)); }, 8); }, 15))
+  if (!__dredd_enabled_mutation(22)) { if (__dredd_replace_expr_bool([&]() -> bool { return __dredd_replace_binary_operator_EQ_int_int([&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return 8; }, 0)); } , [&]() -> int { return static_cast<int>(__dredd_replace_expr_int([&]() -> int { return 24; }, 6)); }, 12); }, 19))
     ; }
 }

--- a/test/single_file/misc002.cc.noopt.expected
+++ b/test/single_file/misc002.cc.noopt.expected
@@ -1,0 +1,72 @@
+#include <inttypes.h>
+
+#include <cinttypes>
+#include <cstddef>
+#include <functional>
+#include <string>
+
+static bool __dredd_some_mutation_enabled = true;
+static bool __dredd_enabled_mutation(int local_mutation_id) {
+  static bool initialized = false;
+  static uint64_t enabled_bitset[1];
+  if (!initialized) {
+    bool some_mutation_enabled = false;
+    const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
+    if (dredd_environment_variable != nullptr) {
+      std::string contents(dredd_environment_variable);
+      while (true) {
+        size_t pos = contents.find(",");
+        std::string token = (pos == std::string::npos ? contents : contents.substr(0, pos));
+        if (!token.empty()) {
+          int value = std::stoi(token);
+          int local_value = value - 0;
+          if (local_value >= 0 && local_value < 19) {
+            enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+            some_mutation_enabled = true;
+          }
+        }
+        if (pos == std::string::npos) {
+          break;
+        }
+        contents.erase(0, pos + 1);
+      }
+    }
+    initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
+  }
+  return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
+}
+
+static unsigned long __dredd_replace_expr_unsigned_long(std::function<unsigned long()> arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg();
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg());
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~(arg());
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 0;
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 1;
+  return arg();
+}
+
+static bool __dredd_replace_expr_bool(std::function<bool()> arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg();
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg());
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return true;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return false;
+  return arg();
+}
+
+static bool __dredd_replace_binary_operator_EQ_unsigned_long_unsigned_long(std::function<unsigned long()> arg1, std::function<unsigned long()> arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1() == arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1() != arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1() >= arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1() > arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return arg1() <= arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return arg1() < arg2();
+  if (__dredd_enabled_mutation(local_mutation_id + 5)) return arg1();
+  if (__dredd_enabled_mutation(local_mutation_id + 6)) return arg2();
+  return arg1() == arg2();
+}
+
+void f() {
+  if (!__dredd_enabled_mutation(18)) { if (__dredd_replace_expr_bool([&]() -> bool { return __dredd_replace_binary_operator_EQ_unsigned_long_unsigned_long([&]() -> unsigned long { return static_cast<unsigned long>(__dredd_replace_expr_unsigned_long([&]() -> unsigned long { return sizeof(uint32_t); }, 0)); } , [&]() -> unsigned long { return static_cast<unsigned long>(__dredd_replace_expr_unsigned_long([&]() -> unsigned long { return sizeof(uint64_t); }, 4)); }, 8); }, 15))
+    ; }
+}

--- a/test/single_file/misc002.cc.noopt.expected
+++ b/test/single_file/misc002.cc.noopt.expected
@@ -5,10 +5,17 @@
 #include <functional>
 #include <string>
 
-static bool __dredd_some_mutation_enabled = true;
+
+#ifdef _MSC_VER
+#define thread_local __declspec(thread)
+#elif __APPLE__
+#define thread_local __thread
+#endif
+
+static thread_local bool __dredd_some_mutation_enabled = true;
 static bool __dredd_enabled_mutation(int local_mutation_id) {
-  static bool initialized = false;
-  static uint64_t enabled_bitset[1];
+  static thread_local bool initialized = false;
+  static thread_local uint64_t enabled_bitset[1];
   if (!initialized) {
     bool some_mutation_enabled = false;
     const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");


### PR DESCRIPTION
No mutation was being applied to a trivial equality test. Decided to commit to simplifying the design of Dredd to avoid the requirement that every generated mutation object will lead to at least one runtime mutation.

Related issue: #171