### PR TITLE
Account for attributes when inserting prelude

### DIFF
--- a/src/libdredd/src/mutate_visitor.cc
+++ b/src/libdredd/src/mutate_visitor.cc
@@ -38,6 +38,7 @@
 #include "clang/Basic/SourceManager.h"
 #include "clang/Basic/TypeTraits.h"
 #include "clang/Frontend/CompilerInstance.h"
+#include "clang/Tooling/Transformer/SourceCode.h"
 #include "libdredd/mutation.h"
 #include "libdredd/mutation_remove_stmt.h"
 #include "libdredd/mutation_replace_binary_operator.h"
@@ -66,17 +67,41 @@ bool MutateVisitor::IsTypeSupported(const clang::QualType qual_type) {
 }
 
 void MutateVisitor::UpdateStartLocationOfFirstFunctionInSourceFile() {
-  if (IsInFunction()) {
-    const clang::BeforeThanCompare<clang::SourceLocation> comparator(
-        compiler_instance_->getSourceManager());
-    auto source_range_in_main_file = GetSourceRangeInMainFile(
-        compiler_instance_->getPreprocessor(), *enclosing_decls_[0]);
-    if (start_location_of_first_function_in_source_file_.isInvalid() ||
-        comparator(source_range_in_main_file.getBegin(),
-                   start_location_of_first_function_in_source_file_)) {
+  assert(IsInFunction() &&
+         "A mutation should only be created for code that is in a function.");
+  const auto& source_manager =
+      compiler_instance_->getASTContext().getSourceManager();
+
+  const auto& outermost_enclosing_decl = *enclosing_decls_[0];
+
+  // The outermost enclosing declaration's regular source range may not include
+  // features such as attributes, like [[nodiscard]]. The "associated range"
+  // provides a range that includes these.
+  auto associated_range = clang::tooling::getAssociatedRange(
+      outermost_enclosing_decl, compiler_instance_->getASTContext());
+  if (associated_range.isInvalid()) {
+    // An example why the associated range may be invalid: instead of using an
+    // explicit [[nodiscard]] attribute, this has been defined by a preprocessor
+    // macro, NODISCARD, and the macro has been used. In such cases, if no start
+    // location of a first function has been recorded, we fall back to the
+    // beginning of the source file.
+    if (start_location_of_first_function_in_source_file_.isInvalid()) {
       start_location_of_first_function_in_source_file_ =
-          source_range_in_main_file.getBegin();
+          source_manager.translateLineCol(source_manager.getMainFileID(), 1, 1);
+      assert(
+          start_location_of_first_function_in_source_file_.isValid() &&
+          "There is at least one mutation, therefore the file must have some "
+          "content.");
     }
+    return;
+  }
+  const clang::BeforeThanCompare<clang::SourceLocation> comparator(
+      compiler_instance_->getSourceManager());
+  if (start_location_of_first_function_in_source_file_.isInvalid() ||
+      comparator(associated_range.getBegin(),
+                 start_location_of_first_function_in_source_file_)) {
+    start_location_of_first_function_in_source_file_ =
+        associated_range.getBegin();
   }
 }
 

--- a/src/libdredd/src/mutate_visitor.cc
+++ b/src/libdredd/src/mutate_visitor.cc
@@ -19,6 +19,7 @@
 #include <memory>
 #include <optional>
 
+#include "clang/AST/ASTContext.h"
 #include "clang/AST/Attrs.inc"
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclBase.h"

--- a/test/single_file/nodiscard.cc
+++ b/test/single_file/nodiscard.cc
@@ -1,0 +1,3 @@
+[[nodiscard]] static int foo() {
+  return 42;
+}

--- a/test/single_file/nodiscard.cc.expected
+++ b/test/single_file/nodiscard.cc.expected
@@ -1,0 +1,57 @@
+#include <cinttypes>
+#include <cstddef>
+#include <functional>
+#include <string>
+
+
+#ifdef _MSC_VER
+#define thread_local __declspec(thread)
+#elif __APPLE__
+#define thread_local __thread
+#endif
+
+static thread_local bool __dredd_some_mutation_enabled = true;
+static bool __dredd_enabled_mutation(int local_mutation_id) {
+  static thread_local bool initialized = false;
+  static thread_local uint64_t enabled_bitset[1];
+  if (!initialized) {
+    bool some_mutation_enabled = false;
+    const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
+    if (dredd_environment_variable != nullptr) {
+      std::string contents(dredd_environment_variable);
+      while (true) {
+        size_t pos = contents.find(",");
+        std::string token = (pos == std::string::npos ? contents : contents.substr(0, pos));
+        if (!token.empty()) {
+          int value = std::stoi(token);
+          int local_value = value - 0;
+          if (local_value >= 0 && local_value < 6) {
+            enabled_bitset[local_value / 64] |= (static_cast<uint64_t>(1) << (local_value % 64));
+            some_mutation_enabled = true;
+          }
+        }
+        if (pos == std::string::npos) {
+          break;
+        }
+        contents.erase(0, pos + 1);
+      }
+    }
+    initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
+  }
+  return (enabled_bitset[local_mutation_id / 64] & (static_cast<uint64_t>(1) << (local_mutation_id % 64))) != 0;
+}
+
+static int __dredd_replace_expr_int_constant(int arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return -(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 0;
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return -1;
+  return arg;
+}
+
+[[nodiscard]] static int foo() {
+  if (!__dredd_enabled_mutation(5)) { return __dredd_replace_expr_int_constant(42, 0); }
+}

--- a/test/single_file/nodiscard.cc.noopt.expected
+++ b/test/single_file/nodiscard.cc.noopt.expected
@@ -1,0 +1,58 @@
+#include <cinttypes>
+#include <cstddef>
+#include <functional>
+#include <string>
+
+
+#ifdef _MSC_VER
+#define thread_local __declspec(thread)
+#elif __APPLE__
+#define thread_local __thread
+#endif
+
+static thread_local bool __dredd_some_mutation_enabled = true;
+static bool __dredd_enabled_mutation(int local_mutation_id) {
+  static thread_local bool initialized = false;
+  static thread_local uint64_t enabled_bitset[1];
+  if (!initialized) {
+    bool some_mutation_enabled = false;
+    const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
+    if (dredd_environment_variable != nullptr) {
+      std::string contents(dredd_environment_variable);
+      while (true) {
+        size_t pos = contents.find(",");
+        std::string token = (pos == std::string::npos ? contents : contents.substr(0, pos));
+        if (!token.empty()) {
+          int value = std::stoi(token);
+          int local_value = value - 0;
+          if (local_value >= 0 && local_value < 7) {
+            enabled_bitset[local_value / 64] |= (static_cast<uint64_t>(1) << (local_value % 64));
+            some_mutation_enabled = true;
+          }
+        }
+        if (pos == std::string::npos) {
+          break;
+        }
+        contents.erase(0, pos + 1);
+      }
+    }
+    initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
+  }
+  return (enabled_bitset[local_mutation_id / 64] & (static_cast<uint64_t>(1) << (local_mutation_id % 64))) != 0;
+}
+
+static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 0;
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
+  return arg;
+}
+
+[[nodiscard]] static int foo() {
+  if (!__dredd_enabled_mutation(6)) { return __dredd_replace_expr_int(42, 0); }
+}

--- a/test/single_file/nodiscard_macro.cc
+++ b/test/single_file/nodiscard_macro.cc
@@ -1,0 +1,5 @@
+#define NODISCARD [[nodiscard]]
+
+NODISCARD static int foo() {
+  return 42;
+}

--- a/test/single_file/nodiscard_macro.cc.expected
+++ b/test/single_file/nodiscard_macro.cc.expected
@@ -1,0 +1,59 @@
+#include <cinttypes>
+#include <cstddef>
+#include <functional>
+#include <string>
+
+
+#ifdef _MSC_VER
+#define thread_local __declspec(thread)
+#elif __APPLE__
+#define thread_local __thread
+#endif
+
+static thread_local bool __dredd_some_mutation_enabled = true;
+static bool __dredd_enabled_mutation(int local_mutation_id) {
+  static thread_local bool initialized = false;
+  static thread_local uint64_t enabled_bitset[1];
+  if (!initialized) {
+    bool some_mutation_enabled = false;
+    const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
+    if (dredd_environment_variable != nullptr) {
+      std::string contents(dredd_environment_variable);
+      while (true) {
+        size_t pos = contents.find(",");
+        std::string token = (pos == std::string::npos ? contents : contents.substr(0, pos));
+        if (!token.empty()) {
+          int value = std::stoi(token);
+          int local_value = value - 0;
+          if (local_value >= 0 && local_value < 6) {
+            enabled_bitset[local_value / 64] |= (static_cast<uint64_t>(1) << (local_value % 64));
+            some_mutation_enabled = true;
+          }
+        }
+        if (pos == std::string::npos) {
+          break;
+        }
+        contents.erase(0, pos + 1);
+      }
+    }
+    initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
+  }
+  return (enabled_bitset[local_mutation_id / 64] & (static_cast<uint64_t>(1) << (local_mutation_id % 64))) != 0;
+}
+
+static int __dredd_replace_expr_int_constant(int arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return -(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 0;
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return -1;
+  return arg;
+}
+
+#define NODISCARD [[nodiscard]]
+
+NODISCARD static int foo() {
+  if (!__dredd_enabled_mutation(5)) { return __dredd_replace_expr_int_constant(42, 0); }
+}

--- a/test/single_file/nodiscard_macro.cc.noopt.expected
+++ b/test/single_file/nodiscard_macro.cc.noopt.expected
@@ -1,0 +1,60 @@
+#include <cinttypes>
+#include <cstddef>
+#include <functional>
+#include <string>
+
+
+#ifdef _MSC_VER
+#define thread_local __declspec(thread)
+#elif __APPLE__
+#define thread_local __thread
+#endif
+
+static thread_local bool __dredd_some_mutation_enabled = true;
+static bool __dredd_enabled_mutation(int local_mutation_id) {
+  static thread_local bool initialized = false;
+  static thread_local uint64_t enabled_bitset[1];
+  if (!initialized) {
+    bool some_mutation_enabled = false;
+    const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
+    if (dredd_environment_variable != nullptr) {
+      std::string contents(dredd_environment_variable);
+      while (true) {
+        size_t pos = contents.find(",");
+        std::string token = (pos == std::string::npos ? contents : contents.substr(0, pos));
+        if (!token.empty()) {
+          int value = std::stoi(token);
+          int local_value = value - 0;
+          if (local_value >= 0 && local_value < 7) {
+            enabled_bitset[local_value / 64] |= (static_cast<uint64_t>(1) << (local_value % 64));
+            some_mutation_enabled = true;
+          }
+        }
+        if (pos == std::string::npos) {
+          break;
+        }
+        contents.erase(0, pos + 1);
+      }
+    }
+    initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
+  }
+  return (enabled_bitset[local_mutation_id / 64] & (static_cast<uint64_t>(1) << (local_mutation_id % 64))) != 0;
+}
+
+static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 0;
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
+  return arg;
+}
+
+#define NODISCARD [[nodiscard]]
+
+NODISCARD static int foo() {
+  if (!__dredd_enabled_mutation(6)) { return __dredd_replace_expr_int(42, 0); }
+}

--- a/test/single_file/noreturn.cc
+++ b/test/single_file/noreturn.cc
@@ -1,0 +1,7 @@
+#include <cstdlib>
+#include <iostream>
+
+[[noreturn]] static int foo() {
+  std::cout << "Aborting\n";
+  std::abort();
+}

--- a/test/single_file/noreturn.cc.expected
+++ b/test/single_file/noreturn.cc.expected
@@ -1,0 +1,51 @@
+#include <cstdlib>
+#include <iostream>
+
+#include <cinttypes>
+#include <cstddef>
+#include <functional>
+#include <string>
+
+
+#ifdef _MSC_VER
+#define thread_local __declspec(thread)
+#elif __APPLE__
+#define thread_local __thread
+#endif
+
+static thread_local bool __dredd_some_mutation_enabled = true;
+static bool __dredd_enabled_mutation(int local_mutation_id) {
+  static thread_local bool initialized = false;
+  static thread_local uint64_t enabled_bitset[1];
+  if (!initialized) {
+    bool some_mutation_enabled = false;
+    const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
+    if (dredd_environment_variable != nullptr) {
+      std::string contents(dredd_environment_variable);
+      while (true) {
+        size_t pos = contents.find(",");
+        std::string token = (pos == std::string::npos ? contents : contents.substr(0, pos));
+        if (!token.empty()) {
+          int value = std::stoi(token);
+          int local_value = value - 0;
+          if (local_value >= 0 && local_value < 2) {
+            enabled_bitset[local_value / 64] |= (static_cast<uint64_t>(1) << (local_value % 64));
+            some_mutation_enabled = true;
+          }
+        }
+        if (pos == std::string::npos) {
+          break;
+        }
+        contents.erase(0, pos + 1);
+      }
+    }
+    initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
+  }
+  return (enabled_bitset[local_mutation_id / 64] & (static_cast<uint64_t>(1) << (local_mutation_id % 64))) != 0;
+}
+
+[[noreturn]] static int foo() {
+  if (!__dredd_enabled_mutation(0)) { std::cout << "Aborting\n"; }
+  if (!__dredd_enabled_mutation(1)) { std::abort(); }
+}

--- a/test/single_file/noreturn.cc.noopt.expected
+++ b/test/single_file/noreturn.cc.noopt.expected
@@ -1,0 +1,51 @@
+#include <cstdlib>
+#include <iostream>
+
+#include <cinttypes>
+#include <cstddef>
+#include <functional>
+#include <string>
+
+
+#ifdef _MSC_VER
+#define thread_local __declspec(thread)
+#elif __APPLE__
+#define thread_local __thread
+#endif
+
+static thread_local bool __dredd_some_mutation_enabled = true;
+static bool __dredd_enabled_mutation(int local_mutation_id) {
+  static thread_local bool initialized = false;
+  static thread_local uint64_t enabled_bitset[1];
+  if (!initialized) {
+    bool some_mutation_enabled = false;
+    const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
+    if (dredd_environment_variable != nullptr) {
+      std::string contents(dredd_environment_variable);
+      while (true) {
+        size_t pos = contents.find(",");
+        std::string token = (pos == std::string::npos ? contents : contents.substr(0, pos));
+        if (!token.empty()) {
+          int value = std::stoi(token);
+          int local_value = value - 0;
+          if (local_value >= 0 && local_value < 2) {
+            enabled_bitset[local_value / 64] |= (static_cast<uint64_t>(1) << (local_value % 64));
+            some_mutation_enabled = true;
+          }
+        }
+        if (pos == std::string::npos) {
+          break;
+        }
+        contents.erase(0, pos + 1);
+      }
+    }
+    initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
+  }
+  return (enabled_bitset[local_mutation_id / 64] & (static_cast<uint64_t>(1) << (local_mutation_id % 64))) != 0;
+}
+
+[[noreturn]] static int foo() {
+  if (!__dredd_enabled_mutation(0)) { std::cout << "Aborting\n"; }
+  if (!__dredd_enabled_mutation(1)) { std::abort(); }
+}


### PR DESCRIPTION
Uses libTooling's "associated range" facility to ensure that attributes are captured in the function source range before which Dredd's prelude should be written.

Fixes #318.