### PR TITLE
Avoid mutation of expression under `Decltype`

### DIFF
--- a/src/libdredd/src/mutate_visitor.cc
+++ b/src/libdredd/src/mutate_visitor.cc
@@ -265,6 +265,14 @@ bool MutateVisitor::TraverseStmt(clang::Stmt* stmt) {
     }
   }
 
+  // Do not mutate expression under `decltype`, as Dredd doesn't change the type
+  // of underlying expression.
+  if (const auto* cast_expr = llvm::dyn_cast<clang::CastExpr>(stmt)) {
+    if (cast_expr->getType()->getAs<clang::DecltypeType>() != nullptr) {
+      return true;
+    }
+  }
+
   // Add a node to the mutation tree to capture any mutations beneath this
   // statement.
   const PushMutationTreeRAII push_mutation_tree(*this);

--- a/test/single_file/decltype_cast.cc
+++ b/test/single_file/decltype_cast.cc
@@ -1,0 +1,3 @@
+void foo() {
+  unsigned x = (decltype(1)) 'a';
+}

--- a/test/single_file/decltype_cast.cc.expected
+++ b/test/single_file/decltype_cast.cc.expected
@@ -1,0 +1,55 @@
+#include <cinttypes>
+#include <cstddef>
+#include <functional>
+#include <string>
+
+
+#ifdef _MSC_VER
+#define thread_local __declspec(thread)
+#elif __APPLE__
+#define thread_local __thread
+#endif
+
+static thread_local bool __dredd_some_mutation_enabled = true;
+static bool __dredd_enabled_mutation(int local_mutation_id) {
+  static thread_local bool initialized = false;
+  static thread_local uint64_t enabled_bitset[1];
+  if (!initialized) {
+    bool some_mutation_enabled = false;
+    const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
+    if (dredd_environment_variable != nullptr) {
+      std::string contents(dredd_environment_variable);
+      while (true) {
+        size_t pos = contents.find(",");
+        std::string token = (pos == std::string::npos ? contents : contents.substr(0, pos));
+        if (!token.empty()) {
+          int value = std::stoi(token);
+          int local_value = value - 0;
+          if (local_value >= 0 && local_value < 3) {
+            enabled_bitset[local_value / 64] |= (static_cast<uint64_t>(1) << (local_value % 64));
+            some_mutation_enabled = true;
+          }
+        }
+        if (pos == std::string::npos) {
+          break;
+        }
+        contents.erase(0, pos + 1);
+      }
+    }
+    initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
+  }
+  return (enabled_bitset[local_mutation_id / 64] & (static_cast<uint64_t>(1) << (local_mutation_id % 64))) != 0;
+}
+
+static unsigned int __dredd_replace_expr_unsigned_int_constant(unsigned int arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 0;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 1;
+  return arg;
+}
+
+void foo() {
+  unsigned x = __dredd_replace_expr_unsigned_int_constant((decltype(1)) 'a', 0);
+}

--- a/test/single_file/decltype_cast.cc.noopt.expected
+++ b/test/single_file/decltype_cast.cc.noopt.expected
@@ -1,0 +1,56 @@
+#include <cinttypes>
+#include <cstddef>
+#include <functional>
+#include <string>
+
+
+#ifdef _MSC_VER
+#define thread_local __declspec(thread)
+#elif __APPLE__
+#define thread_local __thread
+#endif
+
+static thread_local bool __dredd_some_mutation_enabled = true;
+static bool __dredd_enabled_mutation(int local_mutation_id) {
+  static thread_local bool initialized = false;
+  static thread_local uint64_t enabled_bitset[1];
+  if (!initialized) {
+    bool some_mutation_enabled = false;
+    const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
+    if (dredd_environment_variable != nullptr) {
+      std::string contents(dredd_environment_variable);
+      while (true) {
+        size_t pos = contents.find(",");
+        std::string token = (pos == std::string::npos ? contents : contents.substr(0, pos));
+        if (!token.empty()) {
+          int value = std::stoi(token);
+          int local_value = value - 0;
+          if (local_value >= 0 && local_value < 4) {
+            enabled_bitset[local_value / 64] |= (static_cast<uint64_t>(1) << (local_value % 64));
+            some_mutation_enabled = true;
+          }
+        }
+        if (pos == std::string::npos) {
+          break;
+        }
+        contents.erase(0, pos + 1);
+      }
+    }
+    initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
+  }
+  return (enabled_bitset[local_mutation_id / 64] & (static_cast<uint64_t>(1) << (local_mutation_id % 64))) != 0;
+}
+
+static unsigned int __dredd_replace_expr_unsigned_int(unsigned int arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 0;
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 1;
+  return arg;
+}
+
+void foo() {
+  unsigned x = __dredd_replace_expr_unsigned_int((decltype(1)) 'a', 0);
+}

--- a/test/single_file/decltype_cast_function_call.cc
+++ b/test/single_file/decltype_cast_function_call.cc
@@ -1,0 +1,5 @@
+long bar() {}
+
+void foo() {
+  unsigned x = (decltype(bar())) 'a';
+}

--- a/test/single_file/decltype_cast_function_call.cc
+++ b/test/single_file/decltype_cast_function_call.cc
@@ -1,4 +1,6 @@
-long bar() {}
+long bar() {
+  return 1LL;
+}
 
 void foo() {
   unsigned x = (decltype(bar())) 'a';

--- a/test/single_file/decltype_cast_function_call.cc.expected
+++ b/test/single_file/decltype_cast_function_call.cc.expected
@@ -1,0 +1,57 @@
+long bar() {}
+
+#include <cinttypes>
+#include <cstddef>
+#include <functional>
+#include <string>
+
+
+#ifdef _MSC_VER
+#define thread_local __declspec(thread)
+#elif __APPLE__
+#define thread_local __thread
+#endif
+
+static thread_local bool __dredd_some_mutation_enabled = true;
+static bool __dredd_enabled_mutation(int local_mutation_id) {
+  static thread_local bool initialized = false;
+  static thread_local uint64_t enabled_bitset[1];
+  if (!initialized) {
+    bool some_mutation_enabled = false;
+    const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
+    if (dredd_environment_variable != nullptr) {
+      std::string contents(dredd_environment_variable);
+      while (true) {
+        size_t pos = contents.find(",");
+        std::string token = (pos == std::string::npos ? contents : contents.substr(0, pos));
+        if (!token.empty()) {
+          int value = std::stoi(token);
+          int local_value = value - 0;
+          if (local_value >= 0 && local_value < 3) {
+            enabled_bitset[local_value / 64] |= (static_cast<uint64_t>(1) << (local_value % 64));
+            some_mutation_enabled = true;
+          }
+        }
+        if (pos == std::string::npos) {
+          break;
+        }
+        contents.erase(0, pos + 1);
+      }
+    }
+    initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
+  }
+  return (enabled_bitset[local_mutation_id / 64] & (static_cast<uint64_t>(1) << (local_mutation_id % 64))) != 0;
+}
+
+static unsigned int __dredd_replace_expr_unsigned_int_constant(unsigned int arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 0;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 1;
+  return arg;
+}
+
+void foo() {
+  unsigned x = __dredd_replace_expr_unsigned_int_constant((decltype(bar())) 'a', 0);
+}

--- a/test/single_file/decltype_cast_function_call.cc.expected
+++ b/test/single_file/decltype_cast_function_call.cc.expected
@@ -1,5 +1,3 @@
-long bar() {}
-
 #include <cinttypes>
 #include <cstddef>
 #include <functional>
@@ -27,7 +25,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
         if (!token.empty()) {
           int value = std::stoi(token);
           int local_value = value - 0;
-          if (local_value >= 0 && local_value < 3) {
+          if (local_value >= 0 && local_value < 7) {
             enabled_bitset[local_value / 64] |= (static_cast<uint64_t>(1) << (local_value % 64));
             some_mutation_enabled = true;
           }
@@ -52,6 +50,18 @@ static unsigned int __dredd_replace_expr_unsigned_int_constant(unsigned int arg,
   return arg;
 }
 
+static long __dredd_replace_expr_long_one(long arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 0;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
+  return arg;
+}
+
+long bar() {
+  if (!__dredd_enabled_mutation(3)) { return __dredd_replace_expr_long_one(1LL, 0); }
+}
+
 void foo() {
-  unsigned x = __dredd_replace_expr_unsigned_int_constant((decltype(bar())) 'a', 0);
+  unsigned x = __dredd_replace_expr_unsigned_int_constant((decltype(bar())) 'a', 4);
 }

--- a/test/single_file/decltype_cast_function_call.cc.noopt.expected
+++ b/test/single_file/decltype_cast_function_call.cc.noopt.expected
@@ -1,0 +1,58 @@
+long bar() {}
+
+#include <cinttypes>
+#include <cstddef>
+#include <functional>
+#include <string>
+
+
+#ifdef _MSC_VER
+#define thread_local __declspec(thread)
+#elif __APPLE__
+#define thread_local __thread
+#endif
+
+static thread_local bool __dredd_some_mutation_enabled = true;
+static bool __dredd_enabled_mutation(int local_mutation_id) {
+  static thread_local bool initialized = false;
+  static thread_local uint64_t enabled_bitset[1];
+  if (!initialized) {
+    bool some_mutation_enabled = false;
+    const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
+    if (dredd_environment_variable != nullptr) {
+      std::string contents(dredd_environment_variable);
+      while (true) {
+        size_t pos = contents.find(",");
+        std::string token = (pos == std::string::npos ? contents : contents.substr(0, pos));
+        if (!token.empty()) {
+          int value = std::stoi(token);
+          int local_value = value - 0;
+          if (local_value >= 0 && local_value < 4) {
+            enabled_bitset[local_value / 64] |= (static_cast<uint64_t>(1) << (local_value % 64));
+            some_mutation_enabled = true;
+          }
+        }
+        if (pos == std::string::npos) {
+          break;
+        }
+        contents.erase(0, pos + 1);
+      }
+    }
+    initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
+  }
+  return (enabled_bitset[local_mutation_id / 64] & (static_cast<uint64_t>(1) << (local_mutation_id % 64))) != 0;
+}
+
+static unsigned int __dredd_replace_expr_unsigned_int(unsigned int arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 0;
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 1;
+  return arg;
+}
+
+void foo() {
+  unsigned x = __dredd_replace_expr_unsigned_int((decltype(bar())) 'a', 0);
+}

--- a/test/single_file/decltype_cast_function_call.cc.noopt.expected
+++ b/test/single_file/decltype_cast_function_call.cc.noopt.expected
@@ -1,5 +1,3 @@
-long bar() {}
-
 #include <cinttypes>
 #include <cstddef>
 #include <functional>
@@ -27,7 +25,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
         if (!token.empty()) {
           int value = std::stoi(token);
           int local_value = value - 0;
-          if (local_value >= 0 && local_value < 4) {
+          if (local_value >= 0 && local_value < 17) {
             enabled_bitset[local_value / 64] |= (static_cast<uint64_t>(1) << (local_value % 64));
             some_mutation_enabled = true;
           }
@@ -53,6 +51,32 @@ static unsigned int __dredd_replace_expr_unsigned_int(unsigned int arg, int loca
   return arg;
 }
 
+static long long __dredd_replace_expr_long_long(long long arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 0;
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
+  return arg;
+}
+
+static long __dredd_replace_expr_long(long arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 0;
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
+  return arg;
+}
+
+long bar() {
+  if (!__dredd_enabled_mutation(12)) { return __dredd_replace_expr_long(__dredd_replace_expr_long_long(1LL, 0), 6); }
+}
+
 void foo() {
-  unsigned x = __dredd_replace_expr_unsigned_int((decltype(bar())) 'a', 0);
+  unsigned x = __dredd_replace_expr_unsigned_int((decltype(bar())) 'a', 13);
 }


### PR DESCRIPTION
Since Dredd's mutator functions don't change the type of expression,
mutating an expression under `Decltype` won't affect the outcome of
casting (i.e., they introduce equivalent mutation). Furthermore,
mutation of an expression under `Decltype` could introduce lambda
expression in the unevaluated operand.

Fixes #304 