### PR TITLE
Clean up handling of bit-fields

### DIFF
--- a/.github/workflows/cxx_apps.sh
+++ b/.github/workflows/cxx_apps.sh
@@ -157,7 +157,7 @@ pushd SPIRV-Tools
   ./build/test/val/test_val_fghijklmnop
   ./build/test/val/test_val_rstuvw
   NUM_MUTANTS=`python3 ${DREDD_ROOT}/scripts/query_mutant_info.py mutation-info.json --largest-mutant-id`
-  EXPECTED_NUM_MUTANTS=68813
+  EXPECTED_NUM_MUTANTS=68821
   if [ ${NUM_MUTANTS} -ne ${EXPECTED_NUM_MUTANTS} ]
   then
      echo "Found ${NUM_MUTANTS} mutants when mutating the SPIR-V validator source code. Expected ${EXPECTED_NUM_MUTANTS}. If Dredd changed recently, the expected value may just need to be updated, if it still looks sensible. Otherwise, there is likely a problem."

--- a/.github/workflows/cxx_apps.sh
+++ b/.github/workflows/cxx_apps.sh
@@ -183,7 +183,7 @@ pushd llvm-project
   ${DREDD_EXECUTABLE} --mutation-info-file mutation-info.json -p "${DREDD_ROOT}/llvm-project/build/compile_commands.json" "${FILES[@]}"
   cmake --build build --target LLVMInstCombine
   NUM_MUTANTS=`python3 ${DREDD_ROOT}/scripts/query_mutant_info.py mutation-info.json --largest-mutant-id`
-  EXPECTED_NUM_MUTANTS=98026
+  EXPECTED_NUM_MUTANTS=98034
   if [ ${NUM_MUTANTS} -ne ${EXPECTED_NUM_MUTANTS} ]
   then
      echo "Found ${NUM_MUTANTS} mutants when mutating the LLVM source code. Expected ${EXPECTED_NUM_MUTANTS}. If Dredd changed recently, the expected value may just need to be updated, if it still looks sensible. Otherwise, there is likely a problem."

--- a/src/libdredd/include/libdredd/util.h
+++ b/src/libdredd/include/libdredd/util.h
@@ -20,6 +20,7 @@
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Expr.h"
 #include "clang/AST/ParentMapContext.h"
+#include "clang/AST/Stmt.h"
 #include "clang/Basic/SourceLocation.h"
 #include "clang/Basic/SourceManager.h"
 #include "clang/Lex/Preprocessor.h"

--- a/src/libdredd/include/libdredd/util.h
+++ b/src/libdredd/include/libdredd/util.h
@@ -19,6 +19,7 @@
 
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Expr.h"
+#include "clang/AST/ParentMapContext.h"
 #include "clang/Basic/SourceLocation.h"
 #include "clang/Basic/SourceManager.h"
 #include "clang/Lex/Preprocessor.h"
@@ -127,6 +128,23 @@ bool EvaluateAsFloat(const clang::Expr& expr,
 // expression is value-dependent).
 bool IsCxx11ConstantExpr(const clang::Expr& expr,
                          const clang::ASTContext& ast_context);
+
+// It is often necessary to ask whether a given statement (which includes
+// expressions) has a parent of a given type. This helper returns nullptr if
+// the given statement has no parent of the template parameter type, and
+// otherwise returns the first parent that does have the template parameter
+// type.
+template <typename RequiredParentT>
+const RequiredParentT* GetFirstParentOfType(const clang::Stmt& stmt,
+                                            clang::ASTContext& ast_context) {
+  for (const auto& parent : ast_context.getParents(stmt)) {
+    const auto* candidate_result = parent.template get<RequiredParentT>();
+    if (candidate_result != nullptr) {
+      return candidate_result;
+    }
+  }
+  return nullptr;
+}
 
 }  // namespace dredd
 

--- a/src/libdredd/include_private/include/libdredd/mutate_visitor.h
+++ b/src/libdredd/include_private/include/libdredd/mutate_visitor.h
@@ -162,14 +162,6 @@ class MutateVisitor : public clang::RecursiveASTVisitor<MutateVisitor> {
   // }
   bool IsInFunction();
 
-  // It is often necessary to ask whether a given statement (which includes
-  // expressions) has a parent of a given type. This helper returns nullptr if
-  // the given statement has no parent of the template parameter type, and
-  // otherwise returns the first parent that does have the template parameter
-  // type.
-  template <typename RequiredParentT>
-  const RequiredParentT* GetFirstParentOfType(const clang::Stmt& stmt) const;
-
   // Mutating an enum constant can be problematic when the enum constant is used
   // to implicitly construct a C++ object. This helper method allows detecting
   // this special case, so that it can be ignored.

--- a/src/libdredd/src/mutate_visitor.cc
+++ b/src/libdredd/src/mutate_visitor.cc
@@ -302,9 +302,11 @@ void MutateVisitor::HandleUnaryOperator(clang::UnaryOperator* unary_operator) {
     return;
   }
 
-  // As it is not possible to pass bit-fields by reference, mutation of
-  // bit-fields is not supported.
-  if (unary_operator->getSubExpr()->refersToBitField()) {
+  // Mutation functions for ++ and -- operators require their argument to be
+  // passed by reference. It is not possible to pass bit-fields by reference,
+  // this mutation of these operators when applied to bit-fields is not
+  // supported.
+  if (unary_operator->isIncrementDecrementOp() && unary_operator->getSubExpr()->refersToBitField()) {
     return;
   }
 

--- a/src/libdredd/src/mutate_visitor.cc
+++ b/src/libdredd/src/mutate_visitor.cc
@@ -368,9 +368,11 @@ void MutateVisitor::HandleBinaryOperator(
     return;
   }
 
-  // As it is not possible to pass bit-fields by reference, mutation of
-  // bit-fields is not supported.
-  if (binary_operator->getLHS()->refersToBitField()) {
+  // Mutation functions for assignment operators (for example +=) require their
+  // first argument to be passed by reference. It is not possible to pass
+  // bit-fields by reference, this mutation of these operators when applied to a
+  // bit-field first argument is not supported.
+  if (binary_operator->isAssignmentOp() && binary_operator->getLHS()->refersToBitField()) {
     return;
   }
 

--- a/src/libdredd/src/mutate_visitor.cc
+++ b/src/libdredd/src/mutate_visitor.cc
@@ -18,7 +18,6 @@
 #include <cstddef>
 #include <memory>
 
-#include "clang/AST/ASTContext.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclBase.h"
 #include "clang/AST/DeclCXX.h"

--- a/src/libdredd/src/mutation_replace_expr.cc
+++ b/src/libdredd/src/mutation_replace_expr.cc
@@ -685,17 +685,17 @@ bool MutationReplaceExpr::CanMutateLValue(clang::ASTContext& ast_context,
   if (expr.getType().isConstQualified() || expr.getType()->isBooleanType()) {
     return false;
   }
-  // The following checks that `expr` is the child of an ImplicitCastExpr that
-  // yields an r-value.
-  const auto* implicit_cast =
-      GetFirstParentOfType<clang::ImplicitCastExpr>(expr, ast_context);
-  if (implicit_cast == nullptr || implicit_cast->isLValue()) {
-    return false;
-  }
   // Bit-fields cannot be passed by reference, and mutator functions for
   // l-values must be passed by reference, hence bit-fields are not supported
   // in this context.
   if (expr.refersToBitField()) {
+    return false;
+  }
+  // The following checks that `expr` is the child of an ImplicitCastExpr that
+  // yields an r-value.
+  const auto* implicit_cast_expr =
+      GetFirstParentOfType<clang::ImplicitCastExpr>(expr, ast_context);
+  if (implicit_cast_expr == nullptr || implicit_cast_expr->isLValue()) {
     return false;
   }
   return true;

--- a/src/libdredd/src/mutation_replace_expr.cc
+++ b/src/libdredd/src/mutation_replace_expr.cc
@@ -687,11 +687,8 @@ bool MutationReplaceExpr::CanMutateLValue(clang::ASTContext& ast_context,
   }
   // The following checks that `expr` is the child of an ImplicitCastExpr that
   // yields an r-value.
-  auto parents = ast_context.getParents<clang::Expr>(expr);
-  if (parents.size() != 1) {
-    return false;
-  }
-  const auto* implicit_cast = parents[0].get<clang::ImplicitCastExpr>();
+  const auto* implicit_cast =
+      GetFirstParentOfType<clang::ImplicitCastExpr>(expr, ast_context);
   if (implicit_cast == nullptr || implicit_cast->isLValue()) {
     return false;
   }

--- a/test/single_file/bitfield.c
+++ b/test/single_file/bitfield.c
@@ -6,6 +6,7 @@ struct S {
 void foo() {
   struct S myS;
   myS.a = myS.b;
+  myS.a = -myS.b;
   myS.a++;
   --myS.b;
 }

--- a/test/single_file/bitfield.c.expected
+++ b/test/single_file/bitfield.c.expected
@@ -26,7 +26,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
       while(token) {
         int value = atoi(token);
         int local_value = value - 0;
-        if (local_value >= 0 && local_value < 9) {
+        if (local_value >= 0 && local_value < 24) {
           enabled_bitset[local_value / 64] |= ((uint64_t) 1 << (local_value % 64));
           some_mutation_enabled = 1;
         }
@@ -38,6 +38,13 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
     __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return enabled_bitset[local_mutation_id / 64] & ((uint64_t) 1 << (local_mutation_id % 64));
+}
+
+static int __dredd_replace_unary_operator_Minus_int(int arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return -arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return !arg;
+  return -arg;
 }
 
 static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
@@ -59,6 +66,7 @@ struct S {
 void foo() {
   struct S myS;
   if (!__dredd_enabled_mutation(6)) { myS.a = __dredd_replace_expr_int(myS.b, 0); }
-  if (!__dredd_enabled_mutation(7)) { myS.a++; }
-  if (!__dredd_enabled_mutation(8)) { --myS.b; }
+  if (!__dredd_enabled_mutation(21)) { myS.a = __dredd_replace_expr_int(__dredd_replace_unary_operator_Minus_int(__dredd_replace_expr_int(myS.b, 7), 13), 15); }
+  if (!__dredd_enabled_mutation(22)) { myS.a++; }
+  if (!__dredd_enabled_mutation(23)) { --myS.b; }
 }

--- a/test/single_file/bitfield.c.noopt.expected
+++ b/test/single_file/bitfield.c.noopt.expected
@@ -26,7 +26,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
       while(token) {
         int value = atoi(token);
         int local_value = value - 0;
-        if (local_value >= 0 && local_value < 27) {
+        if (local_value >= 0 && local_value < 49) {
           enabled_bitset[local_value / 64] |= ((uint64_t) 1 << (local_value % 64));
           some_mutation_enabled = 1;
         }
@@ -38,6 +38,14 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
     __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return enabled_bitset[local_mutation_id / 64] & ((uint64_t) 1 << (local_mutation_id % 64));
+}
+
+static int __dredd_replace_unary_operator_Minus_int(int arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return -arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return !arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg;
+  return -arg;
 }
 
 static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
@@ -59,6 +67,7 @@ struct S {
 void foo() {
   struct S myS;
   if (!__dredd_enabled_mutation(12)) { __dredd_replace_expr_int(myS.a = __dredd_replace_expr_int(myS.b, 0), 6); }
-  if (!__dredd_enabled_mutation(19)) { __dredd_replace_expr_int(myS.a++, 13); }
-  if (!__dredd_enabled_mutation(26)) { __dredd_replace_expr_int(--myS.b, 20); }
+  if (!__dredd_enabled_mutation(34)) { __dredd_replace_expr_int(myS.a = __dredd_replace_expr_int(__dredd_replace_unary_operator_Minus_int(__dredd_replace_expr_int(myS.b, 13), 19), 22), 28); }
+  if (!__dredd_enabled_mutation(41)) { __dredd_replace_expr_int(myS.a++, 35); }
+  if (!__dredd_enabled_mutation(48)) { __dredd_replace_expr_int(--myS.b, 42); }
 }

--- a/test/single_file/bitfield.cc
+++ b/test/single_file/bitfield.cc
@@ -6,6 +6,7 @@ struct S {
 void foo() {
   S myS;
   myS.a = myS.b;
+  myS.a = -myS.b;
   myS.a++;
   --myS.b;
 }

--- a/test/single_file/bitfield.cc.expected
+++ b/test/single_file/bitfield.cc.expected
@@ -25,7 +25,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
         if (!token.empty()) {
           int value = std::stoi(token);
           int local_value = value - 0;
-          if (local_value >= 0 && local_value < 9) {
+          if (local_value >= 0 && local_value < 24) {
             enabled_bitset[local_value / 64] |= (static_cast<uint64_t>(1) << (local_value % 64));
             some_mutation_enabled = true;
           }
@@ -40,6 +40,13 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
     __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return (enabled_bitset[local_mutation_id / 64] & (static_cast<uint64_t>(1) << (local_mutation_id % 64))) != 0;
+}
+
+static int __dredd_replace_unary_operator_Minus_int(int arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return -arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return !arg;
+  return -arg;
 }
 
 static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
@@ -61,6 +68,7 @@ struct S {
 void foo() {
   S myS;
   if (!__dredd_enabled_mutation(6)) { myS.a = __dredd_replace_expr_int(myS.b, 0); }
-  if (!__dredd_enabled_mutation(7)) { myS.a++; }
-  if (!__dredd_enabled_mutation(8)) { --myS.b; }
+  if (!__dredd_enabled_mutation(21)) { myS.a = __dredd_replace_expr_int(__dredd_replace_unary_operator_Minus_int(__dredd_replace_expr_int(myS.b, 7), 13), 15); }
+  if (!__dredd_enabled_mutation(22)) { myS.a++; }
+  if (!__dredd_enabled_mutation(23)) { --myS.b; }
 }

--- a/test/single_file/bitfield.cc.noopt.expected
+++ b/test/single_file/bitfield.cc.noopt.expected
@@ -25,7 +25,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
         if (!token.empty()) {
           int value = std::stoi(token);
           int local_value = value - 0;
-          if (local_value >= 0 && local_value < 15) {
+          if (local_value >= 0 && local_value < 31) {
             enabled_bitset[local_value / 64] |= (static_cast<uint64_t>(1) << (local_value % 64));
             some_mutation_enabled = true;
           }
@@ -40,6 +40,14 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
     __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return (enabled_bitset[local_mutation_id / 64] & (static_cast<uint64_t>(1) << (local_mutation_id % 64))) != 0;
+}
+
+static int __dredd_replace_unary_operator_Minus_int(int arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return -arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return !arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg;
+  return -arg;
 }
 
 static int __dredd_replace_expr_int(std::function<int()> arg, int local_mutation_id) {
@@ -72,6 +80,7 @@ struct S {
 void foo() {
   S myS;
   if (!__dredd_enabled_mutation(6)) { myS.a = __dredd_replace_expr_int(myS.b, 0); }
-  if (!__dredd_enabled_mutation(13)) { __dredd_replace_expr_int([&]() -> int { return static_cast<int>(myS.a++); }, 7); }
-  if (!__dredd_enabled_mutation(14)) { --myS.b; }
+  if (!__dredd_enabled_mutation(22)) { myS.a = __dredd_replace_expr_int(__dredd_replace_unary_operator_Minus_int(__dredd_replace_expr_int(myS.b, 7), 13), 16); }
+  if (!__dredd_enabled_mutation(29)) { __dredd_replace_expr_int([&]() -> int { return static_cast<int>(myS.a++); }, 23); }
+  if (!__dredd_enabled_mutation(30)) { --myS.b; }
 }


### PR DESCRIPTION
In preparation for fixing #259, this cleans up the code for deciding
when to ignore expressions that refer to bit-fields.