### PR TITLE
Add support for __dredd_prelude_start()

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ To work on Dredd from CLion, open the `CMakeLists.txt` within the root of the Dr
 
 If the code being mutated contains very large expressions, Dredd's mutation may introduce deep nests of lambda functions.
 In extreme cases these may exceed the maximum bracket nesting level supported by a compiler.
-See (this issue)[https://github.com/mc-imperial/dredd/issues/288] for an example.
+See [this issue](https://github.com/mc-imperial/dredd/issues/288) for an example.
 To work around this, you may need to:
 
 - use a compiler option (such as Clang's `-fbracket-depth=N`) to increase the maximum nesting level, or
@@ -336,6 +336,21 @@ programming practices.
 For example, Dredd wraps `return` statements in conditional blocks (to simulate statement deletion), which will lead to warnings that not all paths through a function return a value.
 If your project treats compiler warnings as errors then you will need to disable
 this feature in your project's build configuration.
+
+### Dredd's prelude is injected at an inappropriate location in a source file
+
+The mutations that Dredd applies rely on a number of function definitions that must be present at a suitable point in each file that Dredd mutates.
+These are referred to as the Dredd *prelude*.
+Dredd uses a heuristic to determine where to place its prelude.
+Sometimes this heuristic may not find an appropriate place, e.g. because of limitations or bugs in Clang's libTooling (see [this issue](https://github.com/mc-imperial/dredd/issues/322) for example).
+
+If you face a problem where Dredd-mutated code does not compile due to the Dredd prelude being injected in a bad place, you can declare a function prototype with void return type and no arguments called `__dredd_prelude_start` somewhere in your source file.
+Dredd will then insert its prelude right before this function prototype (regardless of whether this is a sensible place to insert the prelude).
+The signature of this prototype is:
+
+```
+void __dredd_prelude_start();
+```
 
 ## Planned features
 

--- a/src/libdredd/include_private/include/libdredd/mutate_visitor.h
+++ b/src/libdredd/include_private/include/libdredd/mutate_visitor.h
@@ -110,6 +110,16 @@ class MutateVisitor : public clang::RecursiveASTVisitor<MutateVisitor> {
     return constant_sized_arrays_to_rewrite_;
   }
 
+  [[nodiscard]] bool HasDreddPreludeStartLocation() const {
+    return dredd_prelude_start_location_.has_value();
+  }
+
+  [[nodiscard]] clang::SourceLocation GetDreddPreludeStartLocation() const {
+    assert(HasDreddPreludeStartLocation() &&
+           "No Dredd prelude starting function was found");
+    return dredd_prelude_start_location_.value();
+  }
+
   [[nodiscard]] clang::SourceLocation
   GetStartLocationOfFirstFunctionInSourceFile() const {
     return start_location_of_first_function_in_source_file_;
@@ -219,8 +229,16 @@ class MutateVisitor : public clang::RecursiveASTVisitor<MutateVisitor> {
   const clang::CompilerInstance* compiler_instance_;
   bool optimise_mutations_;
 
+  // The begin location of a special function that can be written to indicate
+  // where the Dredd prelude should be inserted. This is useful to cater for
+  // cases where the heuristic that Dredd uses to insert its prelude would lead
+  // to compilation problems.
+  std::optional<clang::SourceLocation> dredd_prelude_start_location_;
+
   // Records the start location of the very first function definition in the
-  // source file, before which Dredd's prelude can be placed.
+  // source file. Dredd's prelude will be placed before this if it is a valid
+  // source location, unless a special Dredd prelude starting function has been
+  // declared.
   clang::SourceLocation start_location_of_first_function_in_source_file_;
 
   // Tracks the nest of declarations currently being traversed. Any new Dredd

--- a/src/libdredd/include_private/include/libdredd/mutate_visitor.h
+++ b/src/libdredd/include_private/include/libdredd/mutate_visitor.h
@@ -15,7 +15,9 @@
 #ifndef LIBDREDD_MUTATE_VISITOR_H
 #define LIBDREDD_MUTATE_VISITOR_H
 
+#include <cassert>
 #include <memory>
+#include <optional>
 #include <set>
 #include <unordered_set>
 #include <utility>

--- a/src/libdredd/src/mutate_ast_consumer.cc
+++ b/src/libdredd/src/mutate_ast_consumer.cc
@@ -45,6 +45,17 @@
 
 namespace dredd {
 
+namespace {
+const char* const kDreddPreludeStartComment =
+    "// DREDD PRELUDE START\n"
+    "// If this has been inserted at an inappropriate place in a source file,\n"
+    "// declare a placeholder function with the following signature to\n"
+    "// mandate where the prelude should be placed:\n"
+    "//\n"
+    "// void __dredd_prelude_start();\n"
+    "//\n";
+}  // namespace
+
 void MutateAstConsumer::HandleTranslationUnit(clang::ASTContext& ast_context) {
   const std::string filename =
       ast_context.getSourceManager()
@@ -336,10 +347,10 @@ std::string MutateAstConsumer::GetMutantTrackingDreddPreludeCpp(
 
 std::string MutateAstConsumer::GetDreddPreludeCpp(
     int initial_mutation_id) const {
-  if (only_track_mutant_coverage_) {
-    return GetMutantTrackingDreddPreludeCpp(initial_mutation_id);
-  }
-  return GetRegularDreddPreludeCpp(initial_mutation_id);
+  return kDreddPreludeStartComment +
+         (only_track_mutant_coverage_
+              ? GetMutantTrackingDreddPreludeCpp(initial_mutation_id)
+              : GetRegularDreddPreludeCpp(initial_mutation_id));
 }
 
 std::string MutateAstConsumer::GetRegularDreddPreludeC(
@@ -435,10 +446,10 @@ std::string MutateAstConsumer::GetMutantTrackingDreddPreludeC(
 }
 
 std::string MutateAstConsumer::GetDreddPreludeC(int initial_mutation_id) const {
-  if (only_track_mutant_coverage_) {
-    return GetMutantTrackingDreddPreludeC(initial_mutation_id);
-  }
-  return GetRegularDreddPreludeC(initial_mutation_id);
+  return kDreddPreludeStartComment +
+         (only_track_mutant_coverage_
+              ? GetMutantTrackingDreddPreludeC(initial_mutation_id)
+              : GetRegularDreddPreludeC(initial_mutation_id));
 }
 
 void MutateAstConsumer::ApplyMutations(

--- a/src/libdredd/src/mutate_ast_consumer.cc
+++ b/src/libdredd/src/mutate_ast_consumer.cc
@@ -155,9 +155,11 @@ void MutateAstConsumer::HandleTranslationUnit(clang::ASTContext& ast_context) {
             .getLimitedValue());
   }
 
-  const clang::SourceLocation start_location_of_first_function_in_source_file =
-      visitor_->GetStartLocationOfFirstFunctionInSourceFile();
-  assert(start_location_of_first_function_in_source_file.isValid() &&
+  const clang::SourceLocation dredd_prelude_start_location =
+      visitor_->HasDreddPreludeStartLocation()
+          ? visitor_->GetDreddPreludeStartLocation()
+          : visitor_->GetStartLocationOfFirstFunctionInSourceFile();
+  assert(dredd_prelude_start_location.isValid() &&
          "There is at least one mutation, therefore there must be at least one "
          "function.");
 
@@ -167,8 +169,8 @@ void MutateAstConsumer::HandleTranslationUnit(clang::ASTContext& ast_context) {
   sorted_dredd_declarations.insert(dredd_declarations.begin(),
                                    dredd_declarations.end());
   for (const auto& decl : sorted_dredd_declarations) {
-    const bool rewriter_result = rewriter_.InsertTextBefore(
-        start_location_of_first_function_in_source_file, decl);
+    const bool rewriter_result =
+        rewriter_.InsertTextBefore(dredd_prelude_start_location, decl);
     (void)rewriter_result;  // Keep release-mode compilers happy.
     assert(!rewriter_result && "Rewrite failed.\n");
   }
@@ -178,8 +180,8 @@ void MutateAstConsumer::HandleTranslationUnit(clang::ASTContext& ast_context) {
           ? GetDreddPreludeCpp(initial_mutation_id)
           : GetDreddPreludeC(initial_mutation_id);
 
-  bool rewriter_result = rewriter_.InsertTextBefore(
-      start_location_of_first_function_in_source_file, dredd_prelude);
+  bool rewriter_result =
+      rewriter_.InsertTextBefore(dredd_prelude_start_location, dredd_prelude);
   (void)rewriter_result;  // Keep release-mode compilers happy.
   assert(!rewriter_result && "Rewrite failed.\n");
 

--- a/src/libdredd/src/mutate_visitor.cc
+++ b/src/libdredd/src/mutate_visitor.cc
@@ -169,6 +169,12 @@ bool MutateVisitor::TraverseDecl(clang::Decl* decl) {
     return true;
   }
   if (const auto* function_decl = llvm::dyn_cast<clang::FunctionDecl>(decl)) {
+    if (function_decl->getNameAsString() == "__dredd_prelude_start" &&
+        !HasDreddPreludeStartLocation()) {
+      // This is a special function provided by the user to record where the
+      // Dredd prelude should be inserted.
+      dredd_prelude_start_location_ = function_decl->getBeginLoc();
+    }
     if (function_decl->isConstexpr()) {
       // Because Dredd's mutations occur dynamically, they cannot be applied to
       // C++ constexpr functions, which require compile-time evaluation.

--- a/src/libdredd/src/mutate_visitor.cc
+++ b/src/libdredd/src/mutate_visitor.cc
@@ -18,6 +18,7 @@
 #include <cstddef>
 #include <memory>
 #include <optional>
+#include <string>
 
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Attrs.inc"

--- a/test/single_file/add.c.expected
+++ b/test/single_file/add.c.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/add.c.noopt.expected
+++ b/test/single_file/add.c.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/add.cc.expected
+++ b/test/single_file/add.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/add.cc.noopt.expected
+++ b/test/single_file/add.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/add_float.c.expected
+++ b/test/single_file/add_float.c.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/add_float.c.noopt.expected
+++ b/test/single_file/add_float.c.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/add_float.cc.expected
+++ b/test/single_file/add_float.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/add_float.cc.noopt.expected
+++ b/test/single_file/add_float.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/add_mul.c.expected
+++ b/test/single_file/add_mul.c.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/add_mul.c.noopt.expected
+++ b/test/single_file/add_mul.c.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/add_mul.cc.expected
+++ b/test/single_file/add_mul.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/add_mul.cc.noopt.expected
+++ b/test/single_file/add_mul.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/add_type_aliases.c.noopt.expected
+++ b/test/single_file/add_type_aliases.c.noopt.expected
@@ -1,6 +1,13 @@
 #include <inttypes.h>
 #include <stddef.h>
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/add_type_aliases.cc.noopt.expected
+++ b/test/single_file/add_type_aliases.cc.noopt.expected
@@ -1,6 +1,13 @@
 #include <cinttypes>
 #include <cstddef>
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/adl.cc.expected
+++ b/test/single_file/adl.cc.expected
@@ -9,6 +9,13 @@ namespace bar {
   };
 }
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/adl.cc.noopt.expected
+++ b/test/single_file/adl.cc.noopt.expected
@@ -9,6 +9,13 @@ namespace bar {
   };
 }
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/array_with_named_constant_size_rewrite.cc.expected
+++ b/test/single_file/array_with_named_constant_size_rewrite.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/array_with_named_constant_size_rewrite.cc.noopt.expected
+++ b/test/single_file/array_with_named_constant_size_rewrite.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/array_with_named_constant_size_rewrite2.cc.expected
+++ b/test/single_file/array_with_named_constant_size_rewrite2.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/array_with_named_constant_size_rewrite2.cc.noopt.expected
+++ b/test/single_file/array_with_named_constant_size_rewrite2.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/assign.c.expected
+++ b/test/single_file/assign.c.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/assign.c.noopt.expected
+++ b/test/single_file/assign.c.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/assign.cc.expected
+++ b/test/single_file/assign.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/assign.cc.noopt.expected
+++ b/test/single_file/assign.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/auto.cc.expected
+++ b/test/single_file/auto.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/auto.cc.noopt.expected
+++ b/test/single_file/auto.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/basic.c.expected
+++ b/test/single_file/basic.c.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/basic.c.noopt.expected
+++ b/test/single_file/basic.c.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/basic.cc.expected
+++ b/test/single_file/basic.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/basic.cc.noopt.expected
+++ b/test/single_file/basic.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/binary_both_zero.cc.expected
+++ b/test/single_file/binary_both_zero.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/binary_both_zero.cc.noopt.expected
+++ b/test/single_file/binary_both_zero.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/binary_lhs_zero.cc.expected
+++ b/test/single_file/binary_lhs_zero.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/binary_lhs_zero.cc.noopt.expected
+++ b/test/single_file/binary_lhs_zero.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/binary_long_long_and_long_name_clash.c.noopt.expected
+++ b/test/single_file/binary_long_long_and_long_name_clash.c.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/binary_no_arg_replacement.cc.expected
+++ b/test/single_file/binary_no_arg_replacement.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/binary_no_arg_replacement.cc.noopt.expected
+++ b/test/single_file/binary_no_arg_replacement.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/binary_operands_both_zero.c.expected
+++ b/test/single_file/binary_operands_both_zero.c.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/binary_operands_both_zero.c.noopt.expected
+++ b/test/single_file/binary_operands_both_zero.c.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/binary_operands_both_zero.cc.expected
+++ b/test/single_file/binary_operands_both_zero.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/binary_operands_both_zero.cc.noopt.expected
+++ b/test/single_file/binary_operands_both_zero.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/binary_redundant_name_clash.cc.expected
+++ b/test/single_file/binary_redundant_name_clash.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/binary_redundant_name_clash.cc.noopt.expected
+++ b/test/single_file/binary_redundant_name_clash.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/binary_rhs_zero.cc.expected
+++ b/test/single_file/binary_rhs_zero.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/binary_rhs_zero.cc.noopt.expected
+++ b/test/single_file/binary_rhs_zero.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/bitfield.c.expected
+++ b/test/single_file/bitfield.c.expected
@@ -3,6 +3,13 @@ struct S {
   int b : 3;
 };
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/bitfield.c.noopt.expected
+++ b/test/single_file/bitfield.c.noopt.expected
@@ -3,6 +3,13 @@ struct S {
   int b : 3;
 };
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/bitfield.cc.expected
+++ b/test/single_file/bitfield.cc.expected
@@ -3,6 +3,13 @@ struct S {
   int b : 3;
 };
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/bitfield.cc.noopt.expected
+++ b/test/single_file/bitfield.cc.noopt.expected
@@ -3,6 +3,13 @@ struct S {
   int b : 3;
 };
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/bitfield_reference_passing.cc.expected
+++ b/test/single_file/bitfield_reference_passing.cc.expected
@@ -4,6 +4,13 @@ struct foo {
   int b : 2;
 };
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/bitfield_reference_passing.cc.noopt.expected
+++ b/test/single_file/bitfield_reference_passing.cc.noopt.expected
@@ -4,6 +4,13 @@ struct foo {
   int b : 2;
 };
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/bool_assignment.cc.expected
+++ b/test/single_file/bool_assignment.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/bool_assignment.cc.noopt.expected
+++ b/test/single_file/bool_assignment.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/boolean_not_insertion_optimisation.c.expected
+++ b/test/single_file/boolean_not_insertion_optimisation.c.expected
@@ -1,5 +1,12 @@
 #include <stdbool.h>
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/boolean_not_insertion_optimisation.c.noopt.expected
+++ b/test/single_file/boolean_not_insertion_optimisation.c.noopt.expected
@@ -1,5 +1,12 @@
 #include <stdbool.h>
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/boolean_not_insertion_optimisation.cc.expected
+++ b/test/single_file/boolean_not_insertion_optimisation.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/boolean_not_insertion_optimisation.cc.noopt.expected
+++ b/test/single_file/boolean_not_insertion_optimisation.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/braced_initialization.cc.expected
+++ b/test/single_file/braced_initialization.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/braced_initialization.cc.noopt.expected
+++ b/test/single_file/braced_initialization.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/builtin_frame_address.cc.expected
+++ b/test/single_file/builtin_frame_address.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/builtin_frame_address.cc.noopt.expected
+++ b/test/single_file/builtin_frame_address.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/builtin_frame_address_with_argument_rewrite.cc.expected
+++ b/test/single_file/builtin_frame_address_with_argument_rewrite.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/builtin_frame_address_with_argument_rewrite.cc.noopt.expected
+++ b/test/single_file/builtin_frame_address_with_argument_rewrite.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/comma.c.expected
+++ b/test/single_file/comma.c.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/comma.c.noopt.expected
+++ b/test/single_file/comma.c.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/comma_initialization.c.expected
+++ b/test/single_file/comma_initialization.c.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/comma_initialization.c.noopt.expected
+++ b/test/single_file/comma_initialization.c.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/comma_initialization.cc.expected
+++ b/test/single_file/comma_initialization.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/comma_initialization.cc.noopt.expected
+++ b/test/single_file/comma_initialization.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/comma_side_effects.c.expected
+++ b/test/single_file/comma_side_effects.c.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/comma_side_effects.c.noopt.expected
+++ b/test/single_file/comma_side_effects.c.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/comma_side_effects.cc.expected
+++ b/test/single_file/comma_side_effects.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/comma_side_effects.cc.noopt.expected
+++ b/test/single_file/comma_side_effects.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/comment.cc.expected
+++ b/test/single_file/comment.cc.expected
@@ -1,5 +1,12 @@
 void g();
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/comment.cc.noopt.expected
+++ b/test/single_file/comment.cc.noopt.expected
@@ -1,5 +1,12 @@
 void g();
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/comment_at_start_of_file.cc.expected
+++ b/test/single_file/comment_at_start_of_file.cc.expected
@@ -1,5 +1,12 @@
 // Hello
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/comment_at_start_of_file.cc.noopt.expected
+++ b/test/single_file/comment_at_start_of_file.cc.noopt.expected
@@ -1,5 +1,12 @@
 // Hello
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/const_expr.cc.expected
+++ b/test/single_file/const_expr.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/const_expr.cc.noopt.expected
+++ b/test/single_file/const_expr.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/const_expr_function.cc.expected
+++ b/test/single_file/const_expr_function.cc.expected
@@ -1,5 +1,12 @@
 constexpr int Max(int a, int b) { return a > b ? a : b; }
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/const_expr_function.cc.noopt.expected
+++ b/test/single_file/const_expr_function.cc.noopt.expected
@@ -1,5 +1,12 @@
 constexpr int Max(int a, int b) { return a > b ? a : b; }
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/const_expr_function_call.cc.expected
+++ b/test/single_file/const_expr_function_call.cc.expected
@@ -1,5 +1,12 @@
 constexpr int Max(int a, int b) { return a > b ? a : b; }
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/const_expr_function_call.cc.noopt.expected
+++ b/test/single_file/const_expr_function_call.cc.noopt.expected
@@ -1,5 +1,12 @@
 constexpr int Max(int a, int b) { return a > b ? a : b; }
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/const_sized_array_int.c.expected
+++ b/test/single_file/const_sized_array_int.c.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/const_sized_array_int.c.noopt.expected
+++ b/test/single_file/const_sized_array_int.c.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/const_sized_array_int.cc.expected
+++ b/test/single_file/const_sized_array_int.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/const_sized_array_int.cc.noopt.expected
+++ b/test/single_file/const_sized_array_int.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/constexpr_array.cc.expected
+++ b/test/single_file/constexpr_array.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/constexpr_array.cc.noopt.expected
+++ b/test/single_file/constexpr_array.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/constexpr_if1.cc.expected
+++ b/test/single_file/constexpr_if1.cc.expected
@@ -1,5 +1,12 @@
 #include <iostream>
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/constexpr_if1.cc.noopt.expected
+++ b/test/single_file/constexpr_if1.cc.noopt.expected
@@ -1,5 +1,12 @@
 #include <iostream>
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/constexpr_if2.cc.expected
+++ b/test/single_file/constexpr_if2.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/constexpr_if2.cc.noopt.expected
+++ b/test/single_file/constexpr_if2.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/construct_struct_from_enum_constant.cc.expected
+++ b/test/single_file/construct_struct_from_enum_constant.cc.expected
@@ -5,6 +5,13 @@ struct foo {
 
 enum baz { bar };
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/construct_struct_from_enum_constant.cc.noopt.expected
+++ b/test/single_file/construct_struct_from_enum_constant.cc.noopt.expected
@@ -5,6 +5,13 @@ struct foo {
 
 enum baz { bar };
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/decltype_cast.cc.expected
+++ b/test/single_file/decltype_cast.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/decltype_cast.cc.noopt.expected
+++ b/test/single_file/decltype_cast.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/decltype_cast_function_call.cc.expected
+++ b/test/single_file/decltype_cast_function_call.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/decltype_cast_function_call.cc.noopt.expected
+++ b/test/single_file/decltype_cast_function_call.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/define_at_start_of_file.c.expected
+++ b/test/single_file/define_at_start_of_file.c.expected
@@ -1,6 +1,13 @@
 #define API
 API int func1();
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/define_at_start_of_file.c.noopt.expected
+++ b/test/single_file/define_at_start_of_file.c.noopt.expected
@@ -1,6 +1,13 @@
 #define API
 API int func1();
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/define_in_first_decl.c.expected
+++ b/test/single_file/define_in_first_decl.c.expected
@@ -1,5 +1,12 @@
 #define TYPE int
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/define_in_first_decl.c.noopt.expected
+++ b/test/single_file/define_in_first_decl.c.noopt.expected
@@ -1,5 +1,12 @@
 #define TYPE int
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/define_in_first_decl.cc.expected
+++ b/test/single_file/define_in_first_decl.cc.expected
@@ -1,5 +1,12 @@
 #define TYPE int
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/define_in_first_decl.cc.noopt.expected
+++ b/test/single_file/define_in_first_decl.cc.noopt.expected
@@ -1,5 +1,12 @@
 #define TYPE int
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/do_not_mutate_under_alignof.cc.expected
+++ b/test/single_file/do_not_mutate_under_alignof.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/do_not_mutate_under_alignof.cc.noopt.expected
+++ b/test/single_file/do_not_mutate_under_alignof.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/do_not_mutate_under_sizeof.c.expected
+++ b/test/single_file/do_not_mutate_under_sizeof.c.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/do_not_mutate_under_sizeof.c.noopt.expected
+++ b/test/single_file/do_not_mutate_under_sizeof.c.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/dredd_prelude_start.cc
+++ b/test/single_file/dredd_prelude_start.cc
@@ -1,0 +1,14 @@
+class foo {
+public:
+  virtual void bar() = 0;
+};
+
+class a : foo {
+  void bar() override;
+};
+
+void __dredd_prelude_start();
+
+void a::bar() {
+  int x = 2;
+}

--- a/test/single_file/dredd_prelude_start.cc.expected
+++ b/test/single_file/dredd_prelude_start.cc.expected
@@ -1,0 +1,68 @@
+class foo {
+public:
+  virtual void bar() = 0;
+};
+
+class a : foo {
+  void bar() override;
+};
+
+#include <cinttypes>
+#include <cstddef>
+#include <functional>
+#include <string>
+
+
+#ifdef _MSC_VER
+#define thread_local __declspec(thread)
+#elif __APPLE__
+#define thread_local __thread
+#endif
+
+static thread_local bool __dredd_some_mutation_enabled = true;
+static bool __dredd_enabled_mutation(int local_mutation_id) {
+  static thread_local bool initialized = false;
+  static thread_local uint64_t enabled_bitset[1];
+  if (!initialized) {
+    bool some_mutation_enabled = false;
+    const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
+    if (dredd_environment_variable != nullptr) {
+      std::string contents(dredd_environment_variable);
+      while (true) {
+        size_t pos = contents.find(",");
+        std::string token = (pos == std::string::npos ? contents : contents.substr(0, pos));
+        if (!token.empty()) {
+          int value = std::stoi(token);
+          int local_value = value - 0;
+          if (local_value >= 0 && local_value < 5) {
+            enabled_bitset[local_value / 64] |= (static_cast<uint64_t>(1) << (local_value % 64));
+            some_mutation_enabled = true;
+          }
+        }
+        if (pos == std::string::npos) {
+          break;
+        }
+        contents.erase(0, pos + 1);
+      }
+    }
+    initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
+  }
+  return (enabled_bitset[local_mutation_id / 64] & (static_cast<uint64_t>(1) << (local_mutation_id % 64))) != 0;
+}
+
+static int __dredd_replace_expr_int_constant(int arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return -(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 0;
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return -1;
+  return arg;
+}
+
+void __dredd_prelude_start();
+
+void a::bar() {
+  int x = __dredd_replace_expr_int_constant(2, 0);
+}

--- a/test/single_file/dredd_prelude_start.cc.expected
+++ b/test/single_file/dredd_prelude_start.cc.expected
@@ -7,6 +7,13 @@ class a : foo {
   void bar() override;
 };
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/dredd_prelude_start.cc.noopt.expected
+++ b/test/single_file/dredd_prelude_start.cc.noopt.expected
@@ -1,0 +1,69 @@
+class foo {
+public:
+  virtual void bar() = 0;
+};
+
+class a : foo {
+  void bar() override;
+};
+
+#include <cinttypes>
+#include <cstddef>
+#include <functional>
+#include <string>
+
+
+#ifdef _MSC_VER
+#define thread_local __declspec(thread)
+#elif __APPLE__
+#define thread_local __thread
+#endif
+
+static thread_local bool __dredd_some_mutation_enabled = true;
+static bool __dredd_enabled_mutation(int local_mutation_id) {
+  static thread_local bool initialized = false;
+  static thread_local uint64_t enabled_bitset[1];
+  if (!initialized) {
+    bool some_mutation_enabled = false;
+    const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
+    if (dredd_environment_variable != nullptr) {
+      std::string contents(dredd_environment_variable);
+      while (true) {
+        size_t pos = contents.find(",");
+        std::string token = (pos == std::string::npos ? contents : contents.substr(0, pos));
+        if (!token.empty()) {
+          int value = std::stoi(token);
+          int local_value = value - 0;
+          if (local_value >= 0 && local_value < 6) {
+            enabled_bitset[local_value / 64] |= (static_cast<uint64_t>(1) << (local_value % 64));
+            some_mutation_enabled = true;
+          }
+        }
+        if (pos == std::string::npos) {
+          break;
+        }
+        contents.erase(0, pos + 1);
+      }
+    }
+    initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
+  }
+  return (enabled_bitset[local_mutation_id / 64] & (static_cast<uint64_t>(1) << (local_mutation_id % 64))) != 0;
+}
+
+static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 0;
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
+  return arg;
+}
+
+void __dredd_prelude_start();
+
+void a::bar() {
+  int x = __dredd_replace_expr_int(2, 0);
+}

--- a/test/single_file/dredd_prelude_start.cc.noopt.expected
+++ b/test/single_file/dredd_prelude_start.cc.noopt.expected
@@ -7,6 +7,13 @@ class a : foo {
   void bar() override;
 };
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/enum.c.noopt.expected
+++ b/test/single_file/enum.c.noopt.expected
@@ -3,6 +3,13 @@ enum A {
   Y
 };
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/expr_lvalue.c.expected
+++ b/test/single_file/expr_lvalue.c.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/expr_lvalue.c.noopt.expected
+++ b/test/single_file/expr_lvalue.c.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/expr_lvalue.cc.expected
+++ b/test/single_file/expr_lvalue.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/expr_lvalue.cc.noopt.expected
+++ b/test/single_file/expr_lvalue.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/expr_macro.c.expected
+++ b/test/single_file/expr_macro.c.expected
@@ -2,6 +2,13 @@
 
 void foo(int, int, int);
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/expr_macro.c.noopt.expected
+++ b/test/single_file/expr_macro.c.noopt.expected
@@ -2,6 +2,13 @@
 
 void foo(int, int, int);
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/expr_macro.cc.expected
+++ b/test/single_file/expr_macro.cc.expected
@@ -2,6 +2,13 @@
 
 void foo(int, int, int);
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/expr_macro.cc.noopt.expected
+++ b/test/single_file/expr_macro.cc.noopt.expected
@@ -2,6 +2,13 @@
 
 void foo(int, int, int);
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/float_binary_opts.c.expected
+++ b/test/single_file/float_binary_opts.c.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/float_binary_opts.c.noopt.expected
+++ b/test/single_file/float_binary_opts.c.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/float_binary_opts.cc.expected
+++ b/test/single_file/float_binary_opts.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/float_binary_opts.cc.noopt.expected
+++ b/test/single_file/float_binary_opts.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/float_unary_opt.c.expected
+++ b/test/single_file/float_unary_opt.c.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/float_unary_opt.c.noopt.expected
+++ b/test/single_file/float_unary_opt.c.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/float_unary_opt.cc.expected
+++ b/test/single_file/float_unary_opt.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/float_unary_opt.cc.noopt.expected
+++ b/test/single_file/float_unary_opt.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/floats.c.expected
+++ b/test/single_file/floats.c.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/floats.c.noopt.expected
+++ b/test/single_file/floats.c.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/floats.cc.expected
+++ b/test/single_file/floats.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/floats.cc.noopt.expected
+++ b/test/single_file/floats.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/initializer.c.expected
+++ b/test/single_file/initializer.c.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/initializer.c.noopt.expected
+++ b/test/single_file/initializer.c.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/initializer.cc.expected
+++ b/test/single_file/initializer.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/initializer.cc.noopt.expected
+++ b/test/single_file/initializer.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/initializer_list.cc.expected
+++ b/test/single_file/initializer_list.cc.expected
@@ -7,6 +7,13 @@ struct A {
 
 void foo(A arg);
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/initializer_list.cc.noopt.expected
+++ b/test/single_file/initializer_list.cc.noopt.expected
@@ -7,6 +7,13 @@ struct A {
 
 void foo(A arg);
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/initializer_list_long_to_short.cc.expected
+++ b/test/single_file/initializer_list_long_to_short.cc.expected
@@ -5,6 +5,13 @@ public:
   foo(std::initializer_list<short>) {}
 };
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/initializer_list_long_to_short.cc.noopt.expected
+++ b/test/single_file/initializer_list_long_to_short.cc.noopt.expected
@@ -5,6 +5,13 @@ public:
   foo(std::initializer_list<short>) {}
 };
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/initializer_list_narrower.cc.expected
+++ b/test/single_file/initializer_list_narrower.cc.expected
@@ -5,6 +5,13 @@ public:
   foo(std::initializer_list<unsigned int>) {}
 };
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/initializer_list_narrower.cc.noopt.expected
+++ b/test/single_file/initializer_list_narrower.cc.noopt.expected
@@ -5,6 +5,13 @@ public:
   foo(std::initializer_list<unsigned int>) {}
 };
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/initializer_list_narrower_nested.cc.expected
+++ b/test/single_file/initializer_list_narrower_nested.cc.expected
@@ -3,6 +3,13 @@ struct foo {
   short y;
 };
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/initializer_list_narrower_nested.cc.noopt.expected
+++ b/test/single_file/initializer_list_narrower_nested.cc.noopt.expected
@@ -3,6 +3,13 @@ struct foo {
   short y;
 };
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/initializer_list_parenthesis.cc.expected
+++ b/test/single_file/initializer_list_parenthesis.cc.expected
@@ -4,6 +4,13 @@ struct foo {
   short z;
 };
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/initializer_list_parenthesis.cc.noopt.expected
+++ b/test/single_file/initializer_list_parenthesis.cc.noopt.expected
@@ -4,6 +4,13 @@ struct foo {
   short z;
 };
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/lambda_capture.cc.expected
+++ b/test/single_file/lambda_capture.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/lambda_capture.cc.noopt.expected
+++ b/test/single_file/lambda_capture.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/large_summation.c.expected
+++ b/test/single_file/large_summation.c.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/large_summation.c.noopt.expected
+++ b/test/single_file/large_summation.c.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/large_summation.cc.expected
+++ b/test/single_file/large_summation.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/large_summation.cc.noopt.expected
+++ b/test/single_file/large_summation.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/left_shift_opt.c.expected
+++ b/test/single_file/left_shift_opt.c.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/left_shift_opt.c.noopt.expected
+++ b/test/single_file/left_shift_opt.c.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/left_shift_opt.cc.expected
+++ b/test/single_file/left_shift_opt.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/left_shift_opt.cc.noopt.expected
+++ b/test/single_file/left_shift_opt.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/logical_and.c.expected
+++ b/test/single_file/logical_and.c.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/logical_and.c.noopt.expected
+++ b/test/single_file/logical_and.c.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/logical_and.cc.expected
+++ b/test/single_file/logical_and.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/logical_and.cc.noopt.expected
+++ b/test/single_file/logical_and.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/logical_and_div.cc.expected
+++ b/test/single_file/logical_and_div.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/logical_and_div.cc.noopt.expected
+++ b/test/single_file/logical_and_div.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/logical_or.c.expected
+++ b/test/single_file/logical_or.c.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/logical_or.c.noopt.expected
+++ b/test/single_file/logical_or.c.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/logical_or.cc.expected
+++ b/test/single_file/logical_or.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/logical_or.cc.noopt.expected
+++ b/test/single_file/logical_or.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/misc002.cc.expected
+++ b/test/single_file/misc002.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/misc002.cc.noopt.expected
+++ b/test/single_file/misc002.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/misc003.cc.expected
+++ b/test/single_file/misc003.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/misc003.cc.noopt.expected
+++ b/test/single_file/misc003.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/misc004.cc.expected
+++ b/test/single_file/misc004.cc.expected
@@ -2,6 +2,13 @@
 #  error test.h must be #included before system headers
 #endif
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/misc004.cc.noopt.expected
+++ b/test/single_file/misc004.cc.noopt.expected
@@ -2,6 +2,13 @@
 #  error test.h must be #included before system headers
 #endif
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/negative_switch_case.c.expected
+++ b/test/single_file/negative_switch_case.c.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/negative_switch_case.c.noopt.expected
+++ b/test/single_file/negative_switch_case.c.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/negative_switch_case.cc.expected
+++ b/test/single_file/negative_switch_case.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/negative_switch_case.cc.noopt.expected
+++ b/test/single_file/negative_switch_case.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/nested_array_with_named_constant_size_rewrite.cc.expected
+++ b/test/single_file/nested_array_with_named_constant_size_rewrite.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/nested_array_with_named_constant_size_rewrite.cc.noopt.expected
+++ b/test/single_file/nested_array_with_named_constant_size_rewrite.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/new_expr_array_size.cc.expected
+++ b/test/single_file/new_expr_array_size.cc.expected
@@ -3,6 +3,13 @@ public:
   foo(int x) {}
 };
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/new_expr_array_size.cc.noopt.expected
+++ b/test/single_file/new_expr_array_size.cc.noopt.expected
@@ -3,6 +3,13 @@ public:
   foo(int x) {}
 };
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/nodiscard.cc.expected
+++ b/test/single_file/nodiscard.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/nodiscard.cc.noopt.expected
+++ b/test/single_file/nodiscard.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/nodiscard_macro.cc.expected
+++ b/test/single_file/nodiscard_macro.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/nodiscard_macro.cc.noopt.expected
+++ b/test/single_file/nodiscard_macro.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/non_const_sized_array.c.expected
+++ b/test/single_file/non_const_sized_array.c.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/non_const_sized_array.c.noopt.expected
+++ b/test/single_file/non_const_sized_array.c.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/non_const_sized_array.cc.expected
+++ b/test/single_file/non_const_sized_array.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/non_const_sized_array.cc.noopt.expected
+++ b/test/single_file/non_const_sized_array.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/noreturn.cc.expected
+++ b/test/single_file/noreturn.cc.expected
@@ -1,6 +1,13 @@
 #include <cstdlib>
 #include <iostream>
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/noreturn.cc.noopt.expected
+++ b/test/single_file/noreturn.cc.noopt.expected
@@ -1,6 +1,13 @@
 #include <cstdlib>
 #include <iostream>
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/parens.cc.expected
+++ b/test/single_file/parens.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/parens.cc.noopt.expected
+++ b/test/single_file/parens.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/positive_int_as_minus_one.c.expected
+++ b/test/single_file/positive_int_as_minus_one.c.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/positive_int_as_minus_one.c.noopt.expected
+++ b/test/single_file/positive_int_as_minus_one.c.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/positive_int_as_minus_one.cc.expected
+++ b/test/single_file/positive_int_as_minus_one.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/positive_int_as_minus_one.cc.noopt.expected
+++ b/test/single_file/positive_int_as_minus_one.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/post_inc_volatile.c.expected
+++ b/test/single_file/post_inc_volatile.c.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/post_inc_volatile.c.noopt.expected
+++ b/test/single_file/post_inc_volatile.c.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/post_inc_volatile.cc.expected
+++ b/test/single_file/post_inc_volatile.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/post_inc_volatile.cc.noopt.expected
+++ b/test/single_file/post_inc_volatile.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/pre_dec_assign.cc.expected
+++ b/test/single_file/pre_dec_assign.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/pre_dec_assign.cc.noopt.expected
+++ b/test/single_file/pre_dec_assign.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/preprocessor_if.c.expected
+++ b/test/single_file/preprocessor_if.c.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/preprocessor_if.c.noopt.expected
+++ b/test/single_file/preprocessor_if.c.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/printing.c.expected
+++ b/test/single_file/printing.c.expected
@@ -1,5 +1,12 @@
 #include <stdio.h>
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/printing.c.noopt.expected
+++ b/test/single_file/printing.c.noopt.expected
@@ -1,5 +1,12 @@
 #include <stdio.h>
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/printing.cc.expected
+++ b/test/single_file/printing.cc.expected
@@ -1,5 +1,12 @@
 #include <iostream>
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/printing.cc.noopt.expected
+++ b/test/single_file/printing.cc.noopt.expected
@@ -1,5 +1,12 @@
 #include <iostream>
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/signed_int_constants.cc.expected
+++ b/test/single_file/signed_int_constants.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/signed_int_constants.cc.noopt.expected
+++ b/test/single_file/signed_int_constants.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/sizeof_template.cc.expected
+++ b/test/single_file/sizeof_template.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/sizeof_template.cc.noopt.expected
+++ b/test/single_file/sizeof_template.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/sizeof_template2.cc.expected
+++ b/test/single_file/sizeof_template2.cc.expected
@@ -1,5 +1,12 @@
 bool f(int);
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/sizeof_template2.cc.noopt.expected
+++ b/test/single_file/sizeof_template2.cc.noopt.expected
@@ -1,5 +1,12 @@
 bool f(int);
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/space_needed_after_macro.c.expected
+++ b/test/single_file/space_needed_after_macro.c.expected
@@ -1,5 +1,12 @@
 #define BEGIN x = 
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/space_needed_after_macro.c.noopt.expected
+++ b/test/single_file/space_needed_after_macro.c.noopt.expected
@@ -1,5 +1,12 @@
 #define BEGIN x = 
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/space_needed_after_macro2.c.expected
+++ b/test/single_file/space_needed_after_macro2.c.expected
@@ -1,5 +1,12 @@
 #define BEGIN_ x = 
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/space_needed_after_macro2.c.noopt.expected
+++ b/test/single_file/space_needed_after_macro2.c.noopt.expected
@@ -1,5 +1,12 @@
 #define BEGIN_ x = 
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/static_assert_rewrite.cc.expected
+++ b/test/single_file/static_assert_rewrite.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/static_assert_rewrite.cc.noopt.expected
+++ b/test/single_file/static_assert_rewrite.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/static_constexpr_array.cc.expected
+++ b/test/single_file/static_constexpr_array.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/static_constexpr_array.cc.noopt.expected
+++ b/test/single_file/static_constexpr_array.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/static_initializer.cc.expected
+++ b/test/single_file/static_initializer.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/static_initializer.cc.noopt.expected
+++ b/test/single_file/static_initializer.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/struct_field_array_constant_size_rewrite.cc.expected
+++ b/test/single_file/struct_field_array_constant_size_rewrite.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/struct_field_array_constant_size_rewrite.cc.noopt.expected
+++ b/test/single_file/struct_field_array_constant_size_rewrite.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/structured_binding.cc.expected
+++ b/test/single_file/structured_binding.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/structured_binding.cc.noopt.expected
+++ b/test/single_file/structured_binding.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/switch_cases1.c.expected
+++ b/test/single_file/switch_cases1.c.expected
@@ -1,5 +1,12 @@
 #include <stdio.h>
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/switch_cases1.c.noopt.expected
+++ b/test/single_file/switch_cases1.c.noopt.expected
@@ -1,5 +1,12 @@
 #include <stdio.h>
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/switch_cases2.c.expected
+++ b/test/single_file/switch_cases2.c.expected
@@ -1,5 +1,12 @@
 #include <stdio.h>
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/switch_cases2.c.noopt.expected
+++ b/test/single_file/switch_cases2.c.noopt.expected
@@ -1,5 +1,12 @@
 #include <stdio.h>
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/template.cc.expected
+++ b/test/single_file/template.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/template.cc.noopt.expected
+++ b/test/single_file/template.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/template_instantiation.cc.expected
+++ b/test/single_file/template_instantiation.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/template_instantiation.cc.noopt.expected
+++ b/test/single_file/template_instantiation.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/typedef.c.noopt.expected
+++ b/test/single_file/typedef.c.noopt.expected
@@ -2,6 +2,13 @@ typedef struct S {
   int x;
 } SomeS;
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/typedef.cc.noopt.expected
+++ b/test/single_file/typedef.cc.noopt.expected
@@ -2,6 +2,13 @@ typedef struct S {
   int x;
 } SomeS;
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/unary.c.expected
+++ b/test/single_file/unary.c.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/unary.c.noopt.expected
+++ b/test/single_file/unary.c.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/unary.cc.expected
+++ b/test/single_file/unary.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/unary.cc.noopt.expected
+++ b/test/single_file/unary.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/unary_logical_not.c.expected
+++ b/test/single_file/unary_logical_not.c.expected
@@ -1,5 +1,12 @@
 #include <stdbool.h>
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/unary_logical_not.c.noopt.expected
+++ b/test/single_file/unary_logical_not.c.noopt.expected
@@ -1,5 +1,12 @@
 #include <stdbool.h>
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/unary_logical_not.cc.expected
+++ b/test/single_file/unary_logical_not.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/unary_logical_not.cc.noopt.expected
+++ b/test/single_file/unary_logical_not.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/unary_minus.c.expected
+++ b/test/single_file/unary_minus.c.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/unary_minus.c.noopt.expected
+++ b/test/single_file/unary_minus.c.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/unary_minus.cc.expected
+++ b/test/single_file/unary_minus.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/unary_minus.cc.noopt.expected
+++ b/test/single_file/unary_minus.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/unary_operator_opt.c.expected
+++ b/test/single_file/unary_operator_opt.c.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/unary_operator_opt.c.noopt.expected
+++ b/test/single_file/unary_operator_opt.c.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/unsigned_int.c.expected
+++ b/test/single_file/unsigned_int.c.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/unsigned_int.c.noopt.expected
+++ b/test/single_file/unsigned_int.c.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/unsigned_int.cc.expected
+++ b/test/single_file/unsigned_int.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/unsigned_int.cc.noopt.expected
+++ b/test/single_file/unsigned_int.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/user_defined_literals.cc.expected
+++ b/test/single_file/user_defined_literals.cc.expected
@@ -1,6 +1,13 @@
 #include <cstdint>
 
 // Number wraps integer, enforcing explicit casting
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/user_defined_literals.cc.noopt.expected
+++ b/test/single_file/user_defined_literals.cc.noopt.expected
@@ -1,6 +1,13 @@
 #include <cstdint>
 
 // Number wraps integer, enforcing explicit casting
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/using.cc.noopt.expected
+++ b/test/single_file/using.cc.noopt.expected
@@ -1,5 +1,12 @@
 using blah = int;
 
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/volatile.c.expected
+++ b/test/single_file/volatile.c.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/volatile.c.noopt.expected
+++ b/test/single_file/volatile.c.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/single_file/volatile.cc.expected
+++ b/test/single_file/volatile.cc.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>

--- a/test/single_file/volatile.cc.noopt.expected
+++ b/test/single_file/volatile.cc.noopt.expected
@@ -1,3 +1,10 @@
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
 #include <cinttypes>
 #include <cstddef>
 #include <functional>


### PR DESCRIPTION
Adds support for the user to specify, via a placeholder function, where the Dredd prelude should be inserted.

Related issue: #322.