### PR TITLE
Fix for issue with casts and initializer lists

### DIFF
--- a/src/libdredd/include/libdredd/mutation_replace_expr.h
+++ b/src/libdredd/include/libdredd/mutation_replace_expr.h
@@ -159,6 +159,14 @@ class MutationReplaceExpr : public Mutation {
       int& mutation_id_offset,
       protobufs::MutationReplaceExpr& protobuf_message);
 
+  // Determines whether the given expression is the child of both an implicit
+  // cast expression and an initializer list expression. In the presence of
+  // templates, such an expression may have more than two parents, because it
+  // may have the initializer list for the non-instantiated template as a
+  // parent, as well as the initializer list for the instantiated template.
+  static bool IsSubjectToImplicitCastInInitializerList(
+      const clang::Expr& expr, clang::ASTContext& ast_context);
+
   const clang::Expr* expr_;
   InfoForSourceRange info_for_source_range_;
 };

--- a/test/single_file/initializer_list_with_templates.cc
+++ b/test/single_file/initializer_list_with_templates.cc
@@ -1,0 +1,16 @@
+#include <memory>
+class a {
+public:
+  a(int);
+  virtual void b();
+};
+template <typename> class c : a {
+  using a::a;
+  void b() {
+    struct {
+      short d;
+    } e{0};
+  }
+};
+
+void f() { std::make_shared<c<int>>(2); }

--- a/test/single_file/initializer_list_with_templates.cc.expected
+++ b/test/single_file/initializer_list_with_templates.cc.expected
@@ -1,0 +1,84 @@
+#include <memory>
+class a {
+public:
+  a(int);
+  virtual void b();
+};
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
+#include <cinttypes>
+#include <cstddef>
+#include <functional>
+#include <string>
+
+
+#ifdef _MSC_VER
+#define thread_local __declspec(thread)
+#elif __APPLE__
+#define thread_local __thread
+#endif
+
+static thread_local bool __dredd_some_mutation_enabled = true;
+static bool __dredd_enabled_mutation(int local_mutation_id) {
+  static thread_local bool initialized = false;
+  static thread_local uint64_t enabled_bitset[1];
+  if (!initialized) {
+    bool some_mutation_enabled = false;
+    const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
+    if (dredd_environment_variable != nullptr) {
+      std::string contents(dredd_environment_variable);
+      while (true) {
+        size_t pos = contents.find(",");
+        std::string token = (pos == std::string::npos ? contents : contents.substr(0, pos));
+        if (!token.empty()) {
+          int value = std::stoi(token);
+          int local_value = value - 0;
+          if (local_value >= 0 && local_value < 13) {
+            enabled_bitset[local_value / 64] |= (static_cast<uint64_t>(1) << (local_value % 64));
+            some_mutation_enabled = true;
+          }
+        }
+        if (pos == std::string::npos) {
+          break;
+        }
+        contents.erase(0, pos + 1);
+      }
+    }
+    initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
+  }
+  return (enabled_bitset[local_mutation_id / 64] & (static_cast<uint64_t>(1) << (local_mutation_id % 64))) != 0;
+}
+
+static int __dredd_replace_expr_int_zero(int arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return -1;
+  return arg;
+}
+
+static int __dredd_replace_expr_int_constant(int arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return ~(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return -(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return 0;
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return -1;
+  return arg;
+}
+
+template <typename> class c : a {
+  using a::a;
+  void b() {
+    struct {
+      short d;
+    } e{static_cast<short>(__dredd_replace_expr_int_zero(0, 0))};
+  }
+};
+
+void f() { if (!__dredd_enabled_mutation(12)) { std::make_shared<c<int>>(__dredd_replace_expr_int_constant(__dredd_replace_expr_int_constant(2, 2), 7)); } }

--- a/test/single_file/initializer_list_with_templates.cc.noopt.expected
+++ b/test/single_file/initializer_list_with_templates.cc.noopt.expected
@@ -1,0 +1,78 @@
+#include <memory>
+class a {
+public:
+  a(int);
+  virtual void b();
+};
+// DREDD PRELUDE START
+// If this has been inserted at an inappropriate place in a source file,
+// declare a placeholder function with the following signature to
+// mandate where the prelude should be placed:
+//
+// void __dredd_prelude_start();
+//
+#include <cinttypes>
+#include <cstddef>
+#include <functional>
+#include <string>
+
+
+#ifdef _MSC_VER
+#define thread_local __declspec(thread)
+#elif __APPLE__
+#define thread_local __thread
+#endif
+
+static thread_local bool __dredd_some_mutation_enabled = true;
+static bool __dredd_enabled_mutation(int local_mutation_id) {
+  static thread_local bool initialized = false;
+  static thread_local uint64_t enabled_bitset[1];
+  if (!initialized) {
+    bool some_mutation_enabled = false;
+    const char* dredd_environment_variable = std::getenv("DREDD_ENABLED_MUTATION");
+    if (dredd_environment_variable != nullptr) {
+      std::string contents(dredd_environment_variable);
+      while (true) {
+        size_t pos = contents.find(",");
+        std::string token = (pos == std::string::npos ? contents : contents.substr(0, pos));
+        if (!token.empty()) {
+          int value = std::stoi(token);
+          int local_value = value - 0;
+          if (local_value >= 0 && local_value < 19) {
+            enabled_bitset[local_value / 64] |= (static_cast<uint64_t>(1) << (local_value % 64));
+            some_mutation_enabled = true;
+          }
+        }
+        if (pos == std::string::npos) {
+          break;
+        }
+        contents.erase(0, pos + 1);
+      }
+    }
+    initialized = true;
+    __dredd_some_mutation_enabled = some_mutation_enabled;
+  }
+  return (enabled_bitset[local_mutation_id / 64] & (static_cast<uint64_t>(1) << (local_mutation_id % 64))) != 0;
+}
+
+static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
+  if (!__dredd_some_mutation_enabled) return arg;
+  if (__dredd_enabled_mutation(local_mutation_id + 0)) return !(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 1)) return ~(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 2)) return -(arg);
+  if (__dredd_enabled_mutation(local_mutation_id + 3)) return 0;
+  if (__dredd_enabled_mutation(local_mutation_id + 4)) return 1;
+  if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
+  return arg;
+}
+
+template <typename> class c : a {
+  using a::a;
+  void b() {
+    struct {
+      short d;
+    } e{static_cast<short>(__dredd_replace_expr_int(0, 0))};
+  }
+};
+
+void f() { if (!__dredd_enabled_mutation(18)) { std::make_shared<c<int>>(__dredd_replace_expr_int(__dredd_replace_expr_int(2, 6), 12)); } }


### PR DESCRIPTION
Fixes a problem where an explicit cast was not being added to a mutated expression in an initializer list where (after mutation) it is required. The logic to handle this was present, but was designed to expect the parents of the relevant AST node to have a specific order. This change generalises the logic to allow for multiple initializer list parents, because in the presence of templates a node may have two initializer list parents: one for the uninstantated version of the initializer list and the other for the instantiated version.

Fixes #321.