### PR TITLE
Avoid static cast bypass for parenthesis expression in initializer list

### DIFF
--- a/src/libdredd/src/mutation_replace_expr.cc
+++ b/src/libdredd/src/mutation_replace_expr.cc
@@ -584,7 +584,7 @@ void MutationReplaceExpr::ReplaceExprWithFunctionCall(
   // cast.
   // For the following check to work, we need to move up any enclosing
   // parentheses.
-  auto* deparenthesis_expr = expr_;
+  const auto* deparenthesis_expr = expr_;
   while (const auto* paren_expr = GetFirstParentOfType<clang::ParenExpr>(
              *deparenthesis_expr, ast_context)) {
     deparenthesis_expr = paren_expr;

--- a/src/libdredd/src/mutation_replace_expr.cc
+++ b/src/libdredd/src/mutation_replace_expr.cc
@@ -582,7 +582,14 @@ void MutationReplaceExpr::ReplaceExprWithFunctionCall(
   // cast. There are cases where such implicit casts are allowed for constants
   // but not for non-constants. This is catered for by inserting an explicit
   // cast.
-  auto parents = ast_context.getParents<clang::Expr>(*expr_);
+  // For the following check to work, we need to move up any enclsoing
+  // parenthesis expressions.
+  auto* deparenthesis_expr = expr_;
+  while (const auto* paren_expr = GetFirstParentOfType<clang::ParenExpr>(
+             *deparenthesis_expr, ast_context)) {
+    deparenthesis_expr = paren_expr;
+  }
+  auto parents = ast_context.getParents<clang::Expr>(*deparenthesis_expr);
   // The expression that occurs in an initializer list and is then subject to an
   // explicit cast will have at least two parents: the initializer list and the
   // implicit cast. (This is probably due to implicit casts being treated as

--- a/src/libdredd/src/mutation_replace_expr.cc
+++ b/src/libdredd/src/mutation_replace_expr.cc
@@ -582,8 +582,8 @@ void MutationReplaceExpr::ReplaceExprWithFunctionCall(
   // cast. There are cases where such implicit casts are allowed for constants
   // but not for non-constants. This is catered for by inserting an explicit
   // cast.
-  // For the following check to work, we need to move up any enclsoing
-  // parenthesis expressions.
+  // For the following check to work, we need to move up any enclosing
+  // parentheses.
   auto* deparenthesis_expr = expr_;
   while (const auto* paren_expr = GetFirstParentOfType<clang::ParenExpr>(
              *deparenthesis_expr, ast_context)) {

--- a/test/single_file/initializer_list_parenthesis.cc
+++ b/test/single_file/initializer_list_parenthesis.cc
@@ -1,0 +1,9 @@
+struct foo {
+  short x;
+  short y;
+  short z;
+};
+
+void baz() {
+  foo bar = {1, (2), (((3)))};
+}

--- a/test/single_file/initializer_list_parenthesis.cc.expected
+++ b/test/single_file/initializer_list_parenthesis.cc.expected
@@ -1,0 +1,71 @@
+struct foo {
+  short x;
+  short y;
+  short z;
+};
+
+#include <cinttypes>
+#include <cstddef>
+#include <functional>
+#include <string>
+
+
+#ifdef _MSC_VER
+#define thread_local __declspec(thread)
+#elif __APPLE__
+#define thread_local __thread
+#endif
+
+static thread_local bool __dredd_some_mutation_enabled = true;
+static bool __dredd_enabled_mutation(int local_mutation_id) {
+  static thread_local bool initialized = false;
+  static thread_local uint64_t enabled_bitset[1];
+  if (!initialized) {
+    bool some_mutation_enabled = false;
+    const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
+    if (dredd_environment_variable != nullptr) {
+      std::string contents(dredd_environment_variable);
+      while (true) {
+        size_t pos = contents.find(",");
+        std::string token = (pos == std::string::npos ? contents : contents.substr(0, pos));
+        if (!token.empty()) {
+          int value = std::stoi(token);
+          int local_value = value - 0;
+          if (local_value >= 0 && local_value < 13) {
+            enabled_bitset[local_value / 64] |= (static_cast<uint64_t>(1) << (local_value % 64));
+            some_mutation_enabled = true;
+          }
+        }
+        if (pos == std::string::npos) {
+          break;
+        }
+        contents.erase(0, pos + 1);
+      }
+    }
+    initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
+  }
+  return (enabled_bitset[local_mutation_id / 64] & (static_cast<uint64_t>(1) << (local_mutation_id % 64))) != 0;
+}
+
+static int __dredd_replace_expr_int_one(int arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 0;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
+  return arg;
+}
+
+static int __dredd_replace_expr_int_constant(int arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return -(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 0;
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return -1;
+  return arg;
+}
+
+void baz() {
+  foo bar = {static_cast<short>(__dredd_replace_expr_int_one(1, 0)), (static_cast<short>(__dredd_replace_expr_int_constant(2, 3))), (((static_cast<short>(__dredd_replace_expr_int_constant(3, 8)))))};
+}

--- a/test/single_file/initializer_list_parenthesis.cc.noopt.expected
+++ b/test/single_file/initializer_list_parenthesis.cc.noopt.expected
@@ -1,0 +1,64 @@
+struct foo {
+  short x;
+  short y;
+  short z;
+};
+
+#include <cinttypes>
+#include <cstddef>
+#include <functional>
+#include <string>
+
+
+#ifdef _MSC_VER
+#define thread_local __declspec(thread)
+#elif __APPLE__
+#define thread_local __thread
+#endif
+
+static thread_local bool __dredd_some_mutation_enabled = true;
+static bool __dredd_enabled_mutation(int local_mutation_id) {
+  static thread_local bool initialized = false;
+  static thread_local uint64_t enabled_bitset[1];
+  if (!initialized) {
+    bool some_mutation_enabled = false;
+    const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
+    if (dredd_environment_variable != nullptr) {
+      std::string contents(dredd_environment_variable);
+      while (true) {
+        size_t pos = contents.find(",");
+        std::string token = (pos == std::string::npos ? contents : contents.substr(0, pos));
+        if (!token.empty()) {
+          int value = std::stoi(token);
+          int local_value = value - 0;
+          if (local_value >= 0 && local_value < 42) {
+            enabled_bitset[local_value / 64] |= (static_cast<uint64_t>(1) << (local_value % 64));
+            some_mutation_enabled = true;
+          }
+        }
+        if (pos == std::string::npos) {
+          break;
+        }
+        contents.erase(0, pos + 1);
+      }
+    }
+    initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
+  }
+  return (enabled_bitset[local_mutation_id / 64] & (static_cast<uint64_t>(1) << (local_mutation_id % 64))) != 0;
+}
+
+static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 0;
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
+  return arg;
+}
+
+void baz() {
+  foo bar = {static_cast<short>(__dredd_replace_expr_int(1, 0)), static_cast<short>(__dredd_replace_expr_int((static_cast<short>(__dredd_replace_expr_int(2, 6))), 12)), static_cast<short>(__dredd_replace_expr_int((static_cast<short>(__dredd_replace_expr_int((static_cast<short>(__dredd_replace_expr_int((static_cast<short>(__dredd_replace_expr_int(3, 18))), 24))), 30))), 36))};
+}


### PR DESCRIPTION
Fix a problem where expressions in parentheses within an initializer
list bypass being explicitly cast with `static_cast`, causing issues
when the expression is implicitly cast to a narrower type.


Fixes #301 