### PR TITLE
Non-redundant ROR mutation for unsigned type

### DIFF
--- a/.github/workflows/cxx_apps.sh
+++ b/.github/workflows/cxx_apps.sh
@@ -157,7 +157,7 @@ pushd SPIRV-Tools
   ./build/test/val/test_val_fghijklmnop
   ./build/test/val/test_val_rstuvw
   NUM_MUTANTS=`python3 ${DREDD_ROOT}/scripts/query_mutant_info.py mutation-info.json --largest-mutant-id`
-  EXPECTED_NUM_MUTANTS=68841
+  EXPECTED_NUM_MUTANTS=68629
   if [ ${NUM_MUTANTS} -ne ${EXPECTED_NUM_MUTANTS} ]
   then
      echo "Found ${NUM_MUTANTS} mutants when mutating the SPIR-V validator source code. Expected ${EXPECTED_NUM_MUTANTS}. If Dredd changed recently, the expected value may just need to be updated, if it still looks sensible. Otherwise, there is likely a problem."
@@ -183,7 +183,7 @@ pushd llvm-project
   ${DREDD_EXECUTABLE} --mutation-info-file mutation-info.json -p "${DREDD_ROOT}/llvm-project/build" "${FILES[@]}"
   cmake --build build --target LLVMInstCombine
   NUM_MUTANTS=`python3 ${DREDD_ROOT}/scripts/query_mutant_info.py mutation-info.json --largest-mutant-id`
-  EXPECTED_NUM_MUTANTS=98042
+  EXPECTED_NUM_MUTANTS=97924
   if [ ${NUM_MUTANTS} -ne ${EXPECTED_NUM_MUTANTS} ]
   then
      echo "Found ${NUM_MUTANTS} mutants when mutating the LLVM source code. Expected ${EXPECTED_NUM_MUTANTS}. If Dredd changed recently, the expected value may just need to be updated, if it still looks sensible. Otherwise, there is likely a problem."

--- a/src/libdredd/include/libdredd/mutation_replace_binary_operator.h
+++ b/src/libdredd/include/libdredd/mutation_replace_binary_operator.h
@@ -63,18 +63,23 @@ class MutationReplaceBinaryOperator : public Mutation {
                               clang::ASTContext& ast_context) const;
 
   [[nodiscard]] bool IsRedundantReplacementOperator(
-      clang::BinaryOperatorKind operator_kind,
+      clang::BinaryOperatorKind replacement_operator,
       const clang::ASTContext& ast_context) const;
 
   [[nodiscard]] bool IsRedundantReplacementForBooleanValuedOperator(
-      clang::BinaryOperatorKind operator_kind) const;
+      clang::BinaryOperatorKind replacement_operator,
+      const clang::ASTContext& ast_context) const;
+
+  [[nodiscard]] bool IsRedundantReplacementForUnsignedComparison(
+      clang::BinaryOperatorKind replacement_operator,
+      const clang::ASTContext& ast_context) const;
 
   [[nodiscard]] bool IsRedundantReplacementForArithmeticOperator(
-      clang::BinaryOperatorKind operator_kind,
+      clang::BinaryOperatorKind replacement_operator,
       const clang::ASTContext& ast_context) const;
 
   [[nodiscard]] bool IsValidReplacementOperator(
-      clang::BinaryOperatorKind operator_kind) const;
+      clang::BinaryOperatorKind replacement_operator) const;
 
   // Replaces binary expressions with either the left or right operand.
   void GenerateArgumentReplacement(

--- a/src/libdredd/include/libdredd/mutation_replace_unary_operator.h
+++ b/src/libdredd/include/libdredd/mutation_replace_unary_operator.h
@@ -54,10 +54,10 @@ class MutationReplaceUnaryOperator : public Mutation {
   [[nodiscard]] static bool IsPrefix(clang::UnaryOperatorKind operator_kind);
 
   [[nodiscard]] bool IsValidReplacementOperator(
-      clang::UnaryOperatorKind operator_kind) const;
+      clang::UnaryOperatorKind replacement_operator) const;
 
   [[nodiscard]] bool IsRedundantReplacementOperator(
-      clang::UnaryOperatorKind operator_kind,
+      clang::UnaryOperatorKind replacement_operator,
       const clang::ASTContext& ast_context) const;
 
   [[nodiscard]] bool IsOperatorSelfInverse() const;

--- a/src/libdredd/src/mutation_replace_binary_operator.cc
+++ b/src/libdredd/src/mutation_replace_binary_operator.cc
@@ -1077,54 +1077,19 @@ bool MutationReplaceBinaryOperator::IsRedundantReplacementForUnsignedComparison(
   if (MutationReplaceExpr::ExprIsEquivalentToInt(*binary_operator_->getLHS(), 0,
                                                  ast_context)) {
     // LHS is 0
-    if (replacement_operator == clang::BO_GT ||
-        replacement_operator == clang::BO_LE) {
-      // We are considering mutating an expression of the form "0 op a" to
-      // one of:
-      //
-      // - "0 > a"
-      // - "0 <= a"
-      //
-      // These are subsumed by replacing the overall expression with "false"
-      // and "true", respectively.
-      return true;
+    if (binary_operator_->getOpcode() == clang::BO_GT || binary_operator_->getOpcode() == clang::BO_LE) {
+      return replacement_operator != clang::BO_NE && replacement_operator != clang::BO_EQ;
     }
-    if (std::set({binary_operator_->getOpcode(), replacement_operator}) ==
-        std::set<clang::BinaryOperatorKind>({clang::BO_EQ, clang::BO_GE})) {
-      // "0 == a" is equivalent to "0 >= a"
-      return true;
-    }
-    if (std::set({binary_operator_->getOpcode(), replacement_operator}) ==
-        std::set<clang::BinaryOperatorKind>({clang::BO_NE, clang::BO_LT})) {
-      // "0 != a" equivalent to "0 < a"
-      return true;
-    }
+    return true;
+    
   }
   if (MutationReplaceExpr::ExprIsEquivalentToInt(*binary_operator_->getRHS(), 0,
                                                  ast_context)) {
     // RHS is 0
-    if (replacement_operator == clang::BO_LT ||
-        replacement_operator == clang::BO_GE) {
-      // We are considering mutating an expression of the form "a op 0" to
-      // one of:
-      //
-      // - "a < 0"
-      // - "a >= 0"
-      //
-      // These are subsumed by replacing the overall expression with "false"
-      // and "true", respectively.
-      return true;
+    if (binary_operator_->getOpcode() == clang::BO_LT || binary_operator_->getOpcode() == clang::BO_GE) {
+      return replacement_operator != clang::BO_NE && replacement_operator != clang::BO_EQ;
     }
-    if (binary_operator_->getOpcode() == clang::BO_EQ &&
-        replacement_operator == clang::BO_LE) {
-      // "a == 0" is equivalent to "a <= 0"
-      return true;
-    }
-    if (binary_operator_->getOpcode() == clang::BO_NE &&
-        replacement_operator == clang::BO_GT) {
-      // "a != 0" equivalent to "a > 0"
-      return true;
-    }
+    return true;
   }
   return false;
 }

--- a/src/libdredd/src/mutation_replace_binary_operator.cc
+++ b/src/libdredd/src/mutation_replace_binary_operator.cc
@@ -16,7 +16,9 @@
 
 #include <algorithm>
 #include <cassert>
+#include <functional>
 #include <initializer_list>
+#include <set>
 #include <sstream>
 #include <string>
 #include <unordered_set>
@@ -51,12 +53,14 @@ MutationReplaceBinaryOperator::MutationReplaceBinaryOperator(
           ast_context) {}
 
 bool MutationReplaceBinaryOperator::IsRedundantReplacementOperator(
-    clang::BinaryOperatorKind operator_kind,
+    clang::BinaryOperatorKind replacement_operator,
     const clang::ASTContext& ast_context) const {
-  if (IsRedundantReplacementForBooleanValuedOperator(operator_kind)) {
+  if (IsRedundantReplacementForBooleanValuedOperator(replacement_operator,
+                                                     ast_context)) {
     return true;
   }
-  if (IsRedundantReplacementForArithmeticOperator(operator_kind, ast_context)) {
+  if (IsRedundantReplacementForArithmeticOperator(replacement_operator,
+                                                  ast_context)) {
     return true;
   }
   return false;
@@ -65,7 +69,7 @@ bool MutationReplaceBinaryOperator::IsRedundantReplacementOperator(
 // Certain operators such as % are not compatible with floating point numbers,
 // this function checks which operators can be applied for each type.
 bool MutationReplaceBinaryOperator::IsValidReplacementOperator(
-    clang::BinaryOperatorKind operator_kind) const {
+    clang::BinaryOperatorKind replacement_operator) const {
   const auto* lhs_type =
       binary_operator_->getLHS()->getType()->getAs<clang::BuiltinType>();
   assert((lhs_type->isFloatingPoint() || lhs_type->isInteger()) &&
@@ -75,13 +79,13 @@ bool MutationReplaceBinaryOperator::IsValidReplacementOperator(
   assert((rhs_type->isFloatingPoint() || rhs_type->isInteger()) &&
          "Expected rhs to be either integer or floating-point.");
   return !((lhs_type->isFloatingPoint() || rhs_type->isFloatingPoint()) &&
-           (operator_kind == clang::BO_Rem ||
-            operator_kind == clang::BO_AndAssign ||
-            operator_kind == clang::BO_OrAssign ||
-            operator_kind == clang::BO_RemAssign ||
-            operator_kind == clang::BO_ShlAssign ||
-            operator_kind == clang::BO_ShrAssign ||
-            operator_kind == clang::BO_XorAssign));
+           (replacement_operator == clang::BO_Rem ||
+            replacement_operator == clang::BO_AndAssign ||
+            replacement_operator == clang::BO_OrAssign ||
+            replacement_operator == clang::BO_RemAssign ||
+            replacement_operator == clang::BO_ShlAssign ||
+            replacement_operator == clang::BO_ShrAssign ||
+            replacement_operator == clang::BO_XorAssign));
 }
 
 std::string MutationReplaceBinaryOperator::GetFunctionName(
@@ -346,16 +350,17 @@ void MutationReplaceBinaryOperator::GenerateBinaryOperatorReplacement(
     bool only_track_mutant_coverage, int mutation_id_base,
     std::stringstream& new_function, int& mutation_id_offset,
     protobufs::MutationReplaceBinaryOperator& protobuf_message) const {
-  for (auto operator_kind :
+  for (auto replacement_operator :
        GetReplacementOperators(optimise_mutations, ast_context)) {
     if (!only_track_mutant_coverage) {
-      new_function << "  if (__dredd_enabled_mutation(local_mutation_id + "
-                   << mutation_id_offset << ")) return " << arg1_evaluated
-                   << " "
-                   << clang::BinaryOperator::getOpcodeStr(operator_kind).str()
-                   << " " << arg2_evaluated << ";\n";
+      new_function
+          << "  if (__dredd_enabled_mutation(local_mutation_id + "
+          << mutation_id_offset << ")) return " << arg1_evaluated << " "
+          << clang::BinaryOperator::getOpcodeStr(replacement_operator).str()
+          << " " << arg2_evaluated << ";\n";
     }
-    AddMutationInstance(mutation_id_base, OperatorKindToAction(operator_kind),
+    AddMutationInstance(mutation_id_base,
+                        OperatorKindToAction(replacement_operator),
                         mutation_id_offset, protobuf_message);
   }
 }
@@ -1024,34 +1029,108 @@ MutationReplaceBinaryOperator::ClangOperatorKindToProtobufOperatorKind(
 
 bool MutationReplaceBinaryOperator::
     IsRedundantReplacementForBooleanValuedOperator(
-        clang::BinaryOperatorKind operator_kind) const {
+        clang::BinaryOperatorKind replacement_operator,
+        const clang::ASTContext& ast_context) const {
+  if (IsRedundantReplacementForUnsignedComparison(replacement_operator,
+                                                  ast_context)) {
+    return true;
+  }
+
   switch (binary_operator_->getOpcode()) {
     // From
     // https://people.cs.umass.edu/~rjust/publ/non_redundant_mutants_jstvr_2014.pdf:
     // For boolean operators, only a subset of replacements are non-redundant.
     case clang::BO_LAnd:
-      return operator_kind != clang::BO_EQ;
+      return replacement_operator != clang::BO_EQ;
     case clang::BO_LOr:
-      return operator_kind != clang::BO_NE;
+      return replacement_operator != clang::BO_NE;
     case clang::BO_GT:
-      return operator_kind != clang::BO_GE && operator_kind != clang::BO_NE;
+      return replacement_operator != clang::BO_GE &&
+             replacement_operator != clang::BO_NE;
     case clang::BO_GE:
-      return operator_kind != clang::BO_GT && operator_kind != clang::BO_EQ;
+      return replacement_operator != clang::BO_GT &&
+             replacement_operator != clang::BO_EQ;
     case clang::BO_LT:
-      return operator_kind != clang::BO_LE && operator_kind != clang::BO_NE;
+      return replacement_operator != clang::BO_LE &&
+             replacement_operator != clang::BO_NE;
     case clang::BO_LE:
-      return operator_kind != clang::BO_LT && operator_kind != clang::BO_EQ;
+      return replacement_operator != clang::BO_LT &&
+             replacement_operator != clang::BO_EQ;
     case clang::BO_EQ:
-      return operator_kind != clang::BO_LE && operator_kind != clang::BO_GE;
+      return replacement_operator != clang::BO_LE &&
+             replacement_operator != clang::BO_GE;
     case clang::BO_NE:
-      return operator_kind != clang::BO_LT && operator_kind != clang::BO_GT;
+      return replacement_operator != clang::BO_LT &&
+             replacement_operator != clang::BO_GT;
     default:
       return false;
   }
 }
 
+bool MutationReplaceBinaryOperator::IsRedundantReplacementForUnsignedComparison(
+    clang::BinaryOperatorKind replacement_operator,
+    const clang::ASTContext& ast_context) const {
+  if (!binary_operator_->getLHS()->getType()->isUnsignedIntegerType() ||
+      !binary_operator_->getRHS()->getType()->isUnsignedIntegerType()) {
+    return false;
+  }
+  if (MutationReplaceExpr::ExprIsEquivalentToInt(*binary_operator_->getLHS(), 0,
+                                                 ast_context)) {
+    // LHS is 0
+    if (replacement_operator == clang::BO_GT ||
+        replacement_operator == clang::BO_LE) {
+      // We are considering mutating an expression of the form "0 op a" to
+      // one of:
+      //
+      // - "0 > a"
+      // - "0 <= a"
+      //
+      // These are subsumed by replacing the overall expression with "false"
+      // and "true", respectively.
+      return true;
+    }
+    if (std::set({binary_operator_->getOpcode(), replacement_operator}) ==
+        std::set<clang::BinaryOperatorKind>({clang::BO_EQ, clang::BO_GE})) {
+      // "0 == a" is equivalent to "0 >= a"
+      return true;
+    }
+    if (std::set({binary_operator_->getOpcode(), replacement_operator}) ==
+        std::set<clang::BinaryOperatorKind>({clang::BO_NE, clang::BO_LT})) {
+      // "0 != a" equivalent to "0 < a"
+      return true;
+    }
+  }
+  if (MutationReplaceExpr::ExprIsEquivalentToInt(*binary_operator_->getRHS(), 0,
+                                                 ast_context)) {
+    // RHS is 0
+    if (replacement_operator == clang::BO_LT ||
+        replacement_operator == clang::BO_GE) {
+      // We are considering mutating an expression of the form "a op 0" to
+      // one of:
+      //
+      // - "a < 0"
+      // - "a >= 0"
+      //
+      // These are subsumed by replacing the overall expression with "false"
+      // and "true", respectively.
+      return true;
+    }
+    if (binary_operator_->getOpcode() == clang::BO_EQ &&
+        replacement_operator == clang::BO_LE) {
+      // "a == 0" is equivalent to "a <= 0"
+      return true;
+    }
+    if (binary_operator_->getOpcode() == clang::BO_NE &&
+        replacement_operator == clang::BO_GT) {
+      // "a != 0" equivalent to "a > 0"
+      return true;
+    }
+  }
+  return false;
+}
+
 bool MutationReplaceBinaryOperator::IsRedundantReplacementForArithmeticOperator(
-    clang::BinaryOperatorKind operator_kind,
+    clang::BinaryOperatorKind replacement_operator,
     const clang::ASTContext& ast_context) const {
   // In the case where both operands are 0, the only case that isn't covered
   // by constant replacement is undefined behaviour, this is achieved by /.
@@ -1063,7 +1142,7 @@ bool MutationReplaceBinaryOperator::IsRedundantReplacementForArithmeticOperator(
                                                   0, ast_context) ||
        MutationReplaceExpr::ExprIsEquivalentToFloat(*binary_operator_->getRHS(),
                                                     0.0, ast_context))) {
-    if (operator_kind == clang::BO_Div) {
+    if (replacement_operator == clang::BO_Div) {
       return false;
     }
   }
@@ -1078,9 +1157,12 @@ bool MutationReplaceBinaryOperator::IsRedundantReplacementForArithmeticOperator(
     // replacement with the right operand; * is equivalent to replacement with
     // the constant 0 and % is equivalent to replacement with / in that both
     // cases lead to undefined behaviour.
-    if (operator_kind == clang::BO_Add || operator_kind == clang::BO_Sub ||
-        operator_kind == clang::BO_Shl || operator_kind == clang::BO_Shr ||
-        operator_kind == clang::BO_Mul || operator_kind == clang::BO_Rem) {
+    if (replacement_operator == clang::BO_Add ||
+        replacement_operator == clang::BO_Sub ||
+        replacement_operator == clang::BO_Shl ||
+        replacement_operator == clang::BO_Shr ||
+        replacement_operator == clang::BO_Mul ||
+        replacement_operator == clang::BO_Rem) {
       return true;
     }
   }
@@ -1091,7 +1173,8 @@ bool MutationReplaceBinaryOperator::IsRedundantReplacementForArithmeticOperator(
                                                     1.0, ast_context))) {
     // When the right operand is 1: * and / are equivalent to replacement by
     // the left operand.
-    if (operator_kind == clang::BO_Mul || operator_kind == clang::BO_Div) {
+    if (replacement_operator == clang::BO_Mul ||
+        replacement_operator == clang::BO_Div) {
       return true;
     }
   }
@@ -1103,9 +1186,12 @@ bool MutationReplaceBinaryOperator::IsRedundantReplacementForArithmeticOperator(
     // When the left operand is 0: *, /, %, << and >> are equivalent to
     // replacement by the constant 0 and + is equivalent to replacement by the
     // right operand.
-    if (operator_kind == clang::BO_Add || operator_kind == clang::BO_Shl ||
-        operator_kind == clang::BO_Shr || operator_kind == clang::BO_Mul ||
-        operator_kind == clang::BO_Rem || operator_kind == clang::BO_Div) {
+    if (replacement_operator == clang::BO_Add ||
+        replacement_operator == clang::BO_Shl ||
+        replacement_operator == clang::BO_Shr ||
+        replacement_operator == clang::BO_Mul ||
+        replacement_operator == clang::BO_Rem ||
+        replacement_operator == clang::BO_Div) {
       return true;
     }
   }
@@ -1114,7 +1200,7 @@ bool MutationReplaceBinaryOperator::IsRedundantReplacementForArithmeticOperator(
                                                   1, ast_context) ||
        MutationReplaceExpr::ExprIsEquivalentToFloat(*binary_operator_->getLHS(),
                                                     1.0, ast_context)) &&
-      operator_kind == clang::BO_Mul) {
+      replacement_operator == clang::BO_Mul) {
     // When the left operand is 1: * is equivalent to replacement by the right
     // operand.
     return true;

--- a/test/single_file/unsigned_comparisons_with_zero.c
+++ b/test/single_file/unsigned_comparisons_with_zero.c
@@ -1,0 +1,101 @@
+#include <stdbool.h>
+
+// Check that optimisations are applied when an unsigned zero literal is used.
+
+bool x_eq_zero(unsigned x) {
+  return x == 0u;
+}
+
+bool x_ne_zero(unsigned x) {
+  return x != 0u;
+}
+
+bool x_gt_zero(unsigned x) {
+  return x > 0u;
+}
+
+bool x_ge_zero(unsigned x) {
+  return x >= 0u;
+}
+
+bool x_lt_zero(unsigned x) {
+  return x < 0u;
+}
+
+bool x_le_zero(unsigned x) {
+  return x <= 0u;
+}
+
+bool zero_eq_x(unsigned x) {
+  return 0u == x;
+}
+
+bool zero_ne_x(unsigned x) {
+  return 0u != x;
+}
+
+bool zero_gt_x(unsigned x) {
+  return 0u > x;
+}
+
+bool zero_ge_x(unsigned x) {
+  return 0u >= x;
+}
+
+bool zero_lt_x(unsigned x) {
+  return 0u < x;
+}
+
+bool zero_le_x(unsigned x) {
+  return 0u <= x;
+}
+
+// Check that optimisations are applied when a signed zero literal is used.
+
+bool x_eq_signed_zero(unsigned x) {
+  return x == 0;
+}
+
+bool x_ne_signed_zero(unsigned x) {
+  return x != 0;
+}
+
+bool x_gt_signed_zero(unsigned x) {
+  return x > 0;
+}
+
+bool x_ge_signed_zero(unsigned x) {
+  return x >= 0;
+}
+
+bool x_lt_signed_zero(unsigned x) {
+  return x < 0;
+}
+
+bool x_le_signed_zero(unsigned x) {
+  return x <= 0;
+}
+
+bool signed_zero_eq_x(unsigned x) {
+  return 0 == x;
+}
+
+bool signed_zero_ne_x(unsigned x) {
+  return 0 != x;
+}
+
+bool signed_zero_gt_x(unsigned x) {
+  return 0 > x;
+}
+
+bool signed_zero_ge_x(unsigned x) {
+  return 0 >= x;
+}
+
+bool signed_zero_lt_x(unsigned x) {
+  return 0 < x;
+}
+
+bool signed_zero_le_x(unsigned x) {
+  return 0 <= x;
+}

--- a/test/single_file/unsigned_comparisons_with_zero.c.expected
+++ b/test/single_file/unsigned_comparisons_with_zero.c.expected
@@ -1,0 +1,244 @@
+#include <stdbool.h>
+
+// Check that optimisations are applied when an unsigned zero literal is used.
+
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _MSC_VER
+#define thread_local __declspec(thread)
+#elif __APPLE__
+#define thread_local __thread
+#else
+#include <threads.h>
+#endif
+
+static thread_local int __dredd_some_mutation_enabled = 1;
+static bool __dredd_enabled_mutation(int local_mutation_id) {
+  static thread_local int initialized = 0;
+  static thread_local uint64_t enabled_bitset[5];
+  if (!initialized) {
+    int some_mutation_enabled = 0;
+    const char* dredd_environment_variable = getenv("DREDD_ENABLED_MUTATION");
+    if (dredd_environment_variable) {
+      char* temp = malloc(strlen(dredd_environment_variable) + 1);
+      strcpy(temp, dredd_environment_variable);
+      char* token;
+      token = strtok(temp, ",");
+      while(token) {
+        int value = atoi(token);
+        int local_value = value - 0;
+        if (local_value >= 0 && local_value < 308) {
+          enabled_bitset[local_value / 64] |= ((uint64_t) 1 << (local_value % 64));
+          some_mutation_enabled = 1;
+        }
+        token = strtok(NULL, ",");
+      }
+      free(temp);
+    }
+    initialized = 1;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
+  }
+  return enabled_bitset[local_mutation_id / 64] & ((uint64_t) 1 << (local_mutation_id % 64));
+}
+
+static unsigned int __dredd_replace_expr_unsigned_int_zero(unsigned int arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 1;
+  return arg;
+}
+
+static unsigned int __dredd_replace_expr_unsigned_int_lvalue(unsigned int* arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return (*arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return ++((*arg));
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return --((*arg));
+  return (*arg);
+}
+
+static unsigned int __dredd_replace_expr_unsigned_int(unsigned int arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 0;
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 1;
+  return arg;
+}
+
+static int __dredd_replace_binary_operator_NE_arg1_unsigned_int_arg2_unsigned_int_rhs_zero(unsigned int arg1, unsigned int arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1 != arg2;
+  return arg1 != arg2;
+}
+
+static int __dredd_replace_binary_operator_NE_arg1_unsigned_int_arg2_unsigned_int_lhs_zero(unsigned int arg1, unsigned int arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1 != arg2;
+  return arg1 != arg2;
+}
+
+static int __dredd_replace_binary_operator_LT_arg1_unsigned_int_arg2_unsigned_int_rhs_zero(unsigned int arg1, unsigned int arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1 < arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1 != arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1 <= arg2;
+  return arg1 < arg2;
+}
+
+static int __dredd_replace_binary_operator_LT_arg1_unsigned_int_arg2_unsigned_int_lhs_zero(unsigned int arg1, unsigned int arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1 < arg2;
+  return arg1 < arg2;
+}
+
+static int __dredd_replace_binary_operator_LE_arg1_unsigned_int_arg2_unsigned_int_rhs_zero(unsigned int arg1, unsigned int arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1 <= arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1 == arg2;
+  return arg1 <= arg2;
+}
+
+static int __dredd_replace_binary_operator_LE_arg1_unsigned_int_arg2_unsigned_int_lhs_zero(unsigned int arg1, unsigned int arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1 <= arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1 == arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1 < arg2;
+  return arg1 <= arg2;
+}
+
+static int __dredd_replace_binary_operator_GT_arg1_unsigned_int_arg2_unsigned_int_rhs_zero(unsigned int arg1, unsigned int arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1 > arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1 != arg2;
+  return arg1 > arg2;
+}
+
+static int __dredd_replace_binary_operator_GT_arg1_unsigned_int_arg2_unsigned_int_lhs_zero(unsigned int arg1, unsigned int arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1 > arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1 != arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1 >= arg2;
+  return arg1 > arg2;
+}
+
+static int __dredd_replace_binary_operator_GE_arg1_unsigned_int_arg2_unsigned_int_rhs_zero(unsigned int arg1, unsigned int arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1 >= arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1 == arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1 > arg2;
+  return arg1 >= arg2;
+}
+
+static int __dredd_replace_binary_operator_GE_arg1_unsigned_int_arg2_unsigned_int_lhs_zero(unsigned int arg1, unsigned int arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1 >= arg2;
+  return arg1 >= arg2;
+}
+
+static int __dredd_replace_binary_operator_EQ_arg1_unsigned_int_arg2_unsigned_int_rhs_zero(unsigned int arg1, unsigned int arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1 == arg2;
+  return arg1 == arg2;
+}
+
+static int __dredd_replace_binary_operator_EQ_arg1_unsigned_int_arg2_unsigned_int_lhs_zero(unsigned int arg1, unsigned int arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1 == arg2;
+  return arg1 == arg2;
+}
+
+static bool __dredd_replace_expr_bool(bool arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 0;
+  return arg;
+}
+
+bool x_eq_zero(unsigned x) {
+  if (!__dredd_enabled_mutation(11)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_EQ_arg1_unsigned_int_arg2_unsigned_int_rhs_zero(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 0), 2) , __dredd_replace_expr_unsigned_int_zero(0u, 6), 8), 8); }
+}
+
+bool x_ne_zero(unsigned x) {
+  if (!__dredd_enabled_mutation(23)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_NE_arg1_unsigned_int_arg2_unsigned_int_rhs_zero(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 12), 14) , __dredd_replace_expr_unsigned_int_zero(0u, 18), 20), 20); }
+}
+
+bool x_gt_zero(unsigned x) {
+  if (!__dredd_enabled_mutation(36)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_GT_arg1_unsigned_int_arg2_unsigned_int_rhs_zero(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 24), 26) , __dredd_replace_expr_unsigned_int_zero(0u, 30), 32), 33); }
+}
+
+bool x_ge_zero(unsigned x) {
+  if (!__dredd_enabled_mutation(50)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_GE_arg1_unsigned_int_arg2_unsigned_int_rhs_zero(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 37), 39) , __dredd_replace_expr_unsigned_int_zero(0u, 43), 45), 47); }
+}
+
+bool x_lt_zero(unsigned x) {
+  if (!__dredd_enabled_mutation(64)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_LT_arg1_unsigned_int_arg2_unsigned_int_rhs_zero(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 51), 53) , __dredd_replace_expr_unsigned_int_zero(0u, 57), 59), 61); }
+}
+
+bool x_le_zero(unsigned x) {
+  if (!__dredd_enabled_mutation(77)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_LE_arg1_unsigned_int_arg2_unsigned_int_rhs_zero(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 65), 67) , __dredd_replace_expr_unsigned_int_zero(0u, 71), 73), 74); }
+}
+
+bool zero_eq_x(unsigned x) {
+  if (!__dredd_enabled_mutation(89)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_EQ_arg1_unsigned_int_arg2_unsigned_int_lhs_zero(__dredd_replace_expr_unsigned_int_zero(0u, 78) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 80), 82), 86), 86); }
+}
+
+bool zero_ne_x(unsigned x) {
+  if (!__dredd_enabled_mutation(101)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_NE_arg1_unsigned_int_arg2_unsigned_int_lhs_zero(__dredd_replace_expr_unsigned_int_zero(0u, 90) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 92), 94), 98), 98); }
+}
+
+bool zero_gt_x(unsigned x) {
+  if (!__dredd_enabled_mutation(115)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_GT_arg1_unsigned_int_arg2_unsigned_int_lhs_zero(__dredd_replace_expr_unsigned_int_zero(0u, 102) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 104), 106), 110), 112); }
+}
+
+bool zero_ge_x(unsigned x) {
+  if (!__dredd_enabled_mutation(127)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_GE_arg1_unsigned_int_arg2_unsigned_int_lhs_zero(__dredd_replace_expr_unsigned_int_zero(0u, 116) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 118), 120), 124), 124); }
+}
+
+bool zero_lt_x(unsigned x) {
+  if (!__dredd_enabled_mutation(139)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_LT_arg1_unsigned_int_arg2_unsigned_int_lhs_zero(__dredd_replace_expr_unsigned_int_zero(0u, 128) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 130), 132), 136), 136); }
+}
+
+bool zero_le_x(unsigned x) {
+  if (!__dredd_enabled_mutation(153)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_LE_arg1_unsigned_int_arg2_unsigned_int_lhs_zero(__dredd_replace_expr_unsigned_int_zero(0u, 140) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 142), 144), 148), 150); }
+}
+
+// Check that optimisations are applied when a signed zero literal is used.
+
+bool x_eq_signed_zero(unsigned x) {
+  if (!__dredd_enabled_mutation(165)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_EQ_arg1_unsigned_int_arg2_unsigned_int_rhs_zero(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 154), 156) , __dredd_replace_expr_unsigned_int_zero(0, 160), 162), 162); }
+}
+
+bool x_ne_signed_zero(unsigned x) {
+  if (!__dredd_enabled_mutation(177)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_NE_arg1_unsigned_int_arg2_unsigned_int_rhs_zero(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 166), 168) , __dredd_replace_expr_unsigned_int_zero(0, 172), 174), 174); }
+}
+
+bool x_gt_signed_zero(unsigned x) {
+  if (!__dredd_enabled_mutation(190)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_GT_arg1_unsigned_int_arg2_unsigned_int_rhs_zero(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 178), 180) , __dredd_replace_expr_unsigned_int_zero(0, 184), 186), 187); }
+}
+
+bool x_ge_signed_zero(unsigned x) {
+  if (!__dredd_enabled_mutation(204)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_GE_arg1_unsigned_int_arg2_unsigned_int_rhs_zero(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 191), 193) , __dredd_replace_expr_unsigned_int_zero(0, 197), 199), 201); }
+}
+
+bool x_lt_signed_zero(unsigned x) {
+  if (!__dredd_enabled_mutation(218)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_LT_arg1_unsigned_int_arg2_unsigned_int_rhs_zero(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 205), 207) , __dredd_replace_expr_unsigned_int_zero(0, 211), 213), 215); }
+}
+
+bool x_le_signed_zero(unsigned x) {
+  if (!__dredd_enabled_mutation(231)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_LE_arg1_unsigned_int_arg2_unsigned_int_rhs_zero(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 219), 221) , __dredd_replace_expr_unsigned_int_zero(0, 225), 227), 228); }
+}
+
+bool signed_zero_eq_x(unsigned x) {
+  if (!__dredd_enabled_mutation(243)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_EQ_arg1_unsigned_int_arg2_unsigned_int_lhs_zero(__dredd_replace_expr_unsigned_int_zero(0, 232) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 234), 236), 240), 240); }
+}
+
+bool signed_zero_ne_x(unsigned x) {
+  if (!__dredd_enabled_mutation(255)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_NE_arg1_unsigned_int_arg2_unsigned_int_lhs_zero(__dredd_replace_expr_unsigned_int_zero(0, 244) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 246), 248), 252), 252); }
+}
+
+bool signed_zero_gt_x(unsigned x) {
+  if (!__dredd_enabled_mutation(269)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_GT_arg1_unsigned_int_arg2_unsigned_int_lhs_zero(__dredd_replace_expr_unsigned_int_zero(0, 256) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 258), 260), 264), 266); }
+}
+
+bool signed_zero_ge_x(unsigned x) {
+  if (!__dredd_enabled_mutation(281)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_GE_arg1_unsigned_int_arg2_unsigned_int_lhs_zero(__dredd_replace_expr_unsigned_int_zero(0, 270) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 272), 274), 278), 278); }
+}
+
+bool signed_zero_lt_x(unsigned x) {
+  if (!__dredd_enabled_mutation(293)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_LT_arg1_unsigned_int_arg2_unsigned_int_lhs_zero(__dredd_replace_expr_unsigned_int_zero(0, 282) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 284), 286), 290), 290); }
+}
+
+bool signed_zero_le_x(unsigned x) {
+  if (!__dredd_enabled_mutation(307)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_LE_arg1_unsigned_int_arg2_unsigned_int_lhs_zero(__dredd_replace_expr_unsigned_int_zero(0, 294) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 296), 298), 302), 304); }
+}

--- a/test/single_file/unsigned_comparisons_with_zero.c.expected
+++ b/test/single_file/unsigned_comparisons_with_zero.c.expected
@@ -30,7 +30,7 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
       while(token) {
         int value = atoi(token);
         int local_value = value - 0;
-        if (local_value >= 0 && local_value < 308) {
+        if (local_value >= 0 && local_value < 304) {
           enabled_bitset[local_value / 64] |= ((uint64_t) 1 << (local_value % 64));
           some_mutation_enabled = 1;
         }
@@ -79,8 +79,8 @@ static int __dredd_replace_binary_operator_NE_arg1_unsigned_int_arg2_unsigned_in
 
 static int __dredd_replace_binary_operator_LT_arg1_unsigned_int_arg2_unsigned_int_rhs_zero(unsigned int arg1, unsigned int arg2, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg1 < arg2;
-  if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1 != arg2;
-  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1 <= arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1 == arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1 != arg2;
   return arg1 < arg2;
 }
 
@@ -91,34 +91,32 @@ static int __dredd_replace_binary_operator_LT_arg1_unsigned_int_arg2_unsigned_in
 
 static int __dredd_replace_binary_operator_LE_arg1_unsigned_int_arg2_unsigned_int_rhs_zero(unsigned int arg1, unsigned int arg2, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg1 <= arg2;
-  if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1 == arg2;
   return arg1 <= arg2;
 }
 
 static int __dredd_replace_binary_operator_LE_arg1_unsigned_int_arg2_unsigned_int_lhs_zero(unsigned int arg1, unsigned int arg2, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg1 <= arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1 == arg2;
-  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1 < arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1 != arg2;
   return arg1 <= arg2;
 }
 
 static int __dredd_replace_binary_operator_GT_arg1_unsigned_int_arg2_unsigned_int_rhs_zero(unsigned int arg1, unsigned int arg2, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg1 > arg2;
-  if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1 != arg2;
   return arg1 > arg2;
 }
 
 static int __dredd_replace_binary_operator_GT_arg1_unsigned_int_arg2_unsigned_int_lhs_zero(unsigned int arg1, unsigned int arg2, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg1 > arg2;
-  if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1 != arg2;
-  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1 >= arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1 == arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1 != arg2;
   return arg1 > arg2;
 }
 
 static int __dredd_replace_binary_operator_GE_arg1_unsigned_int_arg2_unsigned_int_rhs_zero(unsigned int arg1, unsigned int arg2, int local_mutation_id) {
   if (!__dredd_some_mutation_enabled) return arg1 >= arg2;
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1 == arg2;
-  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1 > arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1 != arg2;
   return arg1 >= arg2;
 }
 
@@ -154,91 +152,91 @@ bool x_ne_zero(unsigned x) {
 }
 
 bool x_gt_zero(unsigned x) {
-  if (!__dredd_enabled_mutation(36)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_GT_arg1_unsigned_int_arg2_unsigned_int_rhs_zero(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 24), 26) , __dredd_replace_expr_unsigned_int_zero(0u, 30), 32), 33); }
+  if (!__dredd_enabled_mutation(35)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_GT_arg1_unsigned_int_arg2_unsigned_int_rhs_zero(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 24), 26) , __dredd_replace_expr_unsigned_int_zero(0u, 30), 32), 32); }
 }
 
 bool x_ge_zero(unsigned x) {
-  if (!__dredd_enabled_mutation(50)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_GE_arg1_unsigned_int_arg2_unsigned_int_rhs_zero(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 37), 39) , __dredd_replace_expr_unsigned_int_zero(0u, 43), 45), 47); }
+  if (!__dredd_enabled_mutation(49)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_GE_arg1_unsigned_int_arg2_unsigned_int_rhs_zero(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 36), 38) , __dredd_replace_expr_unsigned_int_zero(0u, 42), 44), 46); }
 }
 
 bool x_lt_zero(unsigned x) {
-  if (!__dredd_enabled_mutation(64)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_LT_arg1_unsigned_int_arg2_unsigned_int_rhs_zero(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 51), 53) , __dredd_replace_expr_unsigned_int_zero(0u, 57), 59), 61); }
+  if (!__dredd_enabled_mutation(63)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_LT_arg1_unsigned_int_arg2_unsigned_int_rhs_zero(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 50), 52) , __dredd_replace_expr_unsigned_int_zero(0u, 56), 58), 60); }
 }
 
 bool x_le_zero(unsigned x) {
-  if (!__dredd_enabled_mutation(77)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_LE_arg1_unsigned_int_arg2_unsigned_int_rhs_zero(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 65), 67) , __dredd_replace_expr_unsigned_int_zero(0u, 71), 73), 74); }
+  if (!__dredd_enabled_mutation(75)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_LE_arg1_unsigned_int_arg2_unsigned_int_rhs_zero(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 64), 66) , __dredd_replace_expr_unsigned_int_zero(0u, 70), 72), 72); }
 }
 
 bool zero_eq_x(unsigned x) {
-  if (!__dredd_enabled_mutation(89)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_EQ_arg1_unsigned_int_arg2_unsigned_int_lhs_zero(__dredd_replace_expr_unsigned_int_zero(0u, 78) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 80), 82), 86), 86); }
+  if (!__dredd_enabled_mutation(87)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_EQ_arg1_unsigned_int_arg2_unsigned_int_lhs_zero(__dredd_replace_expr_unsigned_int_zero(0u, 76) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 78), 80), 84), 84); }
 }
 
 bool zero_ne_x(unsigned x) {
-  if (!__dredd_enabled_mutation(101)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_NE_arg1_unsigned_int_arg2_unsigned_int_lhs_zero(__dredd_replace_expr_unsigned_int_zero(0u, 90) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 92), 94), 98), 98); }
+  if (!__dredd_enabled_mutation(99)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_NE_arg1_unsigned_int_arg2_unsigned_int_lhs_zero(__dredd_replace_expr_unsigned_int_zero(0u, 88) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 90), 92), 96), 96); }
 }
 
 bool zero_gt_x(unsigned x) {
-  if (!__dredd_enabled_mutation(115)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_GT_arg1_unsigned_int_arg2_unsigned_int_lhs_zero(__dredd_replace_expr_unsigned_int_zero(0u, 102) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 104), 106), 110), 112); }
+  if (!__dredd_enabled_mutation(113)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_GT_arg1_unsigned_int_arg2_unsigned_int_lhs_zero(__dredd_replace_expr_unsigned_int_zero(0u, 100) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 102), 104), 108), 110); }
 }
 
 bool zero_ge_x(unsigned x) {
-  if (!__dredd_enabled_mutation(127)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_GE_arg1_unsigned_int_arg2_unsigned_int_lhs_zero(__dredd_replace_expr_unsigned_int_zero(0u, 116) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 118), 120), 124), 124); }
+  if (!__dredd_enabled_mutation(125)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_GE_arg1_unsigned_int_arg2_unsigned_int_lhs_zero(__dredd_replace_expr_unsigned_int_zero(0u, 114) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 116), 118), 122), 122); }
 }
 
 bool zero_lt_x(unsigned x) {
-  if (!__dredd_enabled_mutation(139)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_LT_arg1_unsigned_int_arg2_unsigned_int_lhs_zero(__dredd_replace_expr_unsigned_int_zero(0u, 128) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 130), 132), 136), 136); }
+  if (!__dredd_enabled_mutation(137)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_LT_arg1_unsigned_int_arg2_unsigned_int_lhs_zero(__dredd_replace_expr_unsigned_int_zero(0u, 126) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 128), 130), 134), 134); }
 }
 
 bool zero_le_x(unsigned x) {
-  if (!__dredd_enabled_mutation(153)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_LE_arg1_unsigned_int_arg2_unsigned_int_lhs_zero(__dredd_replace_expr_unsigned_int_zero(0u, 140) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 142), 144), 148), 150); }
+  if (!__dredd_enabled_mutation(151)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_LE_arg1_unsigned_int_arg2_unsigned_int_lhs_zero(__dredd_replace_expr_unsigned_int_zero(0u, 138) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 140), 142), 146), 148); }
 }
 
 // Check that optimisations are applied when a signed zero literal is used.
 
 bool x_eq_signed_zero(unsigned x) {
-  if (!__dredd_enabled_mutation(165)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_EQ_arg1_unsigned_int_arg2_unsigned_int_rhs_zero(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 154), 156) , __dredd_replace_expr_unsigned_int_zero(0, 160), 162), 162); }
+  if (!__dredd_enabled_mutation(163)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_EQ_arg1_unsigned_int_arg2_unsigned_int_rhs_zero(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 152), 154) , __dredd_replace_expr_unsigned_int_zero(0, 158), 160), 160); }
 }
 
 bool x_ne_signed_zero(unsigned x) {
-  if (!__dredd_enabled_mutation(177)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_NE_arg1_unsigned_int_arg2_unsigned_int_rhs_zero(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 166), 168) , __dredd_replace_expr_unsigned_int_zero(0, 172), 174), 174); }
+  if (!__dredd_enabled_mutation(175)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_NE_arg1_unsigned_int_arg2_unsigned_int_rhs_zero(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 164), 166) , __dredd_replace_expr_unsigned_int_zero(0, 170), 172), 172); }
 }
 
 bool x_gt_signed_zero(unsigned x) {
-  if (!__dredd_enabled_mutation(190)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_GT_arg1_unsigned_int_arg2_unsigned_int_rhs_zero(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 178), 180) , __dredd_replace_expr_unsigned_int_zero(0, 184), 186), 187); }
+  if (!__dredd_enabled_mutation(187)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_GT_arg1_unsigned_int_arg2_unsigned_int_rhs_zero(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 176), 178) , __dredd_replace_expr_unsigned_int_zero(0, 182), 184), 184); }
 }
 
 bool x_ge_signed_zero(unsigned x) {
-  if (!__dredd_enabled_mutation(204)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_GE_arg1_unsigned_int_arg2_unsigned_int_rhs_zero(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 191), 193) , __dredd_replace_expr_unsigned_int_zero(0, 197), 199), 201); }
+  if (!__dredd_enabled_mutation(201)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_GE_arg1_unsigned_int_arg2_unsigned_int_rhs_zero(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 188), 190) , __dredd_replace_expr_unsigned_int_zero(0, 194), 196), 198); }
 }
 
 bool x_lt_signed_zero(unsigned x) {
-  if (!__dredd_enabled_mutation(218)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_LT_arg1_unsigned_int_arg2_unsigned_int_rhs_zero(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 205), 207) , __dredd_replace_expr_unsigned_int_zero(0, 211), 213), 215); }
+  if (!__dredd_enabled_mutation(215)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_LT_arg1_unsigned_int_arg2_unsigned_int_rhs_zero(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 202), 204) , __dredd_replace_expr_unsigned_int_zero(0, 208), 210), 212); }
 }
 
 bool x_le_signed_zero(unsigned x) {
-  if (!__dredd_enabled_mutation(231)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_LE_arg1_unsigned_int_arg2_unsigned_int_rhs_zero(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 219), 221) , __dredd_replace_expr_unsigned_int_zero(0, 225), 227), 228); }
+  if (!__dredd_enabled_mutation(227)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_LE_arg1_unsigned_int_arg2_unsigned_int_rhs_zero(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 216), 218) , __dredd_replace_expr_unsigned_int_zero(0, 222), 224), 224); }
 }
 
 bool signed_zero_eq_x(unsigned x) {
-  if (!__dredd_enabled_mutation(243)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_EQ_arg1_unsigned_int_arg2_unsigned_int_lhs_zero(__dredd_replace_expr_unsigned_int_zero(0, 232) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 234), 236), 240), 240); }
+  if (!__dredd_enabled_mutation(239)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_EQ_arg1_unsigned_int_arg2_unsigned_int_lhs_zero(__dredd_replace_expr_unsigned_int_zero(0, 228) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 230), 232), 236), 236); }
 }
 
 bool signed_zero_ne_x(unsigned x) {
-  if (!__dredd_enabled_mutation(255)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_NE_arg1_unsigned_int_arg2_unsigned_int_lhs_zero(__dredd_replace_expr_unsigned_int_zero(0, 244) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 246), 248), 252), 252); }
+  if (!__dredd_enabled_mutation(251)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_NE_arg1_unsigned_int_arg2_unsigned_int_lhs_zero(__dredd_replace_expr_unsigned_int_zero(0, 240) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 242), 244), 248), 248); }
 }
 
 bool signed_zero_gt_x(unsigned x) {
-  if (!__dredd_enabled_mutation(269)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_GT_arg1_unsigned_int_arg2_unsigned_int_lhs_zero(__dredd_replace_expr_unsigned_int_zero(0, 256) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 258), 260), 264), 266); }
+  if (!__dredd_enabled_mutation(265)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_GT_arg1_unsigned_int_arg2_unsigned_int_lhs_zero(__dredd_replace_expr_unsigned_int_zero(0, 252) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 254), 256), 260), 262); }
 }
 
 bool signed_zero_ge_x(unsigned x) {
-  if (!__dredd_enabled_mutation(281)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_GE_arg1_unsigned_int_arg2_unsigned_int_lhs_zero(__dredd_replace_expr_unsigned_int_zero(0, 270) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 272), 274), 278), 278); }
+  if (!__dredd_enabled_mutation(277)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_GE_arg1_unsigned_int_arg2_unsigned_int_lhs_zero(__dredd_replace_expr_unsigned_int_zero(0, 266) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 268), 270), 274), 274); }
 }
 
 bool signed_zero_lt_x(unsigned x) {
-  if (!__dredd_enabled_mutation(293)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_LT_arg1_unsigned_int_arg2_unsigned_int_lhs_zero(__dredd_replace_expr_unsigned_int_zero(0, 282) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 284), 286), 290), 290); }
+  if (!__dredd_enabled_mutation(289)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_LT_arg1_unsigned_int_arg2_unsigned_int_lhs_zero(__dredd_replace_expr_unsigned_int_zero(0, 278) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 280), 282), 286), 286); }
 }
 
 bool signed_zero_le_x(unsigned x) {
-  if (!__dredd_enabled_mutation(307)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_LE_arg1_unsigned_int_arg2_unsigned_int_lhs_zero(__dredd_replace_expr_unsigned_int_zero(0, 294) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 296), 298), 302), 304); }
+  if (!__dredd_enabled_mutation(303)) { return __dredd_replace_expr_bool(__dredd_replace_binary_operator_LE_arg1_unsigned_int_arg2_unsigned_int_lhs_zero(__dredd_replace_expr_unsigned_int_zero(0, 290) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 292), 294), 298), 300); }
 }

--- a/test/single_file/unsigned_comparisons_with_zero.c.noopt.expected
+++ b/test/single_file/unsigned_comparisons_with_zero.c.noopt.expected
@@ -1,0 +1,250 @@
+#include <stdbool.h>
+
+// Check that optimisations are applied when an unsigned zero literal is used.
+
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _MSC_VER
+#define thread_local __declspec(thread)
+#elif __APPLE__
+#define thread_local __thread
+#else
+#include <threads.h>
+#endif
+
+static thread_local int __dredd_some_mutation_enabled = 1;
+static bool __dredd_enabled_mutation(int local_mutation_id) {
+  static thread_local int initialized = 0;
+  static thread_local uint64_t enabled_bitset[12];
+  if (!initialized) {
+    int some_mutation_enabled = 0;
+    const char* dredd_environment_variable = getenv("DREDD_ENABLED_MUTATION");
+    if (dredd_environment_variable) {
+      char* temp = malloc(strlen(dredd_environment_variable) + 1);
+      strcpy(temp, dredd_environment_variable);
+      char* token;
+      token = strtok(temp, ",");
+      while(token) {
+        int value = atoi(token);
+        int local_value = value - 0;
+        if (local_value >= 0 && local_value < 720) {
+          enabled_bitset[local_value / 64] |= ((uint64_t) 1 << (local_value % 64));
+          some_mutation_enabled = 1;
+        }
+        token = strtok(NULL, ",");
+      }
+      free(temp);
+    }
+    initialized = 1;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
+  }
+  return enabled_bitset[local_mutation_id / 64] & ((uint64_t) 1 << (local_mutation_id % 64));
+}
+
+static unsigned int __dredd_replace_expr_unsigned_int_lvalue(unsigned int* arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return (*arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return ++((*arg));
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return --((*arg));
+  return (*arg);
+}
+
+static unsigned int __dredd_replace_expr_unsigned_int(unsigned int arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 0;
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 1;
+  return arg;
+}
+
+static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 0;
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
+  return arg;
+}
+
+static int __dredd_replace_binary_operator_NE_arg1_unsigned_int_arg2_unsigned_int(unsigned int arg1, unsigned int arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1 != arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1 == arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1 >= arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1 > arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return arg1 <= arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return arg1 < arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 5)) return arg1;
+  if (__dredd_enabled_mutation(local_mutation_id + 6)) return arg2;
+  return arg1 != arg2;
+}
+
+static int __dredd_replace_binary_operator_LT_arg1_unsigned_int_arg2_unsigned_int(unsigned int arg1, unsigned int arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1 < arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1 == arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1 != arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1 >= arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return arg1 > arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return arg1 <= arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 5)) return arg1;
+  if (__dredd_enabled_mutation(local_mutation_id + 6)) return arg2;
+  return arg1 < arg2;
+}
+
+static int __dredd_replace_binary_operator_LE_arg1_unsigned_int_arg2_unsigned_int(unsigned int arg1, unsigned int arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1 <= arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1 == arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1 != arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1 >= arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return arg1 > arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return arg1 < arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 5)) return arg1;
+  if (__dredd_enabled_mutation(local_mutation_id + 6)) return arg2;
+  return arg1 <= arg2;
+}
+
+static int __dredd_replace_binary_operator_GT_arg1_unsigned_int_arg2_unsigned_int(unsigned int arg1, unsigned int arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1 > arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1 == arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1 != arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1 >= arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return arg1 <= arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return arg1 < arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 5)) return arg1;
+  if (__dredd_enabled_mutation(local_mutation_id + 6)) return arg2;
+  return arg1 > arg2;
+}
+
+static int __dredd_replace_binary_operator_GE_arg1_unsigned_int_arg2_unsigned_int(unsigned int arg1, unsigned int arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1 >= arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1 == arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1 != arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1 > arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return arg1 <= arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return arg1 < arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 5)) return arg1;
+  if (__dredd_enabled_mutation(local_mutation_id + 6)) return arg2;
+  return arg1 >= arg2;
+}
+
+static int __dredd_replace_binary_operator_EQ_arg1_unsigned_int_arg2_unsigned_int(unsigned int arg1, unsigned int arg2, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg1 == arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return arg1 != arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return arg1 >= arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return arg1 > arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return arg1 <= arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return arg1 < arg2;
+  if (__dredd_enabled_mutation(local_mutation_id + 5)) return arg1;
+  if (__dredd_enabled_mutation(local_mutation_id + 6)) return arg2;
+  return arg1 == arg2;
+}
+
+static bool __dredd_replace_expr_bool(bool arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 0;
+  return arg;
+}
+
+bool x_eq_zero(unsigned x) {
+  if (!__dredd_enabled_mutation(26)) { return __dredd_replace_expr_bool(__dredd_replace_expr_int(__dredd_replace_binary_operator_EQ_arg1_unsigned_int_arg2_unsigned_int(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 0), 2) , __dredd_replace_expr_unsigned_int(0u, 6), 10), 17), 23); }
+}
+
+bool x_ne_zero(unsigned x) {
+  if (!__dredd_enabled_mutation(53)) { return __dredd_replace_expr_bool(__dredd_replace_expr_int(__dredd_replace_binary_operator_NE_arg1_unsigned_int_arg2_unsigned_int(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 27), 29) , __dredd_replace_expr_unsigned_int(0u, 33), 37), 44), 50); }
+}
+
+bool x_gt_zero(unsigned x) {
+  if (!__dredd_enabled_mutation(80)) { return __dredd_replace_expr_bool(__dredd_replace_expr_int(__dredd_replace_binary_operator_GT_arg1_unsigned_int_arg2_unsigned_int(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 54), 56) , __dredd_replace_expr_unsigned_int(0u, 60), 64), 71), 77); }
+}
+
+bool x_ge_zero(unsigned x) {
+  if (!__dredd_enabled_mutation(107)) { return __dredd_replace_expr_bool(__dredd_replace_expr_int(__dredd_replace_binary_operator_GE_arg1_unsigned_int_arg2_unsigned_int(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 81), 83) , __dredd_replace_expr_unsigned_int(0u, 87), 91), 98), 104); }
+}
+
+bool x_lt_zero(unsigned x) {
+  if (!__dredd_enabled_mutation(134)) { return __dredd_replace_expr_bool(__dredd_replace_expr_int(__dredd_replace_binary_operator_LT_arg1_unsigned_int_arg2_unsigned_int(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 108), 110) , __dredd_replace_expr_unsigned_int(0u, 114), 118), 125), 131); }
+}
+
+bool x_le_zero(unsigned x) {
+  if (!__dredd_enabled_mutation(161)) { return __dredd_replace_expr_bool(__dredd_replace_expr_int(__dredd_replace_binary_operator_LE_arg1_unsigned_int_arg2_unsigned_int(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 135), 137) , __dredd_replace_expr_unsigned_int(0u, 141), 145), 152), 158); }
+}
+
+bool zero_eq_x(unsigned x) {
+  if (!__dredd_enabled_mutation(188)) { return __dredd_replace_expr_bool(__dredd_replace_expr_int(__dredd_replace_binary_operator_EQ_arg1_unsigned_int_arg2_unsigned_int(__dredd_replace_expr_unsigned_int(0u, 162) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 166), 168), 172), 179), 185); }
+}
+
+bool zero_ne_x(unsigned x) {
+  if (!__dredd_enabled_mutation(215)) { return __dredd_replace_expr_bool(__dredd_replace_expr_int(__dredd_replace_binary_operator_NE_arg1_unsigned_int_arg2_unsigned_int(__dredd_replace_expr_unsigned_int(0u, 189) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 193), 195), 199), 206), 212); }
+}
+
+bool zero_gt_x(unsigned x) {
+  if (!__dredd_enabled_mutation(242)) { return __dredd_replace_expr_bool(__dredd_replace_expr_int(__dredd_replace_binary_operator_GT_arg1_unsigned_int_arg2_unsigned_int(__dredd_replace_expr_unsigned_int(0u, 216) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 220), 222), 226), 233), 239); }
+}
+
+bool zero_ge_x(unsigned x) {
+  if (!__dredd_enabled_mutation(269)) { return __dredd_replace_expr_bool(__dredd_replace_expr_int(__dredd_replace_binary_operator_GE_arg1_unsigned_int_arg2_unsigned_int(__dredd_replace_expr_unsigned_int(0u, 243) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 247), 249), 253), 260), 266); }
+}
+
+bool zero_lt_x(unsigned x) {
+  if (!__dredd_enabled_mutation(296)) { return __dredd_replace_expr_bool(__dredd_replace_expr_int(__dredd_replace_binary_operator_LT_arg1_unsigned_int_arg2_unsigned_int(__dredd_replace_expr_unsigned_int(0u, 270) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 274), 276), 280), 287), 293); }
+}
+
+bool zero_le_x(unsigned x) {
+  if (!__dredd_enabled_mutation(323)) { return __dredd_replace_expr_bool(__dredd_replace_expr_int(__dredd_replace_binary_operator_LE_arg1_unsigned_int_arg2_unsigned_int(__dredd_replace_expr_unsigned_int(0u, 297) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 301), 303), 307), 314), 320); }
+}
+
+// Check that optimisations are applied when a signed zero literal is used.
+
+bool x_eq_signed_zero(unsigned x) {
+  if (!__dredd_enabled_mutation(356)) { return __dredd_replace_expr_bool(__dredd_replace_expr_int(__dredd_replace_binary_operator_EQ_arg1_unsigned_int_arg2_unsigned_int(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 324), 326) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_int(0, 330), 336), 340), 347), 353); }
+}
+
+bool x_ne_signed_zero(unsigned x) {
+  if (!__dredd_enabled_mutation(389)) { return __dredd_replace_expr_bool(__dredd_replace_expr_int(__dredd_replace_binary_operator_NE_arg1_unsigned_int_arg2_unsigned_int(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 357), 359) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_int(0, 363), 369), 373), 380), 386); }
+}
+
+bool x_gt_signed_zero(unsigned x) {
+  if (!__dredd_enabled_mutation(422)) { return __dredd_replace_expr_bool(__dredd_replace_expr_int(__dredd_replace_binary_operator_GT_arg1_unsigned_int_arg2_unsigned_int(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 390), 392) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_int(0, 396), 402), 406), 413), 419); }
+}
+
+bool x_ge_signed_zero(unsigned x) {
+  if (!__dredd_enabled_mutation(455)) { return __dredd_replace_expr_bool(__dredd_replace_expr_int(__dredd_replace_binary_operator_GE_arg1_unsigned_int_arg2_unsigned_int(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 423), 425) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_int(0, 429), 435), 439), 446), 452); }
+}
+
+bool x_lt_signed_zero(unsigned x) {
+  if (!__dredd_enabled_mutation(488)) { return __dredd_replace_expr_bool(__dredd_replace_expr_int(__dredd_replace_binary_operator_LT_arg1_unsigned_int_arg2_unsigned_int(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 456), 458) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_int(0, 462), 468), 472), 479), 485); }
+}
+
+bool x_le_signed_zero(unsigned x) {
+  if (!__dredd_enabled_mutation(521)) { return __dredd_replace_expr_bool(__dredd_replace_expr_int(__dredd_replace_binary_operator_LE_arg1_unsigned_int_arg2_unsigned_int(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 489), 491) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_int(0, 495), 501), 505), 512), 518); }
+}
+
+bool signed_zero_eq_x(unsigned x) {
+  if (!__dredd_enabled_mutation(554)) { return __dredd_replace_expr_bool(__dredd_replace_expr_int(__dredd_replace_binary_operator_EQ_arg1_unsigned_int_arg2_unsigned_int(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_int(0, 522), 528) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 532), 534), 538), 545), 551); }
+}
+
+bool signed_zero_ne_x(unsigned x) {
+  if (!__dredd_enabled_mutation(587)) { return __dredd_replace_expr_bool(__dredd_replace_expr_int(__dredd_replace_binary_operator_NE_arg1_unsigned_int_arg2_unsigned_int(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_int(0, 555), 561) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 565), 567), 571), 578), 584); }
+}
+
+bool signed_zero_gt_x(unsigned x) {
+  if (!__dredd_enabled_mutation(620)) { return __dredd_replace_expr_bool(__dredd_replace_expr_int(__dredd_replace_binary_operator_GT_arg1_unsigned_int_arg2_unsigned_int(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_int(0, 588), 594) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 598), 600), 604), 611), 617); }
+}
+
+bool signed_zero_ge_x(unsigned x) {
+  if (!__dredd_enabled_mutation(653)) { return __dredd_replace_expr_bool(__dredd_replace_expr_int(__dredd_replace_binary_operator_GE_arg1_unsigned_int_arg2_unsigned_int(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_int(0, 621), 627) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 631), 633), 637), 644), 650); }
+}
+
+bool signed_zero_lt_x(unsigned x) {
+  if (!__dredd_enabled_mutation(686)) { return __dredd_replace_expr_bool(__dredd_replace_expr_int(__dredd_replace_binary_operator_LT_arg1_unsigned_int_arg2_unsigned_int(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_int(0, 654), 660) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 664), 666), 670), 677), 683); }
+}
+
+bool signed_zero_le_x(unsigned x) {
+  if (!__dredd_enabled_mutation(719)) { return __dredd_replace_expr_bool(__dredd_replace_expr_int(__dredd_replace_binary_operator_LE_arg1_unsigned_int_arg2_unsigned_int(__dredd_replace_expr_unsigned_int(__dredd_replace_expr_int(0, 687), 693) , __dredd_replace_expr_unsigned_int(__dredd_replace_expr_unsigned_int_lvalue(&(x), 697), 699), 703), 710), 716); }
+}


### PR DESCRIPTION
Dredd mutates binary operators to non-redundant operators according to
the rules defined in the referenced paper. Previously, this optimization
allowed for equivalent mutations in the case of unsigned types. A
similar analysis to that described in the paper can be done to
avoid redundant or equivalent mutations for unsigned types.

Non-redundant mutation paper:
    [https://people.cs.umass.edu/~rjust/publ/non_redundant_mutants_jstvr_2014.pdf](https://people.cs.umass.edu/~rjust/publ/non_redundant_mutants_jstvr_2014.pdf)

Fixes #240 