### PR TITLE
Avoid mutations that break argument-dependent lookup (ADL)

### DIFF
--- a/src/libdredd/include_private/include/libdredd/mutate_visitor.h
+++ b/src/libdredd/include_private/include/libdredd/mutate_visitor.h
@@ -202,6 +202,20 @@ class MutateVisitor : public clang::RecursiveASTVisitor<MutateVisitor> {
   // bookkeeping.
   void AddMutation(std::unique_ptr<Mutation> mutation);
 
+  // Determines whether the parent of the given expression is a call expression
+  // that uses argument-dependent lookup.
+  bool IsArgumentToArgumentDependentLookupCall(const clang::Expr& expr) const;
+
+  // Conservatively determines whether the given expression is an argument to
+  // a call that has been resolved using argument-dependent lookup, and in
+  // particular whether it might be the case that the expression is itself
+  // relevant to the namespaces that are added during
+  // argument-dependent lookup. Such expressions are not mutated at the top
+  // level, because the replacement mutator function will have a primitive
+  // result type, which cannot contribute to (and might therefore change the
+  // results of) argument-dependent lookup.
+  bool MutatingMayAffectArgumentDependentLookup(const clang::Expr& expr) const;
+
   const clang::CompilerInstance* compiler_instance_;
   bool optimise_mutations_;
 

--- a/src/libdredd/src/mutate_visitor.cc
+++ b/src/libdredd/src/mutate_visitor.cc
@@ -761,7 +761,8 @@ bool MutateVisitor::MutatingMayAffectArgumentDependentLookup(
   // If an implicit cast either converts from a type that would not normally be
   // supported, or converts from the result of a C++ member call, and if this is
   // directly under an ADL call, then inserting a mutator function may affect
-  // the results of ADL and should be avoided.
+  // the results of ADL, and is therefore avoided. This is conservative,
+  // as this particular argument might not contribute to the result of ADL.
   if (const auto* implicit_cast =
           llvm::dyn_cast<clang::ImplicitCastExpr>(&expr)) {
     if (!IsTypeSupported(implicit_cast->getSubExpr()->getType()) ||
@@ -773,9 +774,10 @@ bool MutateVisitor::MutatingMayAffectArgumentDependentLookup(
     }
   }
 
-  // A C++ member expression that is directly under an ADL call (possibly with
-  // an intervening implicit cast) may affect the outcome of ADL. Mutation of
-  // such an expression should therefore be avoided.
+  // A C++ member call expression that is directly under an ADL call (possibly
+  // with an intervening implicit cast) may affect the outcome of ADL. Mutation
+  // of such an expression should therefore be avoided. This is conservative, as
+  // this particular argument might not contribute to the result of ADL.
   if (const auto* member_call_expr =
           llvm::dyn_cast<clang::CXXMemberCallExpr>(&expr)) {
     const clang::Expr* possible_adl_call_argument = member_call_expr;

--- a/test/single_file/adl.cc
+++ b/test/single_file/adl.cc
@@ -1,0 +1,21 @@
+namespace bar {
+  void foo(int x);
+
+  enum {B = 1};
+
+  struct C {
+    operator int();
+    friend void baz(int x);
+  };
+}
+
+void func() {
+  // All of these calls rely on ADL
+  foo(bar::B);
+  foo((bar::B));
+  bar::C c;
+  foo(c);
+  foo((c));
+  baz(c);
+  baz((c));
+}

--- a/test/single_file/adl.cc.expected
+++ b/test/single_file/adl.cc.expected
@@ -1,0 +1,65 @@
+namespace bar {
+  void foo(int x);
+
+  enum {B = 1};
+
+  struct C {
+    operator int();
+    friend void baz(int x);
+  };
+}
+
+#include <cinttypes>
+#include <cstddef>
+#include <functional>
+#include <string>
+
+
+#ifdef _MSC_VER
+#define thread_local __declspec(thread)
+#elif __APPLE__
+#define thread_local __thread
+#endif
+
+static thread_local bool __dredd_some_mutation_enabled = true;
+static bool __dredd_enabled_mutation(int local_mutation_id) {
+  static thread_local bool initialized = false;
+  static thread_local uint64_t enabled_bitset[1];
+  if (!initialized) {
+    bool some_mutation_enabled = false;
+    const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
+    if (dredd_environment_variable != nullptr) {
+      std::string contents(dredd_environment_variable);
+      while (true) {
+        size_t pos = contents.find(",");
+        std::string token = (pos == std::string::npos ? contents : contents.substr(0, pos));
+        if (!token.empty()) {
+          int value = std::stoi(token);
+          int local_value = value - 0;
+          if (local_value >= 0 && local_value < 6) {
+            enabled_bitset[local_value / 64] |= (static_cast<uint64_t>(1) << (local_value % 64));
+            some_mutation_enabled = true;
+          }
+        }
+        if (pos == std::string::npos) {
+          break;
+        }
+        contents.erase(0, pos + 1);
+      }
+    }
+    initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
+  }
+  return (enabled_bitset[local_mutation_id / 64] & (static_cast<uint64_t>(1) << (local_mutation_id % 64))) != 0;
+}
+
+void func() {
+  // All of these calls rely on ADL
+  if (!__dredd_enabled_mutation(0)) { foo(bar::B); }
+  if (!__dredd_enabled_mutation(1)) { foo((bar::B)); }
+  bar::C c;
+  if (!__dredd_enabled_mutation(2)) { foo(c); }
+  if (!__dredd_enabled_mutation(3)) { foo((c)); }
+  if (!__dredd_enabled_mutation(4)) { baz(c); }
+  if (!__dredd_enabled_mutation(5)) { baz((c)); }
+}

--- a/test/single_file/adl.cc.noopt.expected
+++ b/test/single_file/adl.cc.noopt.expected
@@ -1,0 +1,65 @@
+namespace bar {
+  void foo(int x);
+
+  enum {B = 1};
+
+  struct C {
+    operator int();
+    friend void baz(int x);
+  };
+}
+
+#include <cinttypes>
+#include <cstddef>
+#include <functional>
+#include <string>
+
+
+#ifdef _MSC_VER
+#define thread_local __declspec(thread)
+#elif __APPLE__
+#define thread_local __thread
+#endif
+
+static thread_local bool __dredd_some_mutation_enabled = true;
+static bool __dredd_enabled_mutation(int local_mutation_id) {
+  static thread_local bool initialized = false;
+  static thread_local uint64_t enabled_bitset[1];
+  if (!initialized) {
+    bool some_mutation_enabled = false;
+    const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
+    if (dredd_environment_variable != nullptr) {
+      std::string contents(dredd_environment_variable);
+      while (true) {
+        size_t pos = contents.find(",");
+        std::string token = (pos == std::string::npos ? contents : contents.substr(0, pos));
+        if (!token.empty()) {
+          int value = std::stoi(token);
+          int local_value = value - 0;
+          if (local_value >= 0 && local_value < 6) {
+            enabled_bitset[local_value / 64] |= (static_cast<uint64_t>(1) << (local_value % 64));
+            some_mutation_enabled = true;
+          }
+        }
+        if (pos == std::string::npos) {
+          break;
+        }
+        contents.erase(0, pos + 1);
+      }
+    }
+    initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
+  }
+  return (enabled_bitset[local_mutation_id / 64] & (static_cast<uint64_t>(1) << (local_mutation_id % 64))) != 0;
+}
+
+void func() {
+  // All of these calls rely on ADL
+  if (!__dredd_enabled_mutation(0)) { foo(bar::B); }
+  if (!__dredd_enabled_mutation(1)) { foo((bar::B)); }
+  bar::C c;
+  if (!__dredd_enabled_mutation(2)) { foo(c); }
+  if (!__dredd_enabled_mutation(3)) { foo((c)); }
+  if (!__dredd_enabled_mutation(4)) { baz(c); }
+  if (!__dredd_enabled_mutation(5)) { baz((c)); }
+}


### PR DESCRIPTION
Identifies and avoids mutating various expressions that involve implicit casts from enums or class instances to primitive types, that might affect the outcome of argument-dependent lookup.

Fixes #296.