### PR TITLE
Prevent expression-under-cast-bypass in Initializer Lists for more mutations and narrowing type handling

### DIFF
--- a/.github/workflows/cxx_apps.sh
+++ b/.github/workflows/cxx_apps.sh
@@ -157,7 +157,7 @@ pushd SPIRV-Tools
   ./build/test/val/test_val_fghijklmnop
   ./build/test/val/test_val_rstuvw
   NUM_MUTANTS=`python3 ${DREDD_ROOT}/scripts/query_mutant_info.py mutation-info.json --largest-mutant-id`
-  EXPECTED_NUM_MUTANTS=68821
+  EXPECTED_NUM_MUTANTS=68841
   if [ ${NUM_MUTANTS} -ne ${EXPECTED_NUM_MUTANTS} ]
   then
      echo "Found ${NUM_MUTANTS} mutants when mutating the SPIR-V validator source code. Expected ${EXPECTED_NUM_MUTANTS}. If Dredd changed recently, the expected value may just need to be updated, if it still looks sensible. Otherwise, there is likely a problem."

--- a/.github/workflows/cxx_apps.sh
+++ b/.github/workflows/cxx_apps.sh
@@ -183,7 +183,7 @@ pushd llvm-project
   ${DREDD_EXECUTABLE} --mutation-info-file mutation-info.json -p "${DREDD_ROOT}/llvm-project/build" "${FILES[@]}"
   cmake --build build --target LLVMInstCombine
   NUM_MUTANTS=`python3 ${DREDD_ROOT}/scripts/query_mutant_info.py mutation-info.json --largest-mutant-id`
-  EXPECTED_NUM_MUTANTS=98034
+  EXPECTED_NUM_MUTANTS=98042
   if [ ${NUM_MUTANTS} -ne ${EXPECTED_NUM_MUTANTS} ]
   then
      echo "Found ${NUM_MUTANTS} mutants when mutating the LLVM source code. Expected ${EXPECTED_NUM_MUTANTS}. If Dredd changed recently, the expected value may just need to be updated, if it still looks sensible. Otherwise, there is likely a problem."

--- a/src/libdredd/src/mutate_visitor.cc
+++ b/src/libdredd/src/mutate_visitor.cc
@@ -479,17 +479,16 @@ void MutateVisitor::HandleExpr(clang::Expr* expr) {
     // whenever a signed literal, such as `1`, is used in an unsigned context.
     if (const auto* cast_parent = GetFirstParentOfType<clang::CastExpr>(
             *expr, compiler_instance_->getASTContext())) {
-      if (cast_parent->isLValue() == expr->isLValue()) {
-        if (GetFirstParentOfType<clang::InitListExpr>(
-                *expr, compiler_instance_->getASTContext()) == nullptr) {
-          // However, this optimization shouldn't be performed on expressions
-          // under Initializer List. This is because: (1) Dredd won't act on the
-          // outer implicit cast under Initializer List. (2)  Bypassing this
-          // would skip dredd-introduced static_cast, causing issues when the
-          // expression is implicitly cast into a narrower type and passed into
-          // a C++ std::initializer_list.
-          return;
-        }
+      if (cast_parent->isLValue() == expr->isLValue() &&
+          GetFirstParentOfType<clang::InitListExpr>(
+              *expr, compiler_instance_->getASTContext()) == nullptr) {
+        // However, this optimization shouldn't be performed on expressions
+        // under Initializer List. This is because: (1) Dredd won't act on the
+        // outer implicit cast under Initializer List. (2)  Bypassing this
+        // would skip dredd-introduced static_cast, causing issues when the
+        // expression is implicitly cast into a narrower type and passed into
+        // a C++ std::initializer_list.
+        return;
       }
     }
 

--- a/src/libdredd/src/mutate_visitor.cc
+++ b/src/libdredd/src/mutate_visitor.cc
@@ -470,11 +470,6 @@ void MutateVisitor::HandleExpr(clang::Expr* expr) {
   }
 
   if (optimise_mutations_) {
-    if (GetFirstAncestorOfType<clang::CXXStdInitializerListExpr>(*expr, compiler_instance_->getASTContext()) != nullptr) {
-          // However, this optimisation shouldn't be perform on C++'s Initializer List expression as it bypass applying static_cast on
-          std::cout << "dvfwe" << std::endl;
-    }
-    
     // If an expression is the direct child of a cast expression, do not mutate
     // it unless the cast is an l-value to r-value cast. In an l-value to
     // r-value cast it is worth mutating the expression before and after casting
@@ -518,13 +513,6 @@ void MutateVisitor::HandleExpr(clang::Expr* expr) {
 }
 
 bool MutateVisitor::VisitExpr(clang::Expr* expr) {
-  if (!IsTypeSupported(expr->getType())) {
-    std::cout << "NNexpr" << std::endl;
-  } else {
-    std::cout << "expr" << std::endl;
-  }
-
-
   if (optimise_mutations_ &&
       llvm::dyn_cast<clang::ParenExpr>(expr) != nullptr) {
     // There is no value in mutating a parentheses expression.
@@ -561,21 +549,9 @@ bool MutateVisitor::VisitExpr(clang::Expr* expr) {
     return true;
   }
 
-  if (GetFirstParentOfType<clang::CXXStdInitializerListExpr>(*expr, compiler_instance_->getASTContext()) != nullptr) {
-      std::cout << "erty" << std::endl;
-  } else {
-    std::cout << "ffff" << std::endl;
-  }
-
   // Check that the result type is supported
   if (!IsTypeSupported(expr->getType())) {
     return true;
-  }
-
-  if (GetFirstParentOfType<clang::CXXStdInitializerListExpr>(*expr, compiler_instance_->getASTContext()) != nullptr) {
-      std::cout << "dwdd" << std::endl;
-    }else {
-    std::cout << "rrrr" << std::endl;
   }
 
   if (auto* unary_operator = llvm::dyn_cast<clang::UnaryOperator>(expr)) {

--- a/src/libdredd/src/mutate_visitor.cc
+++ b/src/libdredd/src/mutate_visitor.cc
@@ -422,8 +422,6 @@ void MutateVisitor::HandleBinaryOperator(
 }
 
 void MutateVisitor::HandleExpr(clang::Expr* expr) {
-  
-
   // L-values are only mutated by inserting the prefix operators ++ and --, and
   // only under specific circumstances as documented by
   // MutationReplaceExpr::CanMutateLValue.
@@ -482,12 +480,16 @@ void MutateVisitor::HandleExpr(clang::Expr* expr) {
     if (const auto* cast_parent = GetFirstParentOfType<clang::CastExpr>(
             *expr, compiler_instance_->getASTContext())) {
       if (cast_parent->isLValue() == expr->isLValue()) {
-          if (GetFirstParentOfType<clang::InitListExpr>(*expr, compiler_instance_->getASTContext()) == nullptr) {
-          // However, this optimization shouldn't be performed on expressions under Initializer List. This is because:
-          // (1) Dredd won't act on the outer implicit cast under Initializer List.
-          // (2)  Bypassing this would skip dredd-introduced static_cast, causing issues when the expression is implicitly cast into a narrower type and passed into a C++ std::initializer_list.
+        if (GetFirstParentOfType<clang::InitListExpr>(
+                *expr, compiler_instance_->getASTContext()) == nullptr) {
+          // However, this optimization shouldn't be performed on expressions
+          // under Initializer List. This is because: (1) Dredd won't act on the
+          // outer implicit cast under Initializer List. (2)  Bypassing this
+          // would skip dredd-introduced static_cast, causing issues when the
+          // expression is implicitly cast into a narrower type and passed into
+          // a C++ std::initializer_list.
           return;
-          }
+        }
       }
     }
 

--- a/test/single_file/initializer_list.cc.expected
+++ b/test/single_file/initializer_list.cc.expected
@@ -25,7 +25,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
         if (!token.empty()) {
           int value = std::stoi(token);
           int local_value = value - 0;
-          if (local_value >= 0 && local_value < 1) {
+          if (local_value >= 0 && local_value < 5) {
             enabled_bitset[local_value / 64] |= (static_cast<uint64_t>(1) << (local_value % 64));
             some_mutation_enabled = true;
           }
@@ -42,6 +42,13 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   return (enabled_bitset[local_mutation_id / 64] & (static_cast<uint64_t>(1) << (local_mutation_id % 64))) != 0;
 }
 
+static int __dredd_replace_expr_int_zero(int arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return -1;
+  return arg;
+}
+
 #include <cstddef>
 
 struct A {
@@ -52,5 +59,5 @@ struct A {
 void foo(A arg);
 
 void bar() {
-  if (!__dredd_enabled_mutation(0)) { foo({0, 0}); }
+  if (!__dredd_enabled_mutation(4)) { foo({static_cast<unsigned long>(__dredd_replace_expr_int_zero(0, 0)), static_cast<unsigned long>(__dredd_replace_expr_int_zero(0, 2))}); }
 }

--- a/test/single_file/initializer_list_long_to_short.cc
+++ b/test/single_file/initializer_list_long_to_short.cc
@@ -1,0 +1,10 @@
+#include <initializer_list>
+
+class foo {
+public:
+  foo(std::initializer_list<short>) {}
+};
+
+int main() { 
+    foo{(long) 2}; 
+}

--- a/test/single_file/initializer_list_long_to_short.cc.expected
+++ b/test/single_file/initializer_list_long_to_short.cc.expected
@@ -1,0 +1,64 @@
+#include <cinttypes>
+#include <cstddef>
+#include <functional>
+#include <string>
+
+
+#ifdef _MSC_VER
+#define thread_local __declspec(thread)
+#elif __APPLE__
+#define thread_local __thread
+#endif
+
+static thread_local bool __dredd_some_mutation_enabled = true;
+static bool __dredd_enabled_mutation(int local_mutation_id) {
+  static thread_local bool initialized = false;
+  static thread_local uint64_t enabled_bitset[1];
+  if (!initialized) {
+    bool some_mutation_enabled = false;
+    const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
+    if (dredd_environment_variable != nullptr) {
+      std::string contents(dredd_environment_variable);
+      while (true) {
+        size_t pos = contents.find(",");
+        std::string token = (pos == std::string::npos ? contents : contents.substr(0, pos));
+        if (!token.empty()) {
+          int value = std::stoi(token);
+          int local_value = value - 0;
+          if (local_value >= 0 && local_value < 6) {
+            enabled_bitset[local_value / 64] |= (static_cast<uint64_t>(1) << (local_value % 64));
+            some_mutation_enabled = true;
+          }
+        }
+        if (pos == std::string::npos) {
+          break;
+        }
+        contents.erase(0, pos + 1);
+      }
+    }
+    initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
+  }
+  return (enabled_bitset[local_mutation_id / 64] & (static_cast<uint64_t>(1) << (local_mutation_id % 64))) != 0;
+}
+
+static long __dredd_replace_expr_long_constant(long arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return -(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 0;
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return -1;
+  return arg;
+}
+
+#include <initializer_list>
+
+class foo {
+public:
+  foo(std::initializer_list<short>) {}
+};
+
+int main() { 
+    if (!__dredd_enabled_mutation(5)) { foo{static_cast<short>(__dredd_replace_expr_long_constant((long) 2, 0))}; } 
+}

--- a/test/single_file/initializer_list_long_to_short.cc.noopt.expected
+++ b/test/single_file/initializer_list_long_to_short.cc.noopt.expected
@@ -1,0 +1,76 @@
+#include <cinttypes>
+#include <cstddef>
+#include <functional>
+#include <string>
+
+
+#ifdef _MSC_VER
+#define thread_local __declspec(thread)
+#elif __APPLE__
+#define thread_local __thread
+#endif
+
+static thread_local bool __dredd_some_mutation_enabled = true;
+static bool __dredd_enabled_mutation(int local_mutation_id) {
+  static thread_local bool initialized = false;
+  static thread_local uint64_t enabled_bitset[1];
+  if (!initialized) {
+    bool some_mutation_enabled = false;
+    const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
+    if (dredd_environment_variable != nullptr) {
+      std::string contents(dredd_environment_variable);
+      while (true) {
+        size_t pos = contents.find(",");
+        std::string token = (pos == std::string::npos ? contents : contents.substr(0, pos));
+        if (!token.empty()) {
+          int value = std::stoi(token);
+          int local_value = value - 0;
+          if (local_value >= 0 && local_value < 19) {
+            enabled_bitset[local_value / 64] |= (static_cast<uint64_t>(1) << (local_value % 64));
+            some_mutation_enabled = true;
+          }
+        }
+        if (pos == std::string::npos) {
+          break;
+        }
+        contents.erase(0, pos + 1);
+      }
+    }
+    initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
+  }
+  return (enabled_bitset[local_mutation_id / 64] & (static_cast<uint64_t>(1) << (local_mutation_id % 64))) != 0;
+}
+
+static long __dredd_replace_expr_long(long arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 0;
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
+  return arg;
+}
+
+static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 0;
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
+  return arg;
+}
+
+#include <initializer_list>
+
+class foo {
+public:
+  foo(std::initializer_list<short>) {}
+};
+
+int main() { 
+    if (!__dredd_enabled_mutation(18)) { foo{static_cast<short>(__dredd_replace_expr_long((long) __dredd_replace_expr_long(__dredd_replace_expr_int(2, 0), 6), 12))}; } 
+}

--- a/test/single_file/initializer_list_narrower.cc
+++ b/test/single_file/initializer_list_narrower.cc
@@ -1,0 +1,10 @@
+#include <initializer_list>
+
+class foo {
+public:
+  foo(std::initializer_list<unsigned int>) {}
+};
+
+int main() { 
+    foo{+2}; 
+}

--- a/test/single_file/initializer_list_narrower.cc.expected
+++ b/test/single_file/initializer_list_narrower.cc.expected
@@ -1,0 +1,64 @@
+#include <cinttypes>
+#include <cstddef>
+#include <functional>
+#include <string>
+
+
+#ifdef _MSC_VER
+#define thread_local __declspec(thread)
+#elif __APPLE__
+#define thread_local __thread
+#endif
+
+static thread_local bool __dredd_some_mutation_enabled = true;
+static bool __dredd_enabled_mutation(int local_mutation_id) {
+  static thread_local bool initialized = false;
+  static thread_local uint64_t enabled_bitset[1];
+  if (!initialized) {
+    bool some_mutation_enabled = false;
+    const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
+    if (dredd_environment_variable != nullptr) {
+      std::string contents(dredd_environment_variable);
+      while (true) {
+        size_t pos = contents.find(",");
+        std::string token = (pos == std::string::npos ? contents : contents.substr(0, pos));
+        if (!token.empty()) {
+          int value = std::stoi(token);
+          int local_value = value - 0;
+          if (local_value >= 0 && local_value < 11) {
+            enabled_bitset[local_value / 64] |= (static_cast<uint64_t>(1) << (local_value % 64));
+            some_mutation_enabled = true;
+          }
+        }
+        if (pos == std::string::npos) {
+          break;
+        }
+        contents.erase(0, pos + 1);
+      }
+    }
+    initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
+  }
+  return (enabled_bitset[local_mutation_id / 64] & (static_cast<uint64_t>(1) << (local_mutation_id % 64))) != 0;
+}
+
+static int __dredd_replace_expr_int_constant(int arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return -(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 0;
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return -1;
+  return arg;
+}
+
+#include <initializer_list>
+
+class foo {
+public:
+  foo(std::initializer_list<unsigned int>) {}
+};
+
+int main() { 
+    if (!__dredd_enabled_mutation(10)) { foo{static_cast<unsigned int>(__dredd_replace_expr_int_constant(+__dredd_replace_expr_int_constant(2, 0), 5))}; } 
+}

--- a/test/single_file/initializer_list_narrower.cc.noopt.expected
+++ b/test/single_file/initializer_list_narrower.cc.noopt.expected
@@ -1,0 +1,65 @@
+#include <cinttypes>
+#include <cstddef>
+#include <functional>
+#include <string>
+
+
+#ifdef _MSC_VER
+#define thread_local __declspec(thread)
+#elif __APPLE__
+#define thread_local __thread
+#endif
+
+static thread_local bool __dredd_some_mutation_enabled = true;
+static bool __dredd_enabled_mutation(int local_mutation_id) {
+  static thread_local bool initialized = false;
+  static thread_local uint64_t enabled_bitset[1];
+  if (!initialized) {
+    bool some_mutation_enabled = false;
+    const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
+    if (dredd_environment_variable != nullptr) {
+      std::string contents(dredd_environment_variable);
+      while (true) {
+        size_t pos = contents.find(",");
+        std::string token = (pos == std::string::npos ? contents : contents.substr(0, pos));
+        if (!token.empty()) {
+          int value = std::stoi(token);
+          int local_value = value - 0;
+          if (local_value >= 0 && local_value < 13) {
+            enabled_bitset[local_value / 64] |= (static_cast<uint64_t>(1) << (local_value % 64));
+            some_mutation_enabled = true;
+          }
+        }
+        if (pos == std::string::npos) {
+          break;
+        }
+        contents.erase(0, pos + 1);
+      }
+    }
+    initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
+  }
+  return (enabled_bitset[local_mutation_id / 64] & (static_cast<uint64_t>(1) << (local_mutation_id % 64))) != 0;
+}
+
+static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 0;
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
+  return arg;
+}
+
+#include <initializer_list>
+
+class foo {
+public:
+  foo(std::initializer_list<unsigned int>) {}
+};
+
+int main() { 
+    if (!__dredd_enabled_mutation(12)) { foo{static_cast<unsigned int>(__dredd_replace_expr_int(+__dredd_replace_expr_int(2, 0), 6))}; } 
+}


### PR DESCRIPTION
Avoid bypass of implicit inner cast mutation under `default` (optimize_mutations) mode for expressions in Initializer List. Besides producing more mutants, this change ensures that Dredd can correctly handle narrowing type expressions involving `std::initializer_list` without bypassing necessary `static_cast` operations.

Fixes #270 