### PR TITLE
Mutate switch cases properly

### DIFF
--- a/.github/workflows/cxx_apps.sh
+++ b/.github/workflows/cxx_apps.sh
@@ -157,7 +157,7 @@ pushd SPIRV-Tools
   ./build/test/val/test_val_fghijklmnop
   ./build/test/val/test_val_rstuvw
   NUM_MUTANTS=`python3 ${DREDD_ROOT}/scripts/query_mutant_info.py mutation-info.json --largest-mutant-id`
-  EXPECTED_NUM_MUTANTS=67998
+  EXPECTED_NUM_MUTANTS=68813
   if [ ${NUM_MUTANTS} -ne ${EXPECTED_NUM_MUTANTS} ]
   then
      echo "Found ${NUM_MUTANTS} mutants when mutating the SPIR-V validator source code. Expected ${EXPECTED_NUM_MUTANTS}. If Dredd changed recently, the expected value may just need to be updated, if it still looks sensible. Otherwise, there is likely a problem."

--- a/.github/workflows/cxx_apps.sh
+++ b/.github/workflows/cxx_apps.sh
@@ -183,7 +183,7 @@ pushd llvm-project
   ${DREDD_EXECUTABLE} --mutation-info-file mutation-info.json -p "${DREDD_ROOT}/llvm-project/build/compile_commands.json" "${FILES[@]}"
   cmake --build build --target LLVMInstCombine
   NUM_MUTANTS=`python3 ${DREDD_ROOT}/scripts/query_mutant_info.py mutation-info.json --largest-mutant-id`
-  EXPECTED_NUM_MUTANTS=97675
+  EXPECTED_NUM_MUTANTS=98026
   if [ ${NUM_MUTANTS} -ne ${EXPECTED_NUM_MUTANTS} ]
   then
      echo "Found ${NUM_MUTANTS} mutants when mutating the LLVM source code. Expected ${EXPECTED_NUM_MUTANTS}. If Dredd changed recently, the expected value may just need to be updated, if it still looks sensible. Otherwise, there is likely a problem."

--- a/test/execute/switch_cases/harness.c
+++ b/test/execute/switch_cases/harness.c
@@ -1,0 +1,10 @@
+void switch_cases(int c);
+
+int main() {
+  switch_cases(1);
+  switch_cases(2);
+  switch_cases(3);
+  switch_cases(4);
+  switch_cases(5);
+  return 0;
+}

--- a/test/execute/switch_cases/mutants.txt
+++ b/test/execute/switch_cases/mutants.txt
@@ -1,0 +1,7 @@
+d_e_b_c_e_b_c_e_b_c_e_d_e_                 ; remove printf("a_")
+a_e_a_e_a_e_a_e_a_e_                       ; remove entire switch
+a_d_e_a_c_e_a_c_e_a_c_e_a_d_e_             ; remove printf("b_")
+a_d_e_a_b_e_a_b_e_a_b_e_a_d_e_             ; remove printf("c_")
+a_d_e_a_b_c_d_e_a_b_c_d_e_a_b_c_d_e_a_d_e_ ; remove break
+a_e_a_b_c_e_a_b_c_e_a_b_c_e_a_e_           ; remove printf("d_")
+a_d_a_b_c_a_b_c_a_b_c_a_d_                 ; remove printf("e_")

--- a/test/execute/switch_cases/original.txt
+++ b/test/execute/switch_cases/original.txt
@@ -1,0 +1,1 @@
+a_d_e_a_b_c_e_a_b_c_e_a_b_c_e_a_d_e_

--- a/test/execute/switch_cases/tomutate.c
+++ b/test/execute/switch_cases/tomutate.c
@@ -1,0 +1,17 @@
+#include <stdio.h>
+
+void switch_cases(int c) {
+  printf("a_");
+  switch (c) {
+  case 2:
+  case 3:
+  case 4:
+    printf("b_");
+    printf("c_");
+    break;
+  case 5:
+  default:
+    printf("d_");
+  }
+  printf("e_");
+}

--- a/test/single_file/negative_switch_case.c.expected
+++ b/test/single_file/negative_switch_case.c.expected
@@ -26,7 +26,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
       while(token) {
         int value = atoi(token);
         int local_value = value - 0;
-        if (local_value >= 0 && local_value < 3) {
+        if (local_value >= 0 && local_value < 5) {
           enabled_bitset[local_value / 64] |= ((uint64_t) 1 << (local_value % 64));
           some_mutation_enabled = 1;
         }
@@ -48,10 +48,10 @@ static int __dredd_replace_expr_int_zero(int arg, int local_mutation_id) {
 }
 
 int main() {
-  if (!__dredd_enabled_mutation(2)) { switch(__dredd_replace_expr_int_zero(0, 0)) {
+  if (!__dredd_enabled_mutation(4)) { switch(__dredd_replace_expr_int_zero(0, 0)) {
   case -1:
-    break;
+    if (!__dredd_enabled_mutation(2)) { break; }
   default:
-    break;
+    if (!__dredd_enabled_mutation(3)) { break; }
   } }
 }

--- a/test/single_file/negative_switch_case.cc.expected
+++ b/test/single_file/negative_switch_case.cc.expected
@@ -25,7 +25,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
         if (!token.empty()) {
           int value = std::stoi(token);
           int local_value = value - 0;
-          if (local_value >= 0 && local_value < 3) {
+          if (local_value >= 0 && local_value < 5) {
             enabled_bitset[local_value / 64] |= (static_cast<uint64_t>(1) << (local_value % 64));
             some_mutation_enabled = true;
           }
@@ -50,10 +50,10 @@ static int __dredd_replace_expr_int_zero(int arg, int local_mutation_id) {
 }
 
 int main() {
-  if (!__dredd_enabled_mutation(2)) { switch(__dredd_replace_expr_int_zero(0, 0)) {
+  if (!__dredd_enabled_mutation(4)) { switch(__dredd_replace_expr_int_zero(0, 0)) {
   case -1:
-    break;
+    if (!__dredd_enabled_mutation(2)) { break; }
   default:
-    break;
+    if (!__dredd_enabled_mutation(3)) { break; }
   } }
 }

--- a/test/single_file/negative_switch_case.cc.noopt.expected
+++ b/test/single_file/negative_switch_case.cc.noopt.expected
@@ -25,7 +25,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
         if (!token.empty()) {
           int value = std::stoi(token);
           int local_value = value - 0;
-          if (local_value >= 0 && local_value < 7) {
+          if (local_value >= 0 && local_value < 9) {
             enabled_bitset[local_value / 64] |= (static_cast<uint64_t>(1) << (local_value % 64));
             some_mutation_enabled = true;
           }
@@ -54,10 +54,10 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
 }
 
 int main() {
-  if (!__dredd_enabled_mutation(6)) { switch(__dredd_replace_expr_int(0, 0)) {
+  if (!__dredd_enabled_mutation(8)) { switch(__dredd_replace_expr_int(0, 0)) {
   case -1:
-    break;
+    if (!__dredd_enabled_mutation(6)) { break; }
   default:
-    break;
+    if (!__dredd_enabled_mutation(7)) { break; }
   } }
 }

--- a/test/single_file/switch_cases1.c
+++ b/test/single_file/switch_cases1.c
@@ -1,0 +1,12 @@
+#include <stdio.h>
+
+int main() {
+  int x = 10;
+  switch (x) {
+  case 2:
+    printf("bar\n");
+    printf("buz\n");
+  default:
+    printf("baz\n");
+  }
+}

--- a/test/single_file/switch_cases1.c.expected
+++ b/test/single_file/switch_cases1.c.expected
@@ -26,7 +26,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
       while(token) {
         int value = atoi(token);
         int local_value = value - 0;
-        if (local_value >= 0 && local_value < 9) {
+        if (local_value >= 0 && local_value < 17) {
           enabled_bitset[local_value / 64] |= ((uint64_t) 1 << (local_value % 64));
           some_mutation_enabled = 1;
         }
@@ -40,6 +40,23 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   return enabled_bitset[local_mutation_id / 64] & ((uint64_t) 1 << (local_mutation_id % 64));
 }
 
+static int __dredd_replace_expr_int_lvalue(int* arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return (*arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return ++((*arg));
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return --((*arg));
+  return (*arg);
+}
+
+static int __dredd_replace_expr_int_constant(int arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return -(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 0;
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return -1;
+  return arg;
+}
+
 static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg);
@@ -51,11 +68,15 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   return arg;
 }
 
+#include <stdio.h>
+
 int main() {
-  if (!__dredd_enabled_mutation(8)) { switch(__dredd_replace_expr_int(0, 0)) {
-  case -1:
-    if (!__dredd_enabled_mutation(6)) { break; }
+  int x = __dredd_replace_expr_int_constant(10, 0);
+  if (!__dredd_enabled_mutation(16)) { switch (__dredd_replace_expr_int(__dredd_replace_expr_int_lvalue(&(x), 5), 7)) {
+  case 2:
+    if (!__dredd_enabled_mutation(13)) { printf("bar\n"); }
+    if (!__dredd_enabled_mutation(14)) { printf("buz\n"); }
   default:
-    if (!__dredd_enabled_mutation(7)) { break; }
+    if (!__dredd_enabled_mutation(15)) { printf("baz\n"); }
   } }
 }

--- a/test/single_file/switch_cases1.c.noopt.expected
+++ b/test/single_file/switch_cases1.c.noopt.expected
@@ -26,7 +26,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
       while(token) {
         int value = atoi(token);
         int local_value = value - 0;
-        if (local_value >= 0 && local_value < 9) {
+        if (local_value >= 0 && local_value < 36) {
           enabled_bitset[local_value / 64] |= ((uint64_t) 1 << (local_value % 64));
           some_mutation_enabled = 1;
         }
@@ -40,6 +40,13 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   return enabled_bitset[local_mutation_id / 64] & ((uint64_t) 1 << (local_mutation_id % 64));
 }
 
+static int __dredd_replace_expr_int_lvalue(int* arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return (*arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return ++((*arg));
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return --((*arg));
+  return (*arg);
+}
+
 static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg);
@@ -51,11 +58,15 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   return arg;
 }
 
+#include <stdio.h>
+
 int main() {
-  if (!__dredd_enabled_mutation(8)) { switch(__dredd_replace_expr_int(0, 0)) {
-  case -1:
-    if (!__dredd_enabled_mutation(6)) { break; }
+  int x = __dredd_replace_expr_int(10, 0);
+  if (!__dredd_enabled_mutation(35)) { switch (__dredd_replace_expr_int(__dredd_replace_expr_int_lvalue(&(x), 6), 8)) {
+  case 2:
+    if (!__dredd_enabled_mutation(20)) { __dredd_replace_expr_int(printf("bar\n"), 14); }
+    if (!__dredd_enabled_mutation(27)) { __dredd_replace_expr_int(printf("buz\n"), 21); }
   default:
-    if (!__dredd_enabled_mutation(7)) { break; }
+    if (!__dredd_enabled_mutation(34)) { __dredd_replace_expr_int(printf("baz\n"), 28); }
   } }
 }

--- a/test/single_file/switch_cases2.c
+++ b/test/single_file/switch_cases2.c
@@ -1,0 +1,15 @@
+#include <stdio.h>
+
+int main() {
+  int x = 10;
+  switch (x) {
+  case 2:
+  case 3:
+  case 4:
+    printf("bar\n");
+    printf("buz\n");
+  case 5:
+  default:
+    printf("baz\n");
+  }
+}

--- a/test/single_file/switch_cases2.c.expected
+++ b/test/single_file/switch_cases2.c.expected
@@ -26,7 +26,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
       while(token) {
         int value = atoi(token);
         int local_value = value - 0;
-        if (local_value >= 0 && local_value < 9) {
+        if (local_value >= 0 && local_value < 17) {
           enabled_bitset[local_value / 64] |= ((uint64_t) 1 << (local_value % 64));
           some_mutation_enabled = 1;
         }
@@ -40,6 +40,23 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   return enabled_bitset[local_mutation_id / 64] & ((uint64_t) 1 << (local_mutation_id % 64));
 }
 
+static int __dredd_replace_expr_int_lvalue(int* arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return (*arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return ++((*arg));
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return --((*arg));
+  return (*arg);
+}
+
+static int __dredd_replace_expr_int_constant(int arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return -(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 0;
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return -1;
+  return arg;
+}
+
 static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg);
@@ -51,11 +68,18 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   return arg;
 }
 
+#include <stdio.h>
+
 int main() {
-  if (!__dredd_enabled_mutation(8)) { switch(__dredd_replace_expr_int(0, 0)) {
-  case -1:
-    if (!__dredd_enabled_mutation(6)) { break; }
+  int x = __dredd_replace_expr_int_constant(10, 0);
+  if (!__dredd_enabled_mutation(16)) { switch (__dredd_replace_expr_int(__dredd_replace_expr_int_lvalue(&(x), 5), 7)) {
+  case 2:
+  case 3:
+  case 4:
+    if (!__dredd_enabled_mutation(13)) { printf("bar\n"); }
+    if (!__dredd_enabled_mutation(14)) { printf("buz\n"); }
+  case 5:
   default:
-    if (!__dredd_enabled_mutation(7)) { break; }
+    if (!__dredd_enabled_mutation(15)) { printf("baz\n"); }
   } }
 }

--- a/test/single_file/switch_cases2.c.noopt.expected
+++ b/test/single_file/switch_cases2.c.noopt.expected
@@ -26,7 +26,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
       while(token) {
         int value = atoi(token);
         int local_value = value - 0;
-        if (local_value >= 0 && local_value < 9) {
+        if (local_value >= 0 && local_value < 36) {
           enabled_bitset[local_value / 64] |= ((uint64_t) 1 << (local_value % 64));
           some_mutation_enabled = 1;
         }
@@ -40,6 +40,13 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   return enabled_bitset[local_mutation_id / 64] & ((uint64_t) 1 << (local_mutation_id % 64));
 }
 
+static int __dredd_replace_expr_int_lvalue(int* arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return (*arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return ++((*arg));
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return --((*arg));
+  return (*arg);
+}
+
 static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg);
@@ -51,11 +58,18 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   return arg;
 }
 
+#include <stdio.h>
+
 int main() {
-  if (!__dredd_enabled_mutation(8)) { switch(__dredd_replace_expr_int(0, 0)) {
-  case -1:
-    if (!__dredd_enabled_mutation(6)) { break; }
+  int x = __dredd_replace_expr_int(10, 0);
+  if (!__dredd_enabled_mutation(35)) { switch (__dredd_replace_expr_int(__dredd_replace_expr_int_lvalue(&(x), 6), 8)) {
+  case 2:
+  case 3:
+  case 4:
+    if (!__dredd_enabled_mutation(20)) { __dredd_replace_expr_int(printf("bar\n"), 14); }
+    if (!__dredd_enabled_mutation(27)) { __dredd_replace_expr_int(printf("buz\n"), 21); }
+  case 5:
   default:
-    if (!__dredd_enabled_mutation(7)) { break; }
+    if (!__dredd_enabled_mutation(34)) { __dredd_replace_expr_int(printf("baz\n"), 28); }
   } }
 }


### PR DESCRIPTION
Fixes a problem where statements appearing directly after 'case' and 'default' labels were not being mutated properly. Such statements were not being considered for removal, and an optimisation to avoid expression mutation was being missed for such statements.

Fixes #257.