### PR TITLE
Rewrite size expressions of constant-sized constexpr arrays

### DIFF
--- a/src/libdredd/include_private/include/libdredd/mutate_visitor.h
+++ b/src/libdredd/include_private/include/libdredd/mutate_visitor.h
@@ -103,7 +103,7 @@ class MutateVisitor : public clang::RecursiveASTVisitor<MutateVisitor> {
 
   // Yields the C++ constant-sized arrays, whose size expressions need to be
   // rewritten.
-  [[nodiscard]] const std::vector<clang::VarDecl*>&
+  [[nodiscard]] const std::vector<const clang::VarDecl*>&
   GetConstantSizedArraysToRewrite() const {
     return constant_sized_arrays_to_rewrite_;
   }
@@ -217,7 +217,7 @@ class MutateVisitor : public clang::RecursiveASTVisitor<MutateVisitor> {
 
   // This records C++ constant-sized array declarations, so that size
   // expressions can be rewritten with the integers to which they evaluate.
-  std::vector<clang::VarDecl*> constant_sized_arrays_to_rewrite_;
+  std::vector<const clang::VarDecl*> constant_sized_arrays_to_rewrite_;
 };
 
 }  // namespace dredd

--- a/src/libdredd/src/mutate_ast_consumer.cc
+++ b/src/libdredd/src/mutate_ast_consumer.cc
@@ -103,6 +103,7 @@ void MutateAstConsumer::HandleTranslationUnit(clang::ASTContext& ast_context) {
            constant_sized_array_decl->getType()->isConstantArrayType());
     auto constant_array_typeloc = constant_sized_array_decl->getTypeSourceInfo()
                                       ->getTypeLoc()
+                                      .getUnqualifiedLoc()
                                       .getAs<clang::ConstantArrayTypeLoc>();
     if (constant_array_typeloc.isNull()) {
       // In some cases a declaration with constant array type does not have

--- a/src/libdredd/src/mutate_visitor.cc
+++ b/src/libdredd/src/mutate_visitor.cc
@@ -125,6 +125,19 @@ bool MutateVisitor::TraverseDecl(clang::Decl* decl) {
     }
   }
   if (const auto* var_decl = llvm::dyn_cast<clang::VarDecl>(decl)) {
+    if (compiler_instance_->getLangOpts().CPlusPlus &&
+        var_decl->getType()->isConstantArrayType()) {
+      // We have a constant-sized C++ array. Some C++ compilers complain if
+      // components of the size expression are not compile-time constants. Other
+      // compilers are OK with this unless the array is also initialized. To
+      // allow the constant declarations that occur in a size expression to have
+      // their initial values mutated (because they may be used elsewhere), but
+      // to avoid compilation errors, we record the arrays in question so that
+      // later their size expressions can be replaced with the value to which
+      // the size expression would normally evaluate.
+      constant_sized_arrays_to_rewrite_.push_back(var_decl);
+    }
+
     if (var_decl->isConstexpr() || var_decl->hasAttr<clang::ConstInitAttr>()) {
       // Because Dredd's mutations occur dynamically, they cannot be applied to
       // C++ constexprs or variables that require constant initialization as
@@ -610,19 +623,6 @@ bool MutateVisitor::TraverseCompoundStmt(clang::CompoundStmt* compound_stmt) {
 
 bool MutateVisitor::VisitVarDecl(clang::VarDecl* var_decl) {
   var_decl_source_locations_.insert(var_decl->getLocation());
-
-  if (compiler_instance_->getLangOpts().CPlusPlus &&
-      var_decl->getType()->isConstantArrayType()) {
-    // We have a constant-sized C++ array. Some C++ compilers complain if
-    // components of the size expression are not compile-time constants. Other
-    // compilers are OK with this unless the array is also initialized. To allow
-    // the constant declarations that occur in a size expression to have their
-    // initial values mutated (because they may be used elsewhere), but to avoid
-    // compilation errors, we record the arrays in question so that later their
-    // size expressions can be replaced with the value to which the size
-    // expression would normally evaluate.
-    constant_sized_arrays_to_rewrite_.push_back(var_decl);
-  }
   return true;
 }
 

--- a/test/single_file/constexpr_array.cc
+++ b/test/single_file/constexpr_array.cc
@@ -1,0 +1,4 @@
+void foo() {
+  const int a = 4;
+  constexpr char b[a]{};
+}

--- a/test/single_file/constexpr_array.cc.expected
+++ b/test/single_file/constexpr_array.cc.expected
@@ -1,0 +1,58 @@
+#include <cinttypes>
+#include <cstddef>
+#include <functional>
+#include <string>
+
+
+#ifdef _MSC_VER
+#define thread_local __declspec(thread)
+#elif __APPLE__
+#define thread_local __thread
+#endif
+
+static thread_local bool __dredd_some_mutation_enabled = true;
+static bool __dredd_enabled_mutation(int local_mutation_id) {
+  static thread_local bool initialized = false;
+  static thread_local uint64_t enabled_bitset[1];
+  if (!initialized) {
+    bool some_mutation_enabled = false;
+    const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
+    if (dredd_environment_variable != nullptr) {
+      std::string contents(dredd_environment_variable);
+      while (true) {
+        size_t pos = contents.find(",");
+        std::string token = (pos == std::string::npos ? contents : contents.substr(0, pos));
+        if (!token.empty()) {
+          int value = std::stoi(token);
+          int local_value = value - 0;
+          if (local_value >= 0 && local_value < 5) {
+            enabled_bitset[local_value / 64] |= (static_cast<uint64_t>(1) << (local_value % 64));
+            some_mutation_enabled = true;
+          }
+        }
+        if (pos == std::string::npos) {
+          break;
+        }
+        contents.erase(0, pos + 1);
+      }
+    }
+    initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
+  }
+  return (enabled_bitset[local_mutation_id / 64] & (static_cast<uint64_t>(1) << (local_mutation_id % 64))) != 0;
+}
+
+static int __dredd_replace_expr_int_constant(int arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return -(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 0;
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return -1;
+  return arg;
+}
+
+void foo() {
+  const int a = __dredd_replace_expr_int_constant(4, 0);
+  constexpr char b[4]{};
+}

--- a/test/single_file/constexpr_array.cc.noopt.expected
+++ b/test/single_file/constexpr_array.cc.noopt.expected
@@ -1,0 +1,59 @@
+#include <cinttypes>
+#include <cstddef>
+#include <functional>
+#include <string>
+
+
+#ifdef _MSC_VER
+#define thread_local __declspec(thread)
+#elif __APPLE__
+#define thread_local __thread
+#endif
+
+static thread_local bool __dredd_some_mutation_enabled = true;
+static bool __dredd_enabled_mutation(int local_mutation_id) {
+  static thread_local bool initialized = false;
+  static thread_local uint64_t enabled_bitset[1];
+  if (!initialized) {
+    bool some_mutation_enabled = false;
+    const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
+    if (dredd_environment_variable != nullptr) {
+      std::string contents(dredd_environment_variable);
+      while (true) {
+        size_t pos = contents.find(",");
+        std::string token = (pos == std::string::npos ? contents : contents.substr(0, pos));
+        if (!token.empty()) {
+          int value = std::stoi(token);
+          int local_value = value - 0;
+          if (local_value >= 0 && local_value < 6) {
+            enabled_bitset[local_value / 64] |= (static_cast<uint64_t>(1) << (local_value % 64));
+            some_mutation_enabled = true;
+          }
+        }
+        if (pos == std::string::npos) {
+          break;
+        }
+        contents.erase(0, pos + 1);
+      }
+    }
+    initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
+  }
+  return (enabled_bitset[local_mutation_id / 64] & (static_cast<uint64_t>(1) << (local_mutation_id % 64))) != 0;
+}
+
+static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 0;
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
+  return arg;
+}
+
+void foo() {
+  const int a = __dredd_replace_expr_int(4, 0);
+  constexpr char b[4]{};
+}

--- a/test/single_file/static_constexpr_array.cc
+++ b/test/single_file/static_constexpr_array.cc
@@ -1,0 +1,4 @@
+void foo() {
+  const int a = 4;
+  static constexpr char b[a]{};
+}

--- a/test/single_file/static_constexpr_array.cc.expected
+++ b/test/single_file/static_constexpr_array.cc.expected
@@ -1,0 +1,58 @@
+#include <cinttypes>
+#include <cstddef>
+#include <functional>
+#include <string>
+
+
+#ifdef _MSC_VER
+#define thread_local __declspec(thread)
+#elif __APPLE__
+#define thread_local __thread
+#endif
+
+static thread_local bool __dredd_some_mutation_enabled = true;
+static bool __dredd_enabled_mutation(int local_mutation_id) {
+  static thread_local bool initialized = false;
+  static thread_local uint64_t enabled_bitset[1];
+  if (!initialized) {
+    bool some_mutation_enabled = false;
+    const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
+    if (dredd_environment_variable != nullptr) {
+      std::string contents(dredd_environment_variable);
+      while (true) {
+        size_t pos = contents.find(",");
+        std::string token = (pos == std::string::npos ? contents : contents.substr(0, pos));
+        if (!token.empty()) {
+          int value = std::stoi(token);
+          int local_value = value - 0;
+          if (local_value >= 0 && local_value < 5) {
+            enabled_bitset[local_value / 64] |= (static_cast<uint64_t>(1) << (local_value % 64));
+            some_mutation_enabled = true;
+          }
+        }
+        if (pos == std::string::npos) {
+          break;
+        }
+        contents.erase(0, pos + 1);
+      }
+    }
+    initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
+  }
+  return (enabled_bitset[local_mutation_id / 64] & (static_cast<uint64_t>(1) << (local_mutation_id % 64))) != 0;
+}
+
+static int __dredd_replace_expr_int_constant(int arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return -(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 0;
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return -1;
+  return arg;
+}
+
+void foo() {
+  const int a = __dredd_replace_expr_int_constant(4, 0);
+  static constexpr char b[4]{};
+}

--- a/test/single_file/static_constexpr_array.cc.noopt.expected
+++ b/test/single_file/static_constexpr_array.cc.noopt.expected
@@ -1,0 +1,59 @@
+#include <cinttypes>
+#include <cstddef>
+#include <functional>
+#include <string>
+
+
+#ifdef _MSC_VER
+#define thread_local __declspec(thread)
+#elif __APPLE__
+#define thread_local __thread
+#endif
+
+static thread_local bool __dredd_some_mutation_enabled = true;
+static bool __dredd_enabled_mutation(int local_mutation_id) {
+  static thread_local bool initialized = false;
+  static thread_local uint64_t enabled_bitset[1];
+  if (!initialized) {
+    bool some_mutation_enabled = false;
+    const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
+    if (dredd_environment_variable != nullptr) {
+      std::string contents(dredd_environment_variable);
+      while (true) {
+        size_t pos = contents.find(",");
+        std::string token = (pos == std::string::npos ? contents : contents.substr(0, pos));
+        if (!token.empty()) {
+          int value = std::stoi(token);
+          int local_value = value - 0;
+          if (local_value >= 0 && local_value < 6) {
+            enabled_bitset[local_value / 64] |= (static_cast<uint64_t>(1) << (local_value % 64));
+            some_mutation_enabled = true;
+          }
+        }
+        if (pos == std::string::npos) {
+          break;
+        }
+        contents.erase(0, pos + 1);
+      }
+    }
+    initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
+  }
+  return (enabled_bitset[local_mutation_id / 64] & (static_cast<uint64_t>(1) << (local_mutation_id % 64))) != 0;
+}
+
+static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 0;
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
+  return arg;
+}
+
+void foo() {
+  const int a = __dredd_replace_expr_int(4, 0);
+  static constexpr char b[4]{};
+}


### PR DESCRIPTION
Enhances the support for rewriting the size expressions of constant-sized arrays so that arrays with the constexpr qualifier are also handled.

Fixes #283.