### PR TITLE
Error if check-format isn't installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,13 @@ This project uses the [Google C++ style guide](https://google.github.io/stylegui
 
 The following guide assumes that you are using Linux for development.
 
+### Prerequisites
+
+- Python
+- cmake-format python package (used for `./check_format`)
+                                       
+### Scripts Directory
+
 The `scripts` directory contains a number of commands that are useful for developers. To make use of these commands,
 you must first run `./dev_shell.sh.template` from the root of the Dredd repo. This will ensure that the necessary
 environment variables are set as well as building tools that are used in other check commands.

--- a/scripts/check_format.sh
+++ b/scripts/check_format.sh
@@ -20,6 +20,12 @@ set -x
 
 cd "${DREDD_REPO_ROOT}"
 
+if ! cmake-format --version
+then
+  echo "cmake-format is not installed."
+  exit 1
+fi
+
 dredd_source_files.sh | xargs -t clang-format --dry-run --Werror
 for f in $(dredd_cmake_files.sh)
 do


### PR DESCRIPTION
Check if the `check-format` python package is installed at the start of `./check_format` and return a non-zero error code. Update the documentation acordingly

Fixes: #180.