### PR TITLE
Update README for supported Ubuntu version and add assertion for switch case handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ rm -rf examples/math-original
 
 ## Building Dredd from source
 
-The following instructions have been tested on Ubuntu 20.04.
+The following instructions have been tested on Ubuntu 22.04.
 
 ### Prerequisites
 

--- a/src/libdredd/src/mutate_visitor.cc
+++ b/src/libdredd/src/mutate_visitor.cc
@@ -570,7 +570,7 @@ bool MutateVisitor::TraverseCompoundStmt(clang::CompoundStmt* compound_stmt) {
         llvm::dyn_cast<clang::NullStmt>(target_stmt) != nullptr ||
         llvm::dyn_cast<clang::DeclStmt>(target_stmt) != nullptr ||
         llvm::dyn_cast<clang::LabelStmt>(target_stmt) != nullptr) {
-      // Wrapping switch cases, labels and null statements in conditional code
+      // Wrapping labels and null statements in conditional code
       // has no effect. Declarations cannot be wrapped in conditional code
       // without risking breaking compilation.
       continue;

--- a/src/libdredd/src/mutate_visitor.cc
+++ b/src/libdredd/src/mutate_visitor.cc
@@ -564,6 +564,9 @@ bool MutateVisitor::TraverseCompoundStmt(clang::CompoundStmt* compound_stmt) {
     // tree node is pushed per sub-statement.
     const PushMutationTreeRAII push_mutation_tree(*this);
     TraverseStmt(target_stmt);
+
+    assert(llvm::dyn_cast<clang::SwitchCase>(target_stmt) == nullptr &&
+           "target_stmt isn't a SwitchCase due to previous AST traversal.");
     if (GetSourceRangeInMainFile(compiler_instance_->getPreprocessor(),
                                  *target_stmt)
             .isInvalid() ||


### PR DESCRIPTION
Updated the README to specify the supported Ubuntu version for the following shell commands. Additionally, fixed existing comments related to skipping switch case statement mutation because of previous AST traversal until no switch case is encountered. An assertion has been added to validate this behavior.

Implement reviewer suggestion on #260
Fix #217 