### PR TITLE
Insert Dredd declartions before first function

### DIFF
--- a/src/libdredd/include_private/include/libdredd/mutate_visitor.h
+++ b/src/libdredd/include_private/include/libdredd/mutate_visitor.h
@@ -179,9 +179,12 @@ class MutateVisitor : public clang::RecursiveASTVisitor<MutateVisitor> {
   // this special case, so that it can be ignored.
   bool IsConversionOfEnumToConstructor(const clang::Expr& expr) const;
 
-  // It is safe to Dredd's prelude before the first function we encounter in a
-  // file as Dredd only makes source code modifications inside functions.
+  // It is safe to put Dredd's prelude before the first function we encounter in
+  // a file as Dredd only makes source code modifications inside functions.
   void UpdateStartLocationOfFirstFunctionInSourceFile();
+
+  // TODO(JLJ): Add comment
+  void AddMutation(std::unique_ptr<Mutation> mutation);
 
   const clang::CompilerInstance* compiler_instance_;
   bool optimise_mutations_;

--- a/src/libdredd/include_private/include/libdredd/mutate_visitor.h
+++ b/src/libdredd/include_private/include/libdredd/mutate_visitor.h
@@ -179,6 +179,8 @@ class MutateVisitor : public clang::RecursiveASTVisitor<MutateVisitor> {
   // this special case, so that it can be ignored.
   bool IsConversionOfEnumToConstructor(const clang::Expr& expr) const;
 
+  // It is safe to Dredd's prelude before the first function we encounter in a
+  // file as Dredd only makes source code modifications inside functions.
   void UpdateStartLocationOfFirstFunctionInSourceFile();
 
   const clang::CompilerInstance* compiler_instance_;

--- a/src/libdredd/include_private/include/libdredd/mutate_visitor.h
+++ b/src/libdredd/include_private/include/libdredd/mutate_visitor.h
@@ -108,6 +108,11 @@ class MutateVisitor : public clang::RecursiveASTVisitor<MutateVisitor> {
     return constant_sized_arrays_to_rewrite_;
   }
 
+  [[nodiscard]] clang::SourceLocation
+  GetStartLocationOfFirstFunctionInSourceFile() const {
+    return start_location_of_first_function_in_source_file_;
+  }
+
  private:
   // Helper class that uses the RAII pattern to support pushing a new mutation
   // tree node on to the stack of mutation tree nodes used during visitation,
@@ -174,8 +179,14 @@ class MutateVisitor : public clang::RecursiveASTVisitor<MutateVisitor> {
   // this special case, so that it can be ignored.
   bool IsConversionOfEnumToConstructor(const clang::Expr& expr) const;
 
+  void UpdateStartLocationOfFirstFunctionInSourceFile();
+
   const clang::CompilerInstance* compiler_instance_;
   bool optimise_mutations_;
+
+  // Records the start location of the very first function definition in the
+  // source file, before which Dredd's prelude can be placed.
+  clang::SourceLocation start_location_of_first_function_in_source_file_;
 
   // Tracks the nest of declarations currently being traversed. Any new Dredd
   // functions will be put before the start of the current nest, which avoids

--- a/src/libdredd/include_private/include/libdredd/mutate_visitor.h
+++ b/src/libdredd/include_private/include/libdredd/mutate_visitor.h
@@ -184,7 +184,8 @@ class MutateVisitor : public clang::RecursiveASTVisitor<MutateVisitor> {
   // a file as Dredd only makes source code modifications inside functions.
   void UpdateStartLocationOfFirstFunctionInSourceFile();
 
-  // Adds details of a mutation that can be applied, and performs associated bookkeeping.
+  // Adds details of a mutation that can be applied, and performs associated
+  // bookkeeping.
   void AddMutation(std::unique_ptr<Mutation> mutation);
 
   const clang::CompilerInstance* compiler_instance_;

--- a/src/libdredd/include_private/include/libdredd/mutate_visitor.h
+++ b/src/libdredd/include_private/include/libdredd/mutate_visitor.h
@@ -184,7 +184,7 @@ class MutateVisitor : public clang::RecursiveASTVisitor<MutateVisitor> {
   // a file as Dredd only makes source code modifications inside functions.
   void UpdateStartLocationOfFirstFunctionInSourceFile();
 
-  // TODO(JLJ): Add comment
+  // Adds details of a mutation that can be applied, and performs associated bookkeeping.
   void AddMutation(std::unique_ptr<Mutation> mutation);
 
   const clang::CompilerInstance* compiler_instance_;

--- a/src/libdredd/include_private/include/libdredd/mutate_visitor.h
+++ b/src/libdredd/include_private/include/libdredd/mutate_visitor.h
@@ -33,6 +33,7 @@
 #include "clang/AST/TypeLoc.h"
 #include "clang/Basic/SourceLocation.h"
 #include "clang/Frontend/CompilerInstance.h"
+#include "libdredd/mutation.h"
 #include "libdredd/mutation_tree_node.h"
 
 namespace dredd {

--- a/src/libdredd/src/mutate_ast_consumer.cc
+++ b/src/libdredd/src/mutate_ast_consumer.cc
@@ -137,12 +137,11 @@ void MutateAstConsumer::HandleTranslationUnit(clang::ASTContext& ast_context) {
 
   *mutation_info_->add_info_for_files() = mutation_info_for_file;
 
-  auto& source_manager = ast_context.getSourceManager();
-  const clang::SourceLocation start_of_source_file =
-      source_manager.translateLineCol(source_manager.getMainFileID(), 1, 1);
-  assert(start_of_source_file.isValid() &&
-         "There is at least one mutation, therefore the file must have some "
-         "content.");
+  const clang::SourceLocation start_location_of_first_function_in_source_file =
+      visitor_->GetStartLocationOfFirstFunctionInSourceFile();
+  assert(start_location_of_first_function_in_source_file.isValid() &&
+         "There is at least one mutation, therefore there must be at least one "
+         "function.");
 
   // Convert the unordered set Dredd declarations into an ordered set and add
   // them to the source file before the first declaration.
@@ -150,8 +149,8 @@ void MutateAstConsumer::HandleTranslationUnit(clang::ASTContext& ast_context) {
   sorted_dredd_declarations.insert(dredd_declarations.begin(),
                                    dredd_declarations.end());
   for (const auto& decl : sorted_dredd_declarations) {
-    const bool rewriter_result =
-        rewriter_.InsertTextBefore(start_of_source_file, decl);
+    const bool rewriter_result = rewriter_.InsertTextBefore(
+        start_location_of_first_function_in_source_file, decl);
     (void)rewriter_result;  // Keep release-mode compilers happy.
     assert(!rewriter_result && "Rewrite failed.\n");
   }
@@ -161,8 +160,8 @@ void MutateAstConsumer::HandleTranslationUnit(clang::ASTContext& ast_context) {
           ? GetDreddPreludeCpp(initial_mutation_id)
           : GetDreddPreludeC(initial_mutation_id);
 
-  bool rewriter_result =
-      rewriter_.InsertTextBefore(start_of_source_file, dredd_prelude);
+  bool rewriter_result = rewriter_.InsertTextBefore(
+      start_location_of_first_function_in_source_file, dredd_prelude);
   (void)rewriter_result;  // Keep release-mode compilers happy.
   assert(!rewriter_result && "Rewrite failed.\n");
 

--- a/src/libdredd/src/mutate_visitor.cc
+++ b/src/libdredd/src/mutate_visitor.cc
@@ -368,10 +368,9 @@ void MutateVisitor::HandleUnaryOperator(clang::UnaryOperator* unary_operator) {
     }
   }
 
-  mutation_tree_path_.back()->AddMutation(
-      std::make_unique<MutationReplaceUnaryOperator>(
-          *unary_operator, compiler_instance_->getPreprocessor(),
-          compiler_instance_->getASTContext()));
+  AddMutation(std::make_unique<MutationReplaceUnaryOperator>(
+      *unary_operator, compiler_instance_->getPreprocessor(),
+      compiler_instance_->getASTContext()));
 }
 
 void MutateVisitor::HandleBinaryOperator(
@@ -431,10 +430,9 @@ void MutateVisitor::HandleBinaryOperator(
     return;
   }
 
-  mutation_tree_path_.back()->AddMutation(
-      std::make_unique<MutationReplaceBinaryOperator>(
-          *binary_operator, compiler_instance_->getPreprocessor(),
-          compiler_instance_->getASTContext()));
+  AddMutation(std::make_unique<MutationReplaceBinaryOperator>(
+      *binary_operator, compiler_instance_->getPreprocessor(),
+      compiler_instance_->getASTContext()));
 }
 
 void MutateVisitor::HandleExpr(clang::Expr* expr) {
@@ -524,7 +522,7 @@ void MutateVisitor::HandleExpr(clang::Expr* expr) {
     }
   }
 
-  mutation_tree_path_.back()->AddMutation(std::make_unique<MutationReplaceExpr>(
+  AddMutation(std::make_unique<MutationReplaceExpr>(
       *expr, compiler_instance_->getPreprocessor(),
       compiler_instance_->getASTContext()));
 }
@@ -638,13 +636,16 @@ bool MutateVisitor::TraverseCompoundStmt(clang::CompoundStmt* compound_stmt) {
     assert(!enclosing_decls_.empty() &&
            "Statements can only be removed if they are nested in some "
            "declaration.");
-    UpdateStartLocationOfFirstFunctionInSourceFile();
-    mutation_tree_path_.back()->AddMutation(
-        std::make_unique<MutationRemoveStmt>(
-            *target_stmt, compiler_instance_->getPreprocessor(),
-            compiler_instance_->getASTContext()));
+    AddMutation(std::make_unique<MutationRemoveStmt>(
+        *target_stmt, compiler_instance_->getPreprocessor(),
+        compiler_instance_->getASTContext()));
   }
   return true;
+}
+
+void MutateVisitor::AddMutation(std::unique_ptr<Mutation> mutation) {
+  UpdateStartLocationOfFirstFunctionInSourceFile();
+  mutation_tree_path_.back()->AddMutation(std::move(mutation));
 }
 
 bool MutateVisitor::VisitVarDecl(clang::VarDecl* var_decl) {

--- a/src/libdredd/src/mutate_visitor.cc
+++ b/src/libdredd/src/mutate_visitor.cc
@@ -34,8 +34,8 @@
 #include "clang/AST/TypeLoc.h"
 #include "clang/Basic/LangOptions.h"
 #include "clang/Basic/SourceLocation.h"
-#include "clang/Basic/TypeTraits.h"
 #include "clang/Basic/SourceManager.h"
+#include "clang/Basic/TypeTraits.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "libdredd/mutation.h"
 #include "libdredd/mutation_remove_stmt.h"
@@ -65,20 +65,16 @@ bool MutateVisitor::IsTypeSupported(const clang::QualType qual_type) {
 }
 
 void MutateVisitor::UpdateStartLocationOfFirstFunctionInSourceFile() {
-  for (int index = static_cast<int>(enclosing_decls_.size()) - 1; index >= 0;
-       index--) {
-    const auto* decl = enclosing_decls_[static_cast<size_t>(index)];
-    if (llvm::dyn_cast<clang::FunctionDecl>(decl) != nullptr) {
-      const clang::BeforeThanCompare<clang::SourceLocation> comparator(
-          compiler_instance_->getSourceManager());
-      auto source_range_in_main_file = GetSourceRangeInMainFile(
-          compiler_instance_->getPreprocessor(), *enclosing_decls_[0]);
-      if (start_location_of_first_function_in_source_file_.isInvalid() ||
-          comparator(source_range_in_main_file.getBegin(),
-                     start_location_of_first_function_in_source_file_)) {
-        start_location_of_first_function_in_source_file_ =
-            source_range_in_main_file.getBegin();
-      }
+  if (IsInFunction()) {
+    const clang::BeforeThanCompare<clang::SourceLocation> comparator(
+        compiler_instance_->getSourceManager());
+    auto source_range_in_main_file = GetSourceRangeInMainFile(
+        compiler_instance_->getPreprocessor(), *enclosing_decls_[0]);
+    if (start_location_of_first_function_in_source_file_.isInvalid() ||
+        comparator(source_range_in_main_file.getBegin(),
+                   start_location_of_first_function_in_source_file_)) {
+      start_location_of_first_function_in_source_file_ =
+          source_range_in_main_file.getBegin();
     }
   }
 }

--- a/src/libdredd/src/mutate_visitor.cc
+++ b/src/libdredd/src/mutate_visitor.cc
@@ -35,6 +35,7 @@
 #include "clang/Basic/LangOptions.h"
 #include "clang/Basic/SourceLocation.h"
 #include "clang/Basic/TypeTraits.h"
+#include "clang/Basic/SourceManager.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "libdredd/mutation.h"
 #include "libdredd/mutation_remove_stmt.h"

--- a/test/single_file/add_type_aliases.c.noopt.expected
+++ b/test/single_file/add_type_aliases.c.noopt.expected
@@ -1,4 +1,7 @@
 #include <inttypes.h>
+#include <stddef.h>
+
+#include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
@@ -151,9 +154,6 @@ static int __dredd_replace_binary_operator_Add_arg1_int_arg2_int(int arg1, int a
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return arg2;
   return arg1 + arg2;
 }
-
-#include <inttypes.h>
-#include <stddef.h>
 
 int main() {
   unsigned a;

--- a/test/single_file/add_type_aliases.cc.noopt.expected
+++ b/test/single_file/add_type_aliases.cc.noopt.expected
@@ -1,5 +1,8 @@
 #include <cinttypes>
 #include <cstddef>
+
+#include <cinttypes>
+#include <cstddef>
 #include <functional>
 #include <string>
 
@@ -153,9 +156,6 @@ static int __dredd_replace_binary_operator_Add_arg1_int_arg2_int(int arg1, int a
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return arg2;
   return arg1 + arg2;
 }
-
-#include <cinttypes>
-#include <cstddef>
 
 int main() {
   unsigned a;

--- a/test/single_file/bitfield.c.expected
+++ b/test/single_file/bitfield.c.expected
@@ -1,3 +1,8 @@
+struct S {
+  int a : 3;
+  int b : 3;
+};
+
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>
@@ -57,11 +62,6 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
   return arg;
 }
-
-struct S {
-  int a : 3;
-  int b : 3;
-};
 
 void foo() {
   struct S myS;

--- a/test/single_file/bitfield.c.noopt.expected
+++ b/test/single_file/bitfield.c.noopt.expected
@@ -1,3 +1,8 @@
+struct S {
+  int a : 3;
+  int b : 3;
+};
+
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>
@@ -58,11 +63,6 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
   return arg;
 }
-
-struct S {
-  int a : 3;
-  int b : 3;
-};
 
 void foo() {
   struct S myS;

--- a/test/single_file/bitfield.cc.expected
+++ b/test/single_file/bitfield.cc.expected
@@ -1,3 +1,8 @@
+struct S {
+  int a : 3;
+  int b : 3;
+};
+
 #include <cinttypes>
 #include <cstddef>
 #include <functional>
@@ -59,11 +64,6 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
   return arg;
 }
-
-struct S {
-  int a : 3;
-  int b : 3;
-};
 
 void foo() {
   S myS;

--- a/test/single_file/bitfield.cc.noopt.expected
+++ b/test/single_file/bitfield.cc.noopt.expected
@@ -1,3 +1,8 @@
+struct S {
+  int a : 3;
+  int b : 3;
+};
+
 #include <cinttypes>
 #include <cstddef>
 #include <functional>
@@ -71,11 +76,6 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
   return arg;
 }
-
-struct S {
-  int a : 3;
-  int b : 3;
-};
 
 void foo() {
   S myS;

--- a/test/single_file/bitfield_reference_passing.cc.expected
+++ b/test/single_file/bitfield_reference_passing.cc.expected
@@ -1,3 +1,9 @@
+template<typename T> void bloop(T& x) { }
+
+struct foo {
+  int b : 2;
+};
+
 #include <cinttypes>
 #include <cstddef>
 #include <functional>
@@ -41,12 +47,6 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   }
   return (enabled_bitset[local_mutation_id / 64] & (static_cast<uint64_t>(1) << (local_mutation_id % 64))) != 0;
 }
-
-template<typename T> void bloop(T& x) { }
-
-struct foo {
-  int b : 2;
-};
 
 int main() {
   const foo d = foo();

--- a/test/single_file/bitfield_reference_passing.cc.noopt.expected
+++ b/test/single_file/bitfield_reference_passing.cc.noopt.expected
@@ -1,3 +1,9 @@
+template<typename T> void bloop(T& x) { }
+
+struct foo {
+  int b : 2;
+};
+
 #include <cinttypes>
 #include <cstddef>
 #include <functional>
@@ -41,12 +47,6 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   }
   return (enabled_bitset[local_mutation_id / 64] & (static_cast<uint64_t>(1) << (local_mutation_id % 64))) != 0;
 }
-
-template<typename T> void bloop(T& x) { }
-
-struct foo {
-  int b : 2;
-};
 
 int main() {
   const foo d = foo();

--- a/test/single_file/boolean_not_insertion_optimisation.c.expected
+++ b/test/single_file/boolean_not_insertion_optimisation.c.expected
@@ -1,3 +1,5 @@
+#include <stdbool.h>
+
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>
@@ -71,8 +73,6 @@ static int __dredd_replace_binary_operator_LAnd_arg1_int_arg2_int_rhs_zero_lhs_o
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return 1;
   return arg;
 }
-#include <stdbool.h>
-
 int main() {
   int x = __dredd_replace_expr_int_zero(__dredd_replace_binary_operator_LAnd_arg1_int_arg2_int_rhs_zero_lhs_one_outer(__dredd_replace_binary_operator_LAnd_arg1_int_arg2_int_rhs_zero_lhs_one_lhs(__dredd_replace_expr_int_one(1, 0), 5) && __dredd_replace_binary_operator_LAnd_arg1_int_arg2_int_rhs_zero_lhs_one_rhs(__dredd_replace_expr_int_zero(0, 3), 5), 5), 8);
 }

--- a/test/single_file/boolean_not_insertion_optimisation.c.noopt.expected
+++ b/test/single_file/boolean_not_insertion_optimisation.c.noopt.expected
@@ -1,3 +1,5 @@
+#include <stdbool.h>
+
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>
@@ -67,8 +69,6 @@ static int __dredd_replace_binary_operator_LAnd_arg1_int_arg2_int_lhs(int arg, i
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return 1;
   return arg;
 }
-#include <stdbool.h>
-
 int main() {
   int x = __dredd_replace_expr_int(__dredd_replace_binary_operator_LAnd_arg1_int_arg2_int_outer(__dredd_replace_binary_operator_LAnd_arg1_int_arg2_int_lhs(__dredd_replace_expr_int(1, 0), 12) && __dredd_replace_binary_operator_LAnd_arg1_int_arg2_int_rhs(__dredd_replace_expr_int(0, 6), 12), 12), 15);
 }

--- a/test/single_file/comment.cc.expected
+++ b/test/single_file/comment.cc.expected
@@ -1,3 +1,5 @@
+void g();
+
 #include <cinttypes>
 #include <cstddef>
 #include <functional>
@@ -47,8 +49,6 @@ static bool __dredd_replace_expr_bool_true(bool arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return false;
   return arg;
 }
-
-void g();
 
 void f()
 {

--- a/test/single_file/comment.cc.noopt.expected
+++ b/test/single_file/comment.cc.noopt.expected
@@ -1,3 +1,5 @@
+void g();
+
 #include <cinttypes>
 #include <cstddef>
 #include <functional>
@@ -49,8 +51,6 @@ static bool __dredd_replace_expr_bool(bool arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return false;
   return arg;
 }
-
-void g();
 
 void f()
 {

--- a/test/single_file/comment_at_start_of_file.cc.expected
+++ b/test/single_file/comment_at_start_of_file.cc.expected
@@ -1,3 +1,5 @@
+// Hello
+
 #include <cinttypes>
 #include <cstddef>
 #include <functional>
@@ -51,8 +53,6 @@ static int __dredd_replace_expr_int_constant(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 4)) return -1;
   return arg;
 }
-
-// Hello
 
 int main() {
   if (!__dredd_enabled_mutation(5)) { return __dredd_replace_expr_int_constant(42, 0); }

--- a/test/single_file/comment_at_start_of_file.cc.noopt.expected
+++ b/test/single_file/comment_at_start_of_file.cc.noopt.expected
@@ -1,3 +1,5 @@
+// Hello
+
 #include <cinttypes>
 #include <cstddef>
 #include <functional>
@@ -52,8 +54,6 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
   return arg;
 }
-
-// Hello
 
 int main() {
   if (!__dredd_enabled_mutation(6)) { return __dredd_replace_expr_int(42, 0); }

--- a/test/single_file/const_expr_function.cc.expected
+++ b/test/single_file/const_expr_function.cc.expected
@@ -1,3 +1,5 @@
+constexpr int Max(int a, int b) { return a > b ? a : b; }
+
 #include <cinttypes>
 #include <cstddef>
 #include <functional>
@@ -51,8 +53,6 @@ static int __dredd_replace_expr_int_constant(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 4)) return -1;
   return arg;
 }
-
-constexpr int Max(int a, int b) { return a > b ? a : b; }
 
 int main() {
   if (!__dredd_enabled_mutation(10)) { Max(__dredd_replace_expr_int_constant(5, 0),__dredd_replace_expr_int_constant(4, 5)); }

--- a/test/single_file/const_expr_function.cc.noopt.expected
+++ b/test/single_file/const_expr_function.cc.noopt.expected
@@ -1,3 +1,5 @@
+constexpr int Max(int a, int b) { return a > b ? a : b; }
+
 #include <cinttypes>
 #include <cstddef>
 #include <functional>
@@ -63,8 +65,6 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
   return arg;
 }
-
-constexpr int Max(int a, int b) { return a > b ? a : b; }
 
 int main() {
   if (!__dredd_enabled_mutation(18)) { __dredd_replace_expr_int([&]() -> int { return Max(__dredd_replace_expr_int(5, 0),__dredd_replace_expr_int(4, 6)); }, 12); }

--- a/test/single_file/const_expr_function_call.cc.expected
+++ b/test/single_file/const_expr_function_call.cc.expected
@@ -1,3 +1,5 @@
+constexpr int Max(int a, int b) { return a > b ? a : b; }
+
 #include <cinttypes>
 #include <cstddef>
 #include <functional>
@@ -61,8 +63,6 @@ static int __dredd_replace_expr_int_constant(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 4)) return -1;
   return arg;
 }
-
-constexpr int Max(int a, int b) { return a > b ? a : b; }
 
 int foo() {
   if (!__dredd_enabled_mutation(15)) { return __dredd_replace_expr_int_constant([&]() -> int { return Max(__dredd_replace_expr_int_constant(5, 0),__dredd_replace_expr_int_constant(4, 5)); }, 10); }

--- a/test/single_file/const_expr_function_call.cc.noopt.expected
+++ b/test/single_file/const_expr_function_call.cc.noopt.expected
@@ -1,3 +1,5 @@
+constexpr int Max(int a, int b) { return a > b ? a : b; }
+
 #include <cinttypes>
 #include <cstddef>
 #include <functional>
@@ -63,8 +65,6 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
   return arg;
 }
-
-constexpr int Max(int a, int b) { return a > b ? a : b; }
 
 int foo() {
   if (!__dredd_enabled_mutation(18)) { return __dredd_replace_expr_int([&]() -> int { return Max(__dredd_replace_expr_int(5, 0),__dredd_replace_expr_int(4, 6)); }, 12); }

--- a/test/single_file/constexpr_if1.cc.expected
+++ b/test/single_file/constexpr_if1.cc.expected
@@ -1,3 +1,5 @@
+#include <iostream>
+
 #include <cinttypes>
 #include <cstddef>
 #include <functional>
@@ -41,8 +43,6 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   }
   return (enabled_bitset[local_mutation_id / 64] & (static_cast<uint64_t>(1) << (local_mutation_id % 64))) != 0;
 }
-
-#include <iostream>
 
 template <int a> void foo() {
   if (!__dredd_enabled_mutation(1)) { if constexpr (a) {

--- a/test/single_file/constexpr_if1.cc.noopt.expected
+++ b/test/single_file/constexpr_if1.cc.noopt.expected
@@ -1,3 +1,5 @@
+#include <iostream>
+
 #include <cinttypes>
 #include <cstddef>
 #include <functional>
@@ -41,8 +43,6 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   }
   return (enabled_bitset[local_mutation_id / 64] & (static_cast<uint64_t>(1) << (local_mutation_id % 64))) != 0;
 }
-
-#include <iostream>
 
 template <int a> void foo() {
   if (!__dredd_enabled_mutation(1)) { if constexpr (a) {

--- a/test/single_file/construct_struct_from_enum_constant.cc.expected
+++ b/test/single_file/construct_struct_from_enum_constant.cc.expected
@@ -1,3 +1,10 @@
+struct foo {
+  foo(int) {};
+  operator int();
+};
+
+enum baz { bar };
+
 #include <cinttypes>
 #include <cstddef>
 #include <functional>
@@ -54,13 +61,6 @@ static bool __dredd_replace_expr_bool_false(bool arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return true;
   return arg;
 }
-
-struct foo {
-  foo(int) {};
-  operator int();
-};
-
-enum baz { bar };
 
 int main() { 
   if (!__dredd_enabled_mutation(3)) { __dredd_replace_expr_bool_false(0, 0) ? foo(__dredd_replace_expr_int_zero(0, 1)) : baz::bar; }

--- a/test/single_file/construct_struct_from_enum_constant.cc.noopt.expected
+++ b/test/single_file/construct_struct_from_enum_constant.cc.noopt.expected
@@ -1,3 +1,10 @@
+struct foo {
+  foo(int) {};
+  operator int();
+};
+
+enum baz { bar };
+
 #include <cinttypes>
 #include <cstddef>
 #include <functional>
@@ -60,13 +67,6 @@ static bool __dredd_replace_expr_bool(bool arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return false;
   return arg;
 }
-
-struct foo {
-  foo(int) {};
-  operator int();
-};
-
-enum baz { bar };
 
 int main() { 
   if (!__dredd_enabled_mutation(15)) { __dredd_replace_expr_bool(__dredd_replace_expr_int(0, 0), 6) ? foo(__dredd_replace_expr_int(0, 9)) : baz::bar; }

--- a/test/single_file/define_at_start_of_file.c.expected
+++ b/test/single_file/define_at_start_of_file.c.expected
@@ -1,3 +1,6 @@
+#define API
+API int func1();
+
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>
@@ -47,8 +50,5 @@ static int __dredd_replace_expr_int_one(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
   return arg;
 }
-
-#define API
-API int func1();
 
 int main() { int a = __dredd_replace_expr_int_one(1, 0); }

--- a/test/single_file/define_at_start_of_file.c.noopt.expected
+++ b/test/single_file/define_at_start_of_file.c.noopt.expected
@@ -1,3 +1,6 @@
+#define API
+API int func1();
+
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>
@@ -50,8 +53,5 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
   return arg;
 }
-
-#define API
-API int func1();
 
 int main() { int a = __dredd_replace_expr_int(1, 0); }

--- a/test/single_file/define_in_first_decl.c.expected
+++ b/test/single_file/define_in_first_decl.c.expected
@@ -1,3 +1,5 @@
+#define TYPE int
+
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>
@@ -66,8 +68,6 @@ static int __dredd_replace_binary_operator_Add_arg1_int_arg2_int_lhs_one(int arg
   if (__dredd_enabled_mutation(local_mutation_id + 3)) return arg2;
   return arg1 + arg2;
 }
-
-#define TYPE int
 
 TYPE foo() {
   if (!__dredd_enabled_mutation(17)) { return __dredd_replace_expr_int_constant(__dredd_replace_binary_operator_Add_arg1_int_arg2_int_lhs_one(__dredd_replace_expr_int_one(1, 0) , __dredd_replace_expr_int_constant(2, 3), 8), 12); }

--- a/test/single_file/define_in_first_decl.c.noopt.expected
+++ b/test/single_file/define_in_first_decl.c.noopt.expected
@@ -1,3 +1,5 @@
+#define TYPE int
+
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>
@@ -61,8 +63,6 @@ static int __dredd_replace_binary_operator_Add_arg1_int_arg2_int(int arg1, int a
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return arg2;
   return arg1 + arg2;
 }
-
-#define TYPE int
 
 TYPE foo() {
   if (!__dredd_enabled_mutation(24)) { return __dredd_replace_expr_int(__dredd_replace_binary_operator_Add_arg1_int_arg2_int(__dredd_replace_expr_int(1, 0) , __dredd_replace_expr_int(2, 6), 12), 18); }

--- a/test/single_file/define_in_first_decl.cc.expected
+++ b/test/single_file/define_in_first_decl.cc.expected
@@ -1,3 +1,5 @@
+#define TYPE int
+
 #include <cinttypes>
 #include <cstddef>
 #include <functional>
@@ -68,8 +70,6 @@ static int __dredd_replace_binary_operator_Add_arg1_int_arg2_int_lhs_one(int arg
   if (__dredd_enabled_mutation(local_mutation_id + 3)) return arg2;
   return arg1 + arg2;
 }
-
-#define TYPE int
 
 TYPE foo() {
   if (!__dredd_enabled_mutation(17)) { return __dredd_replace_expr_int_constant(__dredd_replace_binary_operator_Add_arg1_int_arg2_int_lhs_one(__dredd_replace_expr_int_one(1, 0) , __dredd_replace_expr_int_constant(2, 3), 8), 12); }

--- a/test/single_file/define_in_first_decl.cc.noopt.expected
+++ b/test/single_file/define_in_first_decl.cc.noopt.expected
@@ -1,3 +1,5 @@
+#define TYPE int
+
 #include <cinttypes>
 #include <cstddef>
 #include <functional>
@@ -63,8 +65,6 @@ static int __dredd_replace_binary_operator_Add_arg1_int_arg2_int(int arg1, int a
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return arg2;
   return arg1 + arg2;
 }
-
-#define TYPE int
 
 TYPE foo() {
   if (!__dredd_enabled_mutation(24)) { return __dredd_replace_expr_int(__dredd_replace_binary_operator_Add_arg1_int_arg2_int(__dredd_replace_expr_int(1, 0) , __dredd_replace_expr_int(2, 6), 12), 18); }

--- a/test/single_file/enum.c.noopt.expected
+++ b/test/single_file/enum.c.noopt.expected
@@ -1,3 +1,8 @@
+enum A {
+  X,
+  Y
+};
+
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>
@@ -50,11 +55,6 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
   return arg;
 }
-
-enum A {
-  X,
-  Y
-};
 
 void foo() {
   enum A myA = __dredd_replace_expr_int(X, 0);

--- a/test/single_file/expr_macro.c.expected
+++ b/test/single_file/expr_macro.c.expected
@@ -1,3 +1,7 @@
+#define E (1, 2, 3)
+
+void foo(int, int, int);
+
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>
@@ -39,10 +43,6 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   }
   return enabled_bitset[local_mutation_id / 64] & ((uint64_t) 1 << (local_mutation_id % 64));
 }
-
-#define E (1, 2, 3)
-
-void foo(int, int, int);
 
 int main() {
   if (!__dredd_enabled_mutation(0)) { foo E; }

--- a/test/single_file/expr_macro.c.noopt.expected
+++ b/test/single_file/expr_macro.c.noopt.expected
@@ -1,3 +1,7 @@
+#define E (1, 2, 3)
+
+void foo(int, int, int);
+
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>
@@ -39,10 +43,6 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   }
   return enabled_bitset[local_mutation_id / 64] & ((uint64_t) 1 << (local_mutation_id % 64));
 }
-
-#define E (1, 2, 3)
-
-void foo(int, int, int);
 
 int main() {
   if (!__dredd_enabled_mutation(0)) { foo E; }

--- a/test/single_file/expr_macro.cc.expected
+++ b/test/single_file/expr_macro.cc.expected
@@ -1,3 +1,7 @@
+#define E (1, 2, 3)
+
+void foo(int, int, int);
+
 #include <cinttypes>
 #include <cstddef>
 #include <functional>
@@ -41,10 +45,6 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   }
   return (enabled_bitset[local_mutation_id / 64] & (static_cast<uint64_t>(1) << (local_mutation_id % 64))) != 0;
 }
-
-#define E (1, 2, 3)
-
-void foo(int, int, int);
 
 int main() {
   if (!__dredd_enabled_mutation(0)) { foo E; }

--- a/test/single_file/expr_macro.cc.noopt.expected
+++ b/test/single_file/expr_macro.cc.noopt.expected
@@ -1,3 +1,7 @@
+#define E (1, 2, 3)
+
+void foo(int, int, int);
+
 #include <cinttypes>
 #include <cstddef>
 #include <functional>
@@ -41,10 +45,6 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   }
   return (enabled_bitset[local_mutation_id / 64] & (static_cast<uint64_t>(1) << (local_mutation_id % 64))) != 0;
 }
-
-#define E (1, 2, 3)
-
-void foo(int, int, int);
 
 int main() {
   if (!__dredd_enabled_mutation(0)) { foo E; }

--- a/test/single_file/initializer_list.cc.expected
+++ b/test/single_file/initializer_list.cc.expected
@@ -1,3 +1,12 @@
+#include <cstddef>
+
+struct A {
+  size_t x;
+  size_t y;
+};
+
+void foo(A arg);
+
 #include <cinttypes>
 #include <cstddef>
 #include <functional>
@@ -48,15 +57,6 @@ static int __dredd_replace_expr_int_zero(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return -1;
   return arg;
 }
-
-#include <cstddef>
-
-struct A {
-  size_t x;
-  size_t y;
-};
-
-void foo(A arg);
 
 void bar() {
   if (!__dredd_enabled_mutation(4)) { foo({static_cast<unsigned long>(__dredd_replace_expr_int_zero(0, 0)), static_cast<unsigned long>(__dredd_replace_expr_int_zero(0, 2))}); }

--- a/test/single_file/initializer_list.cc.noopt.expected
+++ b/test/single_file/initializer_list.cc.noopt.expected
@@ -1,3 +1,12 @@
+#include <cstddef>
+
+struct A {
+  size_t x;
+  size_t y;
+};
+
+void foo(A arg);
+
 #include <cinttypes>
 #include <cstddef>
 #include <functional>
@@ -52,15 +61,6 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
   return arg;
 }
-
-#include <cstddef>
-
-struct A {
-  size_t x;
-  size_t y;
-};
-
-void foo(A arg);
 
 void bar() {
   if (!__dredd_enabled_mutation(12)) { foo({static_cast<unsigned long>(__dredd_replace_expr_int(0, 0)), static_cast<unsigned long>(__dredd_replace_expr_int(0, 6))}); }

--- a/test/single_file/initializer_list_long_to_short.cc.expected
+++ b/test/single_file/initializer_list_long_to_short.cc.expected
@@ -1,3 +1,10 @@
+#include <initializer_list>
+
+class foo {
+public:
+  foo(std::initializer_list<short>) {}
+};
+
 #include <cinttypes>
 #include <cstddef>
 #include <functional>
@@ -51,13 +58,6 @@ static long __dredd_replace_expr_long_constant(long arg, int local_mutation_id) 
   if (__dredd_enabled_mutation(local_mutation_id + 4)) return -1;
   return arg;
 }
-
-#include <initializer_list>
-
-class foo {
-public:
-  foo(std::initializer_list<short>) {}
-};
 
 int main() { 
     if (!__dredd_enabled_mutation(5)) { foo{static_cast<short>(__dredd_replace_expr_long_constant((long) 2, 0))}; } 

--- a/test/single_file/initializer_list_long_to_short.cc.noopt.expected
+++ b/test/single_file/initializer_list_long_to_short.cc.noopt.expected
@@ -1,3 +1,10 @@
+#include <initializer_list>
+
+class foo {
+public:
+  foo(std::initializer_list<short>) {}
+};
+
 #include <cinttypes>
 #include <cstddef>
 #include <functional>
@@ -63,13 +70,6 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
   return arg;
 }
-
-#include <initializer_list>
-
-class foo {
-public:
-  foo(std::initializer_list<short>) {}
-};
 
 int main() { 
     if (!__dredd_enabled_mutation(18)) { foo{static_cast<short>(__dredd_replace_expr_long((long) __dredd_replace_expr_long(__dredd_replace_expr_int(2, 0), 6), 12))}; } 

--- a/test/single_file/initializer_list_narrower.cc.expected
+++ b/test/single_file/initializer_list_narrower.cc.expected
@@ -1,3 +1,10 @@
+#include <initializer_list>
+
+class foo {
+public:
+  foo(std::initializer_list<unsigned int>) {}
+};
+
 #include <cinttypes>
 #include <cstddef>
 #include <functional>
@@ -51,13 +58,6 @@ static int __dredd_replace_expr_int_constant(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 4)) return -1;
   return arg;
 }
-
-#include <initializer_list>
-
-class foo {
-public:
-  foo(std::initializer_list<unsigned int>) {}
-};
 
 int main() { 
     if (!__dredd_enabled_mutation(10)) { foo{static_cast<unsigned int>(__dredd_replace_expr_int_constant(+__dredd_replace_expr_int_constant(2, 0), 5))}; } 

--- a/test/single_file/initializer_list_narrower.cc.noopt.expected
+++ b/test/single_file/initializer_list_narrower.cc.noopt.expected
@@ -1,3 +1,10 @@
+#include <initializer_list>
+
+class foo {
+public:
+  foo(std::initializer_list<unsigned int>) {}
+};
+
 #include <cinttypes>
 #include <cstddef>
 #include <functional>
@@ -52,13 +59,6 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
   return arg;
 }
-
-#include <initializer_list>
-
-class foo {
-public:
-  foo(std::initializer_list<unsigned int>) {}
-};
 
 int main() { 
     if (!__dredd_enabled_mutation(12)) { foo{static_cast<unsigned int>(__dredd_replace_expr_int(+__dredd_replace_expr_int(2, 0), 6))}; } 

--- a/test/single_file/misc004.cc
+++ b/test/single_file/misc004.cc
@@ -1,0 +1,7 @@
+#if defined(__GLIBC__) && !defined(__FreeBSD_kernel__) &&  defined(__CONFIG_H__)
+#  error test.h must be #included before system headers
+#endif
+
+int main() {
+    int x = 1 + 2;
+}

--- a/test/single_file/misc004.cc.expected
+++ b/test/single_file/misc004.cc.expected
@@ -1,0 +1,78 @@
+#if defined(__GLIBC__) && !defined(__FreeBSD_kernel__) &&  defined(__CONFIG_H__)
+#  error test.h must be #included before system headers
+#endif
+
+#include <cinttypes>
+#include <cstddef>
+#include <functional>
+#include <string>
+
+
+#ifdef _MSC_VER
+#define thread_local __declspec(thread)
+#elif __APPLE__
+#define thread_local __thread
+#endif
+
+static thread_local bool __dredd_some_mutation_enabled = true;
+static bool __dredd_enabled_mutation(int local_mutation_id) {
+  static thread_local bool initialized = false;
+  static thread_local uint64_t enabled_bitset[1];
+  if (!initialized) {
+    bool some_mutation_enabled = false;
+    const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
+    if (dredd_environment_variable != nullptr) {
+      std::string contents(dredd_environment_variable);
+      while (true) {
+        size_t pos = contents.find(",");
+        std::string token = (pos == std::string::npos ? contents : contents.substr(0, pos));
+        if (!token.empty()) {
+          int value = std::stoi(token);
+          int local_value = value - 0;
+          if (local_value >= 0 && local_value < 17) {
+            enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+            some_mutation_enabled = true;
+          }
+        }
+        if (pos == std::string::npos) {
+          break;
+        }
+        contents.erase(0, pos + 1);
+      }
+    }
+    initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
+  }
+  return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
+}
+
+static int __dredd_replace_expr_int_one(int arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 0;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
+  return arg;
+}
+
+static int __dredd_replace_expr_int_constant(int arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return -(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 0;
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return -1;
+  return arg;
+}
+
+static int __dredd_replace_binary_operator_Add_arg1_int_arg2_int_lhs_one(int arg1, int arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1 + arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1 / arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1 % arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1 - arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return arg2;
+  return arg1 + arg2;
+}
+
+int main() {
+    int x = __dredd_replace_expr_int_constant(__dredd_replace_binary_operator_Add_arg1_int_arg2_int_lhs_one(__dredd_replace_expr_int_one(1, 0) , __dredd_replace_expr_int_constant(2, 3), 8), 12);
+}

--- a/test/single_file/misc004.cc.expected
+++ b/test/single_file/misc004.cc.expected
@@ -30,7 +30,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
           int value = std::stoi(token);
           int local_value = value - 0;
           if (local_value >= 0 && local_value < 17) {
-            enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+            enabled_bitset[local_value / 64] |= (static_cast<uint64_t>(1) << (local_value % 64));
             some_mutation_enabled = true;
           }
         }
@@ -43,7 +43,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
     initialized = true;
     __dredd_some_mutation_enabled = some_mutation_enabled;
   }
-  return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
+  return (enabled_bitset[local_mutation_id / 64] & (static_cast<uint64_t>(1) << (local_mutation_id % 64))) != 0;
 }
 
 static int __dredd_replace_expr_int_one(int arg, int local_mutation_id) {

--- a/test/single_file/misc004.cc.noopt.expected
+++ b/test/single_file/misc004.cc.noopt.expected
@@ -30,7 +30,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
           int value = std::stoi(token);
           int local_value = value - 0;
           if (local_value >= 0 && local_value < 24) {
-            enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+            enabled_bitset[local_value / 64] |= (static_cast<uint64_t>(1) << (local_value % 64));
             some_mutation_enabled = true;
           }
         }
@@ -43,7 +43,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
     initialized = true;
     __dredd_some_mutation_enabled = some_mutation_enabled;
   }
-  return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
+  return (enabled_bitset[local_mutation_id / 64] & (static_cast<uint64_t>(1) << (local_mutation_id % 64))) != 0;
 }
 
 static int __dredd_replace_expr_int(int arg, int local_mutation_id) {

--- a/test/single_file/misc004.cc.noopt.expected
+++ b/test/single_file/misc004.cc.noopt.expected
@@ -1,0 +1,73 @@
+#if defined(__GLIBC__) && !defined(__FreeBSD_kernel__) &&  defined(__CONFIG_H__)
+#  error test.h must be #included before system headers
+#endif
+
+#include <cinttypes>
+#include <cstddef>
+#include <functional>
+#include <string>
+
+
+#ifdef _MSC_VER
+#define thread_local __declspec(thread)
+#elif __APPLE__
+#define thread_local __thread
+#endif
+
+static thread_local bool __dredd_some_mutation_enabled = true;
+static bool __dredd_enabled_mutation(int local_mutation_id) {
+  static thread_local bool initialized = false;
+  static thread_local uint64_t enabled_bitset[1];
+  if (!initialized) {
+    bool some_mutation_enabled = false;
+    const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
+    if (dredd_environment_variable != nullptr) {
+      std::string contents(dredd_environment_variable);
+      while (true) {
+        size_t pos = contents.find(",");
+        std::string token = (pos == std::string::npos ? contents : contents.substr(0, pos));
+        if (!token.empty()) {
+          int value = std::stoi(token);
+          int local_value = value - 0;
+          if (local_value >= 0 && local_value < 24) {
+            enabled_bitset[local_value / 64] |= (1 << (local_value % 64));
+            some_mutation_enabled = true;
+          }
+        }
+        if (pos == std::string::npos) {
+          break;
+        }
+        contents.erase(0, pos + 1);
+      }
+    }
+    initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
+  }
+  return (enabled_bitset[local_mutation_id / 64] & (1 << (local_mutation_id % 64))) != 0;
+}
+
+static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 0;
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
+  return arg;
+}
+
+static int __dredd_replace_binary_operator_Add_arg1_int_arg2_int(int arg1, int arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1 + arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1 / arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1 * arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1 % arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return arg1 - arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return arg1;
+  if (__dredd_enabled_mutation(local_mutation_id + 5)) return arg2;
+  return arg1 + arg2;
+}
+
+int main() {
+    int x = __dredd_replace_expr_int(__dredd_replace_binary_operator_Add_arg1_int_arg2_int(__dredd_replace_expr_int(1, 0) , __dredd_replace_expr_int(2, 6), 12), 18);
+}

--- a/test/single_file/new_expr_array_size.cc.expected
+++ b/test/single_file/new_expr_array_size.cc.expected
@@ -1,3 +1,8 @@
+class foo {
+public:
+  foo(int x) {}
+};
+
 #include <cinttypes>
 #include <cstddef>
 #include <functional>
@@ -51,11 +56,6 @@ static int __dredd_replace_expr_int_constant(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 4)) return -1;
   return arg;
 }
-
-class foo {
-public:
-  foo(int x) {}
-};
 
 int main() { 
   if (!__dredd_enabled_mutation(10)) { new foo[2]{__dredd_replace_expr_int_constant(4, 0), __dredd_replace_expr_int_constant(5, 5)}; } 

--- a/test/single_file/new_expr_array_size.cc.noopt.expected
+++ b/test/single_file/new_expr_array_size.cc.noopt.expected
@@ -1,3 +1,8 @@
+class foo {
+public:
+  foo(int x) {}
+};
+
 #include <cinttypes>
 #include <cstddef>
 #include <functional>
@@ -52,11 +57,6 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
   return arg;
 }
-
-class foo {
-public:
-  foo(int x) {}
-};
 
 int main() { 
   if (!__dredd_enabled_mutation(12)) { new foo[2]{__dredd_replace_expr_int(4, 0), __dredd_replace_expr_int(5, 6)}; } 

--- a/test/single_file/printing.c.expected
+++ b/test/single_file/printing.c.expected
@@ -1,3 +1,5 @@
+#include <stdio.h>
+
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>
@@ -39,8 +41,6 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   }
   return enabled_bitset[local_mutation_id / 64] & ((uint64_t) 1 << (local_mutation_id % 64));
 }
-
-#include <stdio.h>
 
 int main() {
   if (!__dredd_enabled_mutation(0)) { printf("%s\n", "A\n"); }

--- a/test/single_file/printing.c.noopt.expected
+++ b/test/single_file/printing.c.noopt.expected
@@ -1,3 +1,5 @@
+#include <stdio.h>
+
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>
@@ -50,8 +52,6 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
   return arg;
 }
-
-#include <stdio.h>
 
 int main() {
   if (!__dredd_enabled_mutation(6)) { __dredd_replace_expr_int(printf("%s\n", "A\n"), 0); }

--- a/test/single_file/printing.cc.expected
+++ b/test/single_file/printing.cc.expected
@@ -1,3 +1,5 @@
+#include <iostream>
+
 #include <cinttypes>
 #include <cstddef>
 #include <functional>
@@ -41,8 +43,6 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   }
   return (enabled_bitset[local_mutation_id / 64] & (static_cast<uint64_t>(1) << (local_mutation_id % 64))) != 0;
 }
-
-#include <iostream>
 
 int main() {
   if (!__dredd_enabled_mutation(0)) { std::cout << "A\n"; }

--- a/test/single_file/printing.cc.noopt.expected
+++ b/test/single_file/printing.cc.noopt.expected
@@ -1,3 +1,5 @@
+#include <iostream>
+
 #include <cinttypes>
 #include <cstddef>
 #include <functional>
@@ -41,8 +43,6 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   }
   return (enabled_bitset[local_mutation_id / 64] & (static_cast<uint64_t>(1) << (local_mutation_id % 64))) != 0;
 }
-
-#include <iostream>
 
 int main() {
   if (!__dredd_enabled_mutation(0)) { std::cout << "A\n"; }

--- a/test/single_file/sizeof_template2.cc.expected
+++ b/test/single_file/sizeof_template2.cc.expected
@@ -1,3 +1,5 @@
+bool f(int);
+
 #include <cinttypes>
 #include <cstddef>
 #include <functional>
@@ -60,8 +62,6 @@ static bool __dredd_replace_expr_bool(std::function<bool()> arg, int local_mutat
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return false;
   return arg();
 }
-
-bool f(int);
 
 template <typename a> struct b {
   bool c() { if (!__dredd_enabled_mutation(9)) { return __dredd_replace_expr_bool([&]() -> bool { return static_cast<bool>(f(__dredd_replace_expr_int(sizeof(a), 0))); }, 6); } }

--- a/test/single_file/sizeof_template2.cc.noopt.expected
+++ b/test/single_file/sizeof_template2.cc.noopt.expected
@@ -1,3 +1,5 @@
+bool f(int);
+
 #include <cinttypes>
 #include <cstddef>
 #include <functional>
@@ -69,8 +71,6 @@ static bool __dredd_replace_expr_bool(std::function<bool()> arg, int local_mutat
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return false;
   return arg();
 }
-
-bool f(int);
 
 template <typename a> struct b {
   bool c() { if (!__dredd_enabled_mutation(13)) { return __dredd_replace_expr_bool([&]() -> bool { return static_cast<bool>(f(__dredd_replace_expr_int(__dredd_replace_expr_unsigned_long(sizeof(a), 0), 4))); }, 10); } }

--- a/test/single_file/space_needed_after_macro.c.expected
+++ b/test/single_file/space_needed_after_macro.c.expected
@@ -1,3 +1,5 @@
+#define BEGIN x = 
+
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>
@@ -50,8 +52,6 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
   return arg;
 }
-
-#define BEGIN x = 
 
 int main() {
   int x, y;

--- a/test/single_file/space_needed_after_macro.c.noopt.expected
+++ b/test/single_file/space_needed_after_macro.c.noopt.expected
@@ -1,3 +1,5 @@
+#define BEGIN x = 
+
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>
@@ -57,8 +59,6 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
   return arg;
 }
-
-#define BEGIN x = 
 
 int main() {
   int x, y;

--- a/test/single_file/space_needed_after_macro2.c.expected
+++ b/test/single_file/space_needed_after_macro2.c.expected
@@ -1,3 +1,5 @@
+#define BEGIN_ x = 
+
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>
@@ -50,8 +52,6 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
   return arg;
 }
-
-#define BEGIN_ x = 
 
 int main() {
   int x, y;

--- a/test/single_file/space_needed_after_macro2.c.noopt.expected
+++ b/test/single_file/space_needed_after_macro2.c.noopt.expected
@@ -1,3 +1,5 @@
+#define BEGIN_ x = 
+
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>
@@ -57,8 +59,6 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
   return arg;
 }
-
-#define BEGIN_ x = 
 
 int main() {
   int x, y;

--- a/test/single_file/switch_cases1.c.expected
+++ b/test/single_file/switch_cases1.c.expected
@@ -1,3 +1,5 @@
+#include <stdio.h>
+
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>
@@ -67,8 +69,6 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
   return arg;
 }
-
-#include <stdio.h>
 
 int main() {
   int x = __dredd_replace_expr_int_constant(10, 0);

--- a/test/single_file/switch_cases1.c.noopt.expected
+++ b/test/single_file/switch_cases1.c.noopt.expected
@@ -1,3 +1,5 @@
+#include <stdio.h>
+
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>
@@ -57,8 +59,6 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
   return arg;
 }
-
-#include <stdio.h>
 
 int main() {
   int x = __dredd_replace_expr_int(10, 0);

--- a/test/single_file/switch_cases2.c.expected
+++ b/test/single_file/switch_cases2.c.expected
@@ -1,3 +1,5 @@
+#include <stdio.h>
+
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>
@@ -67,8 +69,6 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
   return arg;
 }
-
-#include <stdio.h>
 
 int main() {
   int x = __dredd_replace_expr_int_constant(10, 0);

--- a/test/single_file/switch_cases2.c.noopt.expected
+++ b/test/single_file/switch_cases2.c.noopt.expected
@@ -1,3 +1,5 @@
+#include <stdio.h>
+
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>
@@ -57,8 +59,6 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
   return arg;
 }
-
-#include <stdio.h>
 
 int main() {
   int x = __dredd_replace_expr_int(10, 0);

--- a/test/single_file/typedef.c.noopt.expected
+++ b/test/single_file/typedef.c.noopt.expected
@@ -1,3 +1,7 @@
+typedef struct S {
+  int x;
+} SomeS;
+
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>
@@ -61,10 +65,6 @@ static int __dredd_replace_binary_operator_Add_arg1_int_arg2_int(int arg1, int a
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return arg2;
   return arg1 + arg2;
 }
-
-typedef struct S {
-  int x;
-} SomeS;
 
 void foo() {
   if (!__dredd_enabled_mutation(24)) { __dredd_replace_expr_int(__dredd_replace_binary_operator_Add_arg1_int_arg2_int(__dredd_replace_expr_int(1, 0) , __dredd_replace_expr_int(2, 6), 12), 18); }

--- a/test/single_file/typedef.cc.noopt.expected
+++ b/test/single_file/typedef.cc.noopt.expected
@@ -1,3 +1,7 @@
+typedef struct S {
+  int x;
+} SomeS;
+
 #include <cinttypes>
 #include <cstddef>
 #include <functional>
@@ -63,10 +67,6 @@ static int __dredd_replace_binary_operator_Add_arg1_int_arg2_int(int arg1, int a
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return arg2;
   return arg1 + arg2;
 }
-
-typedef struct S {
-  int x;
-} SomeS;
 
 void foo() {
   if (!__dredd_enabled_mutation(24)) { __dredd_replace_expr_int(__dredd_replace_binary_operator_Add_arg1_int_arg2_int(__dredd_replace_expr_int(1, 0) , __dredd_replace_expr_int(2, 6), 12), 18); }

--- a/test/single_file/unary_logical_not.c.expected
+++ b/test/single_file/unary_logical_not.c.expected
@@ -1,3 +1,5 @@
+#include <stdbool.h>
+
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>
@@ -71,8 +73,6 @@ static bool __dredd_replace_expr_bool(bool arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return 0;
   return arg;
 }
-
-#include <stdbool.h>
 
 int main() {
   bool y = __dredd_replace_expr_bool_true(true, 0);

--- a/test/single_file/unary_logical_not.c.noopt.expected
+++ b/test/single_file/unary_logical_not.c.noopt.expected
@@ -1,3 +1,5 @@
+#include <stdbool.h>
+
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>
@@ -66,8 +68,6 @@ static bool __dredd_replace_expr_bool(bool arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return 0;
   return arg;
 }
-
-#include <stdbool.h>
 
 int main() {
   bool y = __dredd_replace_expr_bool(__dredd_replace_expr_int(true, 0), 6);

--- a/test/single_file/user_defined_literals.cc.expected
+++ b/test/single_file/user_defined_literals.cc.expected
@@ -1,3 +1,6 @@
+#include <cstdint>
+
+// Number wraps integer, enforcing explicit casting
 #include <cinttypes>
 #include <cstddef>
 #include <functional>
@@ -74,9 +77,6 @@ static int __dredd_replace_expr_int_zero(int arg, int local_mutation_id) {
   return arg;
 }
 
-#include <cstdint>
-
-// Number wraps integer, enforcing explicit casting
 struct Number {
     
     uint32_t value = {};

--- a/test/single_file/user_defined_literals.cc.noopt.expected
+++ b/test/single_file/user_defined_literals.cc.noopt.expected
@@ -1,3 +1,6 @@
+#include <cstdint>
+
+// Number wraps integer, enforcing explicit casting
 #include <cinttypes>
 #include <cstddef>
 #include <functional>
@@ -78,9 +81,6 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   return arg;
 }
 
-#include <cstdint>
-
-// Number wraps integer, enforcing explicit casting
 struct Number {
     
     uint32_t value = {};

--- a/test/single_file/using.cc.noopt.expected
+++ b/test/single_file/using.cc.noopt.expected
@@ -1,3 +1,5 @@
+using blah = int;
+
 #include <cinttypes>
 #include <cstddef>
 #include <functional>
@@ -63,8 +65,6 @@ static int __dredd_replace_binary_operator_Add_arg1_int_arg2_int(int arg1, int a
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return arg2;
   return arg1 + arg2;
 }
-
-using blah = int;
 
 void foo() {
   if (!__dredd_enabled_mutation(24)) { __dredd_replace_expr_int(__dredd_replace_binary_operator_Add_arg1_int_arg2_int(__dredd_replace_expr_int(1, 0) , __dredd_replace_expr_int(2, 6), 12), 18); }


### PR DESCRIPTION
Inserting Dredd's declarations at the beginning of the file can cause
issues with header files that have to be before any system headers. So
instead, insert Dredd's declarations at the top level before the first
mutation that we find.

Fixes: #219, #215