### PR TITLE
Insert Dredd declarations at very start of file

### DIFF
--- a/src/libdredd/include_private/include/libdredd/mutate_visitor.h
+++ b/src/libdredd/include_private/include/libdredd/mutate_visitor.h
@@ -101,11 +101,6 @@ class MutateVisitor : public clang::RecursiveASTVisitor<MutateVisitor> {
     return mutation_tree_root_;
   }
 
-  [[nodiscard]] clang::SourceLocation GetStartLocationOfFirstDeclInSourceFile()
-      const {
-    return start_location_of_first_decl_in_source_file_;
-  }
-
  private:
   // Helper class that uses the RAII pattern to support pushing a new mutation
   // tree node on to the stack of mutation tree nodes used during visitation,
@@ -169,10 +164,6 @@ class MutateVisitor : public clang::RecursiveASTVisitor<MutateVisitor> {
 
   const clang::CompilerInstance* compiler_instance_;
   bool optimise_mutations_;
-
-  // Records the start locat of the very first declaration in the source file,
-  // before which Dredd's prelude can be placed.
-  clang::SourceLocation start_location_of_first_decl_in_source_file_;
 
   // Tracks the nest of declarations currently being traversed. Any new Dredd
   // functions will be put before the start of the current nest, which avoids

--- a/src/libdredd/src/mutate_visitor.cc
+++ b/src/libdredd/src/mutate_visitor.cc
@@ -109,23 +109,6 @@ bool MutateVisitor::TraverseDecl(clang::Decl* decl) {
     // consider it for mutation.
     return true;
   }
-  const clang::BeforeThanCompare<clang::SourceLocation> comparator(
-      compiler_instance_->getSourceManager());
-  if (start_location_of_first_decl_in_source_file_.isInvalid() ||
-      comparator(source_range_in_main_file.getBegin(),
-                 start_location_of_first_decl_in_source_file_)) {
-    // This is the first declaration wholly contained in the main file that has
-    // been encountered so far: record it so that the dredd prelude can be
-    // inserted before it.
-    //
-    // The order in which declarations appear in the source file may not exactly
-    // match the order they are visited in the AST (for example, a typedef
-    // declaration is visited after the associated type declaration, even though
-    // the 'typedef' keyword occurs first in the AST), thus this location is
-    // updated each time a declaration that appears earlier is encountered.
-    start_location_of_first_decl_in_source_file_ =
-        source_range_in_main_file.getBegin();
-  }
   if (llvm::dyn_cast<clang::StaticAssertDecl>(decl) != nullptr) {
     // It does not make sense to mutate static assertions, as (a) this will
     // very likely lead to compile-time failures due to the assertion not

--- a/src/libdredd/src/mutate_visitor.cc
+++ b/src/libdredd/src/mutate_visitor.cc
@@ -35,7 +35,6 @@
 #include "clang/AST/TypeLoc.h"
 #include "clang/Basic/LangOptions.h"
 #include "clang/Basic/SourceLocation.h"
-#include "clang/Basic/SourceManager.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "libdredd/mutation.h"
 #include "libdredd/mutation_remove_stmt.h"

--- a/test/single_file/add.c.expected
+++ b/test/single_file/add.c.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/add.c.noopt.expected
+++ b/test/single_file/add.c.noopt.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/add_float.c.expected
+++ b/test/single_file/add_float.c.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/add_float.c.noopt.expected
+++ b/test/single_file/add_float.c.noopt.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/add_mul.c.expected
+++ b/test/single_file/add_mul.c.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/add_mul.c.noopt.expected
+++ b/test/single_file/add_mul.c.noopt.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/add_type_aliases.c.noopt.expected
+++ b/test/single_file/add_type_aliases.c.noopt.expected
@@ -1,7 +1,5 @@
 #include <inttypes.h>
-#include <stddef.h>
-
-#include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -153,6 +151,9 @@ static int __dredd_replace_binary_operator_Add_arg1_int_arg2_int(int arg1, int a
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return arg2;
   return arg1 + arg2;
 }
+
+#include <inttypes.h>
+#include <stddef.h>
 
 int main() {
   unsigned a;

--- a/test/single_file/add_type_aliases.cc.noopt.expected
+++ b/test/single_file/add_type_aliases.cc.noopt.expected
@@ -1,8 +1,5 @@
 #include <cinttypes>
 #include <cstddef>
-
-#include <cinttypes>
-#include <cstddef>
 #include <functional>
 #include <string>
 
@@ -156,6 +153,9 @@ static int __dredd_replace_binary_operator_Add_arg1_int_arg2_int(int arg1, int a
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return arg2;
   return arg1 + arg2;
 }
+
+#include <cinttypes>
+#include <cstddef>
 
 int main() {
   unsigned a;

--- a/test/single_file/assign.c.expected
+++ b/test/single_file/assign.c.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/assign.c.noopt.expected
+++ b/test/single_file/assign.c.noopt.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/basic.c.expected
+++ b/test/single_file/basic.c.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/basic.c.noopt.expected
+++ b/test/single_file/basic.c.noopt.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/binary_long_long_and_long_name_clash.c.noopt.expected
+++ b/test/single_file/binary_long_long_and_long_name_clash.c.noopt.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/binary_operands_both_zero.c.expected
+++ b/test/single_file/binary_operands_both_zero.c.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/binary_operands_both_zero.c.noopt.expected
+++ b/test/single_file/binary_operands_both_zero.c.noopt.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/bitfield.c.expected
+++ b/test/single_file/bitfield.c.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/boolean_not_insertion_optimisation.c.expected
+++ b/test/single_file/boolean_not_insertion_optimisation.c.expected
@@ -1,6 +1,5 @@
-#include <stdbool.h>
-
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -72,6 +71,8 @@ static int __dredd_replace_binary_operator_LAnd_arg1_int_arg2_int_rhs_zero_lhs_o
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return 1;
   return arg;
 }
+#include <stdbool.h>
+
 int main() {
   int x = __dredd_replace_expr_int_zero(__dredd_replace_binary_operator_LAnd_arg1_int_arg2_int_rhs_zero_lhs_one_outer(__dredd_replace_binary_operator_LAnd_arg1_int_arg2_int_rhs_zero_lhs_one_lhs(__dredd_replace_expr_int_one(1, 0), 5) && __dredd_replace_binary_operator_LAnd_arg1_int_arg2_int_rhs_zero_lhs_one_rhs(__dredd_replace_expr_int_zero(0, 3), 5), 5), 8);
 }

--- a/test/single_file/boolean_not_insertion_optimisation.c.noopt.expected
+++ b/test/single_file/boolean_not_insertion_optimisation.c.noopt.expected
@@ -1,6 +1,5 @@
-#include <stdbool.h>
-
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -68,6 +67,8 @@ static int __dredd_replace_binary_operator_LAnd_arg1_int_arg2_int_lhs(int arg, i
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return 1;
   return arg;
 }
+#include <stdbool.h>
+
 int main() {
   int x = __dredd_replace_expr_int(__dredd_replace_binary_operator_LAnd_arg1_int_arg2_int_outer(__dredd_replace_binary_operator_LAnd_arg1_int_arg2_int_lhs(__dredd_replace_expr_int(1, 0), 12) && __dredd_replace_binary_operator_LAnd_arg1_int_arg2_int_rhs(__dredd_replace_expr_int(0, 6), 12), 12), 15);
 }

--- a/test/single_file/comma.c.expected
+++ b/test/single_file/comma.c.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/comma.c.noopt.expected
+++ b/test/single_file/comma.c.noopt.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/comment_at_start_of_file.cc
+++ b/test/single_file/comment_at_start_of_file.cc
@@ -1,0 +1,5 @@
+// Hello
+
+int main() {
+  return 42;
+}

--- a/test/single_file/comment_at_start_of_file.cc.expected
+++ b/test/single_file/comment_at_start_of_file.cc.expected
@@ -25,7 +25,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
         if (!token.empty()) {
           int value = std::stoi(token);
           int local_value = value - 0;
-          if (local_value >= 0 && local_value < 13) {
+          if (local_value >= 0 && local_value < 6) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
             some_mutation_enabled = true;
           }
@@ -42,26 +42,18 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }
 
-static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
+static int __dredd_replace_expr_int_constant(int arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg;
-  if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg);
-  if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~(arg);
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -(arg);
-  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 0;
-  if (__dredd_enabled_mutation(local_mutation_id + 4)) return 1;
-  if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return -(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 0;
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return -1;
   return arg;
 }
 
-#include <cstddef>
+// Hello
 
-struct A {
-  size_t x;
-  size_t y;
-};
-
-void foo(A arg);
-
-void bar() {
-  if (!__dredd_enabled_mutation(12)) { foo({static_cast<unsigned long>(__dredd_replace_expr_int(0, 0)), static_cast<unsigned long>(__dredd_replace_expr_int(0, 6))}); }
+int main() {
+  if (!__dredd_enabled_mutation(5)) { return __dredd_replace_expr_int_constant(42, 0); }
 }

--- a/test/single_file/comment_at_start_of_file.cc.noopt.expected
+++ b/test/single_file/comment_at_start_of_file.cc.noopt.expected
@@ -25,7 +25,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
         if (!token.empty()) {
           int value = std::stoi(token);
           int local_value = value - 0;
-          if (local_value >= 0 && local_value < 13) {
+          if (local_value >= 0 && local_value < 7) {
             enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
             some_mutation_enabled = true;
           }
@@ -53,15 +53,8 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   return arg;
 }
 
-#include <cstddef>
+// Hello
 
-struct A {
-  size_t x;
-  size_t y;
-};
-
-void foo(A arg);
-
-void bar() {
-  if (!__dredd_enabled_mutation(12)) { foo({static_cast<unsigned long>(__dredd_replace_expr_int(0, 0)), static_cast<unsigned long>(__dredd_replace_expr_int(0, 6))}); }
+int main() {
+  if (!__dredd_enabled_mutation(6)) { return __dredd_replace_expr_int(42, 0); }
 }

--- a/test/single_file/const_sized_array_int.c.expected
+++ b/test/single_file/const_sized_array_int.c.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/const_sized_array_int.c.noopt.expected
+++ b/test/single_file/const_sized_array_int.c.noopt.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/define_at_start_of_file.c
+++ b/test/single_file/define_at_start_of_file.c
@@ -1,0 +1,4 @@
+#define API
+API int func1();
+
+int main() { int a = 1; }

--- a/test/single_file/define_at_start_of_file.c.expected
+++ b/test/single_file/define_at_start_of_file.c.expected
@@ -26,7 +26,7 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
       while(token) {
         int value = atoi(token);
         int local_value = value - 0;
-        if (local_value >= 0 && local_value < 27) {
+        if (local_value >= 0 && local_value < 3) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
           some_mutation_enabled = 1;
         }
@@ -40,25 +40,15 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
   return enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64));
 }
 
-static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
+static int __dredd_replace_expr_int_one(int arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg;
-  if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg);
-  if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~(arg);
-  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -(arg);
-  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 0;
-  if (__dredd_enabled_mutation(local_mutation_id + 4)) return 1;
-  if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 0;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
   return arg;
 }
 
-struct S {
-  int a : 3;
-  int b : 3;
-};
+#define API
+API int func1();
 
-void foo() {
-  struct S myS;
-  if (!__dredd_enabled_mutation(12)) { __dredd_replace_expr_int(myS.a = __dredd_replace_expr_int(myS.b, 0), 6); }
-  if (!__dredd_enabled_mutation(19)) { __dredd_replace_expr_int(myS.a++, 13); }
-  if (!__dredd_enabled_mutation(26)) { __dredd_replace_expr_int(--myS.b, 20); }
-}
+int main() { int a = __dredd_replace_expr_int_one(1, 0); }

--- a/test/single_file/define_at_start_of_file.c.noopt.expected
+++ b/test/single_file/define_at_start_of_file.c.noopt.expected
@@ -26,7 +26,7 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
       while(token) {
         int value = atoi(token);
         int local_value = value - 0;
-        if (local_value >= 0 && local_value < 27) {
+        if (local_value >= 0 && local_value < 6) {
           enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
           some_mutation_enabled = 1;
         }
@@ -51,14 +51,7 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   return arg;
 }
 
-struct S {
-  int a : 3;
-  int b : 3;
-};
+#define API
+API int func1();
 
-void foo() {
-  struct S myS;
-  if (!__dredd_enabled_mutation(12)) { __dredd_replace_expr_int(myS.a = __dredd_replace_expr_int(myS.b, 0), 6); }
-  if (!__dredd_enabled_mutation(19)) { __dredd_replace_expr_int(myS.a++, 13); }
-  if (!__dredd_enabled_mutation(26)) { __dredd_replace_expr_int(--myS.b, 20); }
-}
+int main() { int a = __dredd_replace_expr_int(1, 0); }

--- a/test/single_file/define_in_first_decl.c.expected
+++ b/test/single_file/define_in_first_decl.c.expected
@@ -1,6 +1,5 @@
-#define TYPE int
-
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -67,6 +66,8 @@ static int __dredd_replace_binary_operator_Add_arg1_int_arg2_int_lhs_one(int arg
   if (__dredd_enabled_mutation(local_mutation_id + 3)) return arg2;
   return arg1 + arg2;
 }
+
+#define TYPE int
 
 TYPE foo() {
   if (!__dredd_enabled_mutation(17)) { return __dredd_replace_expr_int_constant(__dredd_replace_binary_operator_Add_arg1_int_arg2_int_lhs_one(__dredd_replace_expr_int_one(1, 0) , __dredd_replace_expr_int_constant(2, 3), 8), 12); }

--- a/test/single_file/define_in_first_decl.c.noopt.expected
+++ b/test/single_file/define_in_first_decl.c.noopt.expected
@@ -1,6 +1,5 @@
-#define TYPE int
-
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -62,6 +61,8 @@ static int __dredd_replace_binary_operator_Add_arg1_int_arg2_int(int arg1, int a
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return arg2;
   return arg1 + arg2;
 }
+
+#define TYPE int
 
 TYPE foo() {
   if (!__dredd_enabled_mutation(24)) { return __dredd_replace_expr_int(__dredd_replace_binary_operator_Add_arg1_int_arg2_int(__dredd_replace_expr_int(1, 0) , __dredd_replace_expr_int(2, 6), 12), 18); }

--- a/test/single_file/define_in_first_decl.cc.expected
+++ b/test/single_file/define_in_first_decl.cc.expected
@@ -1,5 +1,3 @@
-#define TYPE int
-
 #include <cinttypes>
 #include <cstddef>
 #include <functional>
@@ -70,6 +68,8 @@ static int __dredd_replace_binary_operator_Add_arg1_int_arg2_int_lhs_one(int arg
   if (__dredd_enabled_mutation(local_mutation_id + 3)) return arg2;
   return arg1 + arg2;
 }
+
+#define TYPE int
 
 TYPE foo() {
   if (!__dredd_enabled_mutation(17)) { return __dredd_replace_expr_int_constant(__dredd_replace_binary_operator_Add_arg1_int_arg2_int_lhs_one(__dredd_replace_expr_int_one(1, 0) , __dredd_replace_expr_int_constant(2, 3), 8), 12); }

--- a/test/single_file/define_in_first_decl.cc.noopt.expected
+++ b/test/single_file/define_in_first_decl.cc.noopt.expected
@@ -1,5 +1,3 @@
-#define TYPE int
-
 #include <cinttypes>
 #include <cstddef>
 #include <functional>
@@ -65,6 +63,8 @@ static int __dredd_replace_binary_operator_Add_arg1_int_arg2_int(int arg1, int a
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return arg2;
   return arg1 + arg2;
 }
+
+#define TYPE int
 
 TYPE foo() {
   if (!__dredd_enabled_mutation(24)) { return __dredd_replace_expr_int(__dredd_replace_binary_operator_Add_arg1_int_arg2_int(__dredd_replace_expr_int(1, 0) , __dredd_replace_expr_int(2, 6), 12), 18); }

--- a/test/single_file/enum.c.noopt.expected
+++ b/test/single_file/enum.c.noopt.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/expr_lvalue.c.expected
+++ b/test/single_file/expr_lvalue.c.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/expr_lvalue.c.noopt.expected
+++ b/test/single_file/expr_lvalue.c.noopt.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/expr_macro.c.expected
+++ b/test/single_file/expr_macro.c.expected
@@ -1,6 +1,5 @@
-#define E (1, 2, 3)
-
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -40,6 +39,8 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
   }
   return enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64));
 }
+
+#define E (1, 2, 3)
 
 void foo(int, int, int);
 

--- a/test/single_file/expr_macro.c.noopt.expected
+++ b/test/single_file/expr_macro.c.noopt.expected
@@ -1,6 +1,5 @@
-#define E (1, 2, 3)
-
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -40,6 +39,8 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
   }
   return enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64));
 }
+
+#define E (1, 2, 3)
 
 void foo(int, int, int);
 

--- a/test/single_file/expr_macro.cc.expected
+++ b/test/single_file/expr_macro.cc.expected
@@ -1,5 +1,3 @@
-#define E (1, 2, 3)
-
 #include <cinttypes>
 #include <cstddef>
 #include <functional>
@@ -43,6 +41,8 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   }
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }
+
+#define E (1, 2, 3)
 
 void foo(int, int, int);
 

--- a/test/single_file/expr_macro.cc.noopt.expected
+++ b/test/single_file/expr_macro.cc.noopt.expected
@@ -1,5 +1,3 @@
-#define E (1, 2, 3)
-
 #include <cinttypes>
 #include <cstddef>
 #include <functional>
@@ -43,6 +41,8 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   }
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }
+
+#define E (1, 2, 3)
 
 void foo(int, int, int);
 

--- a/test/single_file/float_binary_opts.c.expected
+++ b/test/single_file/float_binary_opts.c.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/float_binary_opts.c.noopt.expected
+++ b/test/single_file/float_binary_opts.c.noopt.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/float_unary_opt.c.expected
+++ b/test/single_file/float_unary_opt.c.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/float_unary_opt.c.noopt.expected
+++ b/test/single_file/float_unary_opt.c.noopt.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/floats.c.expected
+++ b/test/single_file/floats.c.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/floats.c.noopt.expected
+++ b/test/single_file/floats.c.noopt.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/initializer.c.expected
+++ b/test/single_file/initializer.c.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/initializer.c.noopt.expected
+++ b/test/single_file/initializer.c.noopt.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/initializer_list.cc.expected
+++ b/test/single_file/initializer_list.cc.expected
@@ -1,5 +1,3 @@
-#include <cstddef>
-
 #include <cinttypes>
 #include <cstddef>
 #include <functional>
@@ -43,6 +41,8 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   }
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }
+
+#include <cstddef>
 
 struct A {
   size_t x;

--- a/test/single_file/left_shift_opt.c.expected
+++ b/test/single_file/left_shift_opt.c.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/left_shift_opt.c.noopt.expected
+++ b/test/single_file/left_shift_opt.c.noopt.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/logical_and.c.expected
+++ b/test/single_file/logical_and.c.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/logical_and.c.noopt.expected
+++ b/test/single_file/logical_and.c.noopt.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/logical_or.c.expected
+++ b/test/single_file/logical_or.c.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/logical_or.c.noopt.expected
+++ b/test/single_file/logical_or.c.noopt.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/negative_switch_case.c.expected
+++ b/test/single_file/negative_switch_case.c.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/negative_switch_case.c.noopt.expected
+++ b/test/single_file/negative_switch_case.c.noopt.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/non_const_sized_array.c.expected
+++ b/test/single_file/non_const_sized_array.c.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/non_const_sized_array.c.noopt.expected
+++ b/test/single_file/non_const_sized_array.c.noopt.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/positive_int_as_minus_one.c.expected
+++ b/test/single_file/positive_int_as_minus_one.c.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/positive_int_as_minus_one.c.noopt.expected
+++ b/test/single_file/positive_int_as_minus_one.c.noopt.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/post_inc_volatile.c.expected
+++ b/test/single_file/post_inc_volatile.c.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/post_inc_volatile.c.noopt.expected
+++ b/test/single_file/post_inc_volatile.c.noopt.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/preprocessor_if.c.expected
+++ b/test/single_file/preprocessor_if.c.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/preprocessor_if.c.noopt.expected
+++ b/test/single_file/preprocessor_if.c.noopt.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/printing.c.expected
+++ b/test/single_file/printing.c.expected
@@ -1,6 +1,5 @@
-#include <stdio.h>
-
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -40,6 +39,8 @@ static int __dredd_enabled_mutation(int local_mutation_id) {
   }
   return enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64));
 }
+
+#include <stdio.h>
 
 int main() {
   if (!__dredd_enabled_mutation(0)) { printf("%s\n", "A\n"); }

--- a/test/single_file/printing.c.noopt.expected
+++ b/test/single_file/printing.c.noopt.expected
@@ -1,6 +1,5 @@
-#include <stdio.h>
-
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -51,6 +50,8 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
   return arg;
 }
+
+#include <stdio.h>
 
 int main() {
   if (!__dredd_enabled_mutation(6)) { __dredd_replace_expr_int(printf("%s\n", "A\n"), 0); }

--- a/test/single_file/printing.cc.expected
+++ b/test/single_file/printing.cc.expected
@@ -1,5 +1,3 @@
-#include <iostream>
-
 #include <cinttypes>
 #include <cstddef>
 #include <functional>
@@ -43,6 +41,8 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   }
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }
+
+#include <iostream>
 
 int main() {
   if (!__dredd_enabled_mutation(0)) { std::cout << "A\n"; }

--- a/test/single_file/printing.cc.noopt.expected
+++ b/test/single_file/printing.cc.noopt.expected
@@ -1,5 +1,3 @@
-#include <iostream>
-
 #include <cinttypes>
 #include <cstddef>
 #include <functional>
@@ -43,6 +41,8 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   }
   return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
 }
+
+#include <iostream>
 
 int main() {
   if (!__dredd_enabled_mutation(0)) { std::cout << "A\n"; }

--- a/test/single_file/typedef.c.noopt.expected
+++ b/test/single_file/typedef.c.noopt.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/unary.c.expected
+++ b/test/single_file/unary.c.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/unary.c.noopt.expected
+++ b/test/single_file/unary.c.noopt.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/unary_logical_not.c.expected
+++ b/test/single_file/unary_logical_not.c.expected
@@ -1,6 +1,5 @@
-#include <stdbool.h>
-
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -72,6 +71,8 @@ static bool __dredd_replace_expr_bool(bool arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return 0;
   return arg;
 }
+
+#include <stdbool.h>
 
 int main() {
   bool y = __dredd_replace_expr_bool_true(true, 0);

--- a/test/single_file/unary_logical_not.c.noopt.expected
+++ b/test/single_file/unary_logical_not.c.noopt.expected
@@ -1,6 +1,5 @@
-#include <stdbool.h>
-
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -67,6 +66,8 @@ static bool __dredd_replace_expr_bool(bool arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return 0;
   return arg;
 }
+
+#include <stdbool.h>
 
 int main() {
   bool y = __dredd_replace_expr_bool(__dredd_replace_expr_int(true, 0), 6);

--- a/test/single_file/unary_minus.c.expected
+++ b/test/single_file/unary_minus.c.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/unary_minus.c.noopt.expected
+++ b/test/single_file/unary_minus.c.noopt.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/unary_operator_opt.c.expected
+++ b/test/single_file/unary_operator_opt.c.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/unary_operator_opt.c.noopt.expected
+++ b/test/single_file/unary_operator_opt.c.noopt.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/unsigned_int.c.expected
+++ b/test/single_file/unsigned_int.c.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/unsigned_int.c.noopt.expected
+++ b/test/single_file/unsigned_int.c.noopt.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/volatile.c.expected
+++ b/test/single_file/volatile.c.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/single_file/volatile.c.noopt.expected
+++ b/test/single_file/volatile.c.noopt.expected
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 


### PR DESCRIPTION
Rather than looking for the first declaration in the file and inserting Dredd declarations before that, declarations are now inserted at the very beginning of the source file being mutated. This means that they even precede preprocessor directives and comments. This fixes an issue where declarations were being placed at invalid positions in the presence of certain uses of preprocessor directives.

Fixes #198.