### PR TITLE
Avoid mutating enum constant in C++ constructor

### DIFF
--- a/src/libdredd/include_private/include/libdredd/mutate_visitor.h
+++ b/src/libdredd/include_private/include/libdredd/mutate_visitor.h
@@ -170,6 +170,11 @@ class MutateVisitor : public clang::RecursiveASTVisitor<MutateVisitor> {
   template <typename RequiredParentT>
   const RequiredParentT* GetFirstParentOfType(const clang::Stmt& stmt) const;
 
+  // Mutating an enum constant can be problematic when the enum constant is used
+  // to implicitly construct a C++ object. This helper method allows detecting
+  // this special case, so that it can be ignored.
+  bool IsConversionOfEnumToConstructor(const clang::Expr& expr) const;
+
   const clang::CompilerInstance* compiler_instance_;
   bool optimise_mutations_;
 

--- a/src/libdredd/src/mutate_visitor.cc
+++ b/src/libdredd/src/mutate_visitor.cc
@@ -609,8 +609,7 @@ bool MutateVisitor::IsConversionOfEnumToConstructor(
     return false;
   }
   // Check whether the parent expression is a C++ constructor.
-  if (GetFirstParentOfType<clang::CXXConstructExpr>(
-          expr, compiler_instance_->getASTContext()) == nullptr) {
+  if (GetFirstParentOfType<clang::CXXConstructExpr>(expr) == nullptr) {
     return false;
   }
   // Check whether there is an enum constant under the implicit cast.

--- a/test/single_file/construct_struct_from_enum_constant.cc
+++ b/test/single_file/construct_struct_from_enum_constant.cc
@@ -1,0 +1,10 @@
+struct foo {
+  foo(int) {};
+  operator int();
+};
+
+enum baz { bar };
+
+int main() { 
+  0 ? foo(0) : baz::bar;
+}

--- a/test/single_file/construct_struct_from_enum_constant.cc.expected
+++ b/test/single_file/construct_struct_from_enum_constant.cc.expected
@@ -1,0 +1,67 @@
+#include <cinttypes>
+#include <cstddef>
+#include <functional>
+#include <string>
+
+
+#ifdef _MSC_VER
+#define thread_local __declspec(thread)
+#elif __APPLE__
+#define thread_local __thread
+#endif
+
+static thread_local bool __dredd_some_mutation_enabled = true;
+static bool __dredd_enabled_mutation(int local_mutation_id) {
+  static thread_local bool initialized = false;
+  static thread_local uint64_t enabled_bitset[1];
+  if (!initialized) {
+    bool some_mutation_enabled = false;
+    const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
+    if (dredd_environment_variable != nullptr) {
+      std::string contents(dredd_environment_variable);
+      while (true) {
+        size_t pos = contents.find(",");
+        std::string token = (pos == std::string::npos ? contents : contents.substr(0, pos));
+        if (!token.empty()) {
+          int value = std::stoi(token);
+          int local_value = value - 0;
+          if (local_value >= 0 && local_value < 4) {
+            enabled_bitset[local_value / 64] |= (static_cast<uint64_t>(1) << (local_value % 64));
+            some_mutation_enabled = true;
+          }
+        }
+        if (pos == std::string::npos) {
+          break;
+        }
+        contents.erase(0, pos + 1);
+      }
+    }
+    initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
+  }
+  return (enabled_bitset[local_mutation_id / 64] & (static_cast<uint64_t>(1) << (local_mutation_id % 64))) != 0;
+}
+
+static int __dredd_replace_expr_int_zero(int arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return -1;
+  return arg;
+}
+
+static bool __dredd_replace_expr_bool_false(bool arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return true;
+  return arg;
+}
+
+struct foo {
+  foo(int) {};
+  operator int();
+};
+
+enum baz { bar };
+
+int main() { 
+  if (!__dredd_enabled_mutation(3)) { __dredd_replace_expr_bool_false(0, 0) ? foo(__dredd_replace_expr_int_zero(0, 1)) : baz::bar; }
+}

--- a/test/single_file/construct_struct_from_enum_constant.cc.noopt.expected
+++ b/test/single_file/construct_struct_from_enum_constant.cc.noopt.expected
@@ -1,0 +1,73 @@
+#include <cinttypes>
+#include <cstddef>
+#include <functional>
+#include <string>
+
+
+#ifdef _MSC_VER
+#define thread_local __declspec(thread)
+#elif __APPLE__
+#define thread_local __thread
+#endif
+
+static thread_local bool __dredd_some_mutation_enabled = true;
+static bool __dredd_enabled_mutation(int local_mutation_id) {
+  static thread_local bool initialized = false;
+  static thread_local uint64_t enabled_bitset[1];
+  if (!initialized) {
+    bool some_mutation_enabled = false;
+    const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
+    if (dredd_environment_variable != nullptr) {
+      std::string contents(dredd_environment_variable);
+      while (true) {
+        size_t pos = contents.find(",");
+        std::string token = (pos == std::string::npos ? contents : contents.substr(0, pos));
+        if (!token.empty()) {
+          int value = std::stoi(token);
+          int local_value = value - 0;
+          if (local_value >= 0 && local_value < 16) {
+            enabled_bitset[local_value / 64] |= (static_cast<uint64_t>(1) << (local_value % 64));
+            some_mutation_enabled = true;
+          }
+        }
+        if (pos == std::string::npos) {
+          break;
+        }
+        contents.erase(0, pos + 1);
+      }
+    }
+    initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
+  }
+  return (enabled_bitset[local_mutation_id / 64] & (static_cast<uint64_t>(1) << (local_mutation_id % 64))) != 0;
+}
+
+static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 0;
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
+  return arg;
+}
+
+static bool __dredd_replace_expr_bool(bool arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return true;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return false;
+  return arg;
+}
+
+struct foo {
+  foo(int) {};
+  operator int();
+};
+
+enum baz { bar };
+
+int main() { 
+  if (!__dredd_enabled_mutation(15)) { __dredd_replace_expr_bool(__dredd_replace_expr_int(0, 0), 6) ? foo(__dredd_replace_expr_int(0, 9)) : baz::bar; }
+}


### PR DESCRIPTION
Works around a special cases where mutating an enum constant that occurs in a C++ constructor can lead to ambiguity when used in a conditional expression.

Fixes #264.