### PR TITLE
Refactor options and add option for showing AST node types

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,15 @@ The signature of this prototype is:
 void __dredd_prelude_start();
 ```
 
+### Debugging Dredd
+
+If you are surprised at the mutations that Dredd is applying and believe they may be incorrect, the following options may be useful in debugging Dredd:
+
+- `--dump-asts`: this causes Dredd to dump the Clang abstract syntax tree for each translation unit that it processes.
+
+- `--show-ast-node-types`: this causes Dredd to insert, as a source code comment in the mutated code, the name of the type of AST node associated with each statement or expression that is mutated.
+Each comment is placed right after the name of the associated mutator function.
+
 ## Planned features
 
 See [planned feature

--- a/src/libdredd/CMakeLists.txt
+++ b/src/libdredd/CMakeLists.txt
@@ -39,6 +39,7 @@ add_library(
   include/libdredd/mutation_replace_binary_operator.h
   include/libdredd/mutation_replace_expr.h
   include/libdredd/mutation_replace_unary_operator.h
+  include/libdredd/options.h
   include/libdredd/new_mutate_frontend_action_factory.h
   include/libdredd/protobufs/dredd_protobufs.h
   include/libdredd/util.h

--- a/src/libdredd/include/libdredd/mutation.h
+++ b/src/libdredd/include/libdredd/mutation.h
@@ -21,6 +21,7 @@
 #include "clang/AST/ASTContext.h"
 #include "clang/Lex/Preprocessor.h"
 #include "clang/Rewrite/Core/Rewriter.h"
+#include "libdredd/options.h"
 #include "libdredd/protobufs/dredd_protobufs.h"
 
 namespace dredd {
@@ -50,8 +51,7 @@ class Mutation {
   // avoiding redundant repeat declarations.
   virtual protobufs::MutationGroup Apply(
       clang::ASTContext& ast_context, const clang::Preprocessor& preprocessor,
-      bool optimise_mutations, bool only_track_mutant_coverage,
-      int first_mutation_id_in_file, int& mutation_id,
+      const Options& options, int first_mutation_id_in_file, int& mutation_id,
       clang::Rewriter& rewriter,
       std::unordered_set<std::string>& dredd_declarations) const = 0;
 };

--- a/src/libdredd/include/libdredd/mutation_remove_stmt.h
+++ b/src/libdredd/include/libdredd/mutation_remove_stmt.h
@@ -24,6 +24,7 @@
 #include "clang/Lex/Preprocessor.h"
 #include "clang/Rewrite/Core/Rewriter.h"
 #include "libdredd/mutation.h"
+#include "libdredd/options.h"
 #include "libdredd/protobufs/dredd_protobufs.h"
 #include "libdredd/util.h"
 
@@ -37,8 +38,7 @@ class MutationRemoveStmt : public Mutation {
 
   protobufs::MutationGroup Apply(
       clang::ASTContext& ast_context, const clang::Preprocessor& preprocessor,
-      bool optimise_mutations, bool only_track_mutant_coverage,
-      int first_mutation_id_in_file, int& mutation_id,
+      const Options& options, int first_mutation_id_in_file, int& mutation_id,
       clang::Rewriter& rewriter,
       std::unordered_set<std::string>& dredd_declarations) const override;
 

--- a/src/libdredd/include/libdredd/mutation_replace_binary_operator.h
+++ b/src/libdredd/include/libdredd/mutation_replace_binary_operator.h
@@ -26,6 +26,7 @@
 #include "clang/Lex/Preprocessor.h"
 #include "clang/Rewrite/Core/Rewriter.h"
 #include "libdredd/mutation.h"
+#include "libdredd/options.h"
 #include "libdredd/protobufs/dredd_protobufs.h"
 #include "libdredd/util.h"
 
@@ -39,8 +40,7 @@ class MutationReplaceBinaryOperator : public Mutation {
 
   protobufs::MutationGroup Apply(
       clang::ASTContext& ast_context, const clang::Preprocessor& preprocessor,
-      bool optimise_mutations, bool only_track_mutant_coverage,
-      int first_mutation_id_in_file, int& mutation_id,
+      const Options& options, int first_mutation_id_in_file, int& mutation_id,
       clang::Rewriter& rewriter,
       std::unordered_set<std::string>& dredd_declarations) const override;
 
@@ -57,6 +57,7 @@ class MutationReplaceBinaryOperator : public Mutation {
                        clang::ASTContext& ast_context,
                        const clang::Preprocessor& preprocessor,
                        int first_mutation_id_in_file, int mutation_id,
+                       bool show_ast_node_types,
                        clang::Rewriter& rewriter) const;
 
   std::string GetFunctionName(bool optimise_mutations,

--- a/src/libdredd/include/libdredd/mutation_replace_expr.h
+++ b/src/libdredd/include/libdredd/mutation_replace_expr.h
@@ -25,6 +25,7 @@
 #include "clang/Lex/Preprocessor.h"
 #include "clang/Rewrite/Core/Rewriter.h"
 #include "libdredd/mutation.h"
+#include "libdredd/options.h"
 #include "libdredd/protobufs/dredd_protobufs.h"
 #include "libdredd/util.h"
 
@@ -38,8 +39,7 @@ class MutationReplaceExpr : public Mutation {
 
   protobufs::MutationGroup Apply(
       clang::ASTContext& ast_context, const clang::Preprocessor& preprocessor,
-      bool optimise_mutations, bool only_track_mutant_coverage,
-      int first_mutation_id_in_file, int& mutation_id,
+      const Options& options, int first_mutation_id_in_file, int& mutation_id,
       clang::Rewriter& rewriter,
       std::unordered_set<std::string>& dredd_declarations) const override;
 
@@ -152,6 +152,7 @@ class MutationReplaceExpr : public Mutation {
                                    int local_mutation_id,
                                    clang::ASTContext& ast_context,
                                    const clang::Preprocessor& preprocessor,
+                                   bool show_ast_node_types,
                                    clang::Rewriter& rewriter) const;
 
   static void AddMutationInstance(

--- a/src/libdredd/include/libdredd/mutation_replace_unary_operator.h
+++ b/src/libdredd/include/libdredd/mutation_replace_unary_operator.h
@@ -25,6 +25,7 @@
 #include "clang/Lex/Preprocessor.h"
 #include "clang/Rewrite/Core/Rewriter.h"
 #include "libdredd/mutation.h"
+#include "libdredd/options.h"
 #include "libdredd/protobufs/dredd_protobufs.h"
 #include "libdredd/util.h"
 
@@ -38,8 +39,7 @@ class MutationReplaceUnaryOperator : public Mutation {
 
   protobufs::MutationGroup Apply(
       clang::ASTContext& ast_context, const clang::Preprocessor& preprocessor,
-      bool optimise_mutations, bool only_track_mutant_coverage,
-      int first_mutation_id_in_file, int& mutation_id,
+      const Options& options, int first_mutation_id_in_file, int& mutation_id,
       clang::Rewriter& rewriter,
       std::unordered_set<std::string>& dredd_declarations) const override;
 

--- a/src/libdredd/include/libdredd/new_mutate_frontend_action_factory.h
+++ b/src/libdredd/include/libdredd/new_mutate_frontend_action_factory.h
@@ -19,14 +19,15 @@
 #include <optional>
 
 #include "clang/Tooling/Tooling.h"
+#include "libdredd/options.h"
 #include "libdredd/protobufs/dredd_protobufs.h"
 
 namespace dredd {
 
 std::unique_ptr<clang::tooling::FrontendActionFactory>
 NewMutateFrontendActionFactory(
-    bool optimise_mutations, bool dump_asts, bool only_track_mutant_coverage,
-    int& mutation_id, std::optional<protobufs::MutationInfo>& mutation_info);
+    const Options& options, int& mutation_id,
+    std::optional<protobufs::MutationInfo>& mutation_info);
 
 }  // namespace dredd
 

--- a/src/libdredd/include/libdredd/options.h
+++ b/src/libdredd/include/libdredd/options.h
@@ -44,19 +44,19 @@ class Options {
 
  private:
   // True if and only if Dredd's optimisations are enabled.
-  const bool optimise_mutations_;
+  bool optimise_mutations_;
 
   // True if and only if the AST being consumed should be dumped; useful for
   // debugging.
-  const bool dump_asts_;
+  bool dump_asts_;
 
   // True if and only if instrumentation should track whether mutants are
   // reached, rather than allowing mutants to be enabled.
-  const bool only_track_mutant_coverage_;
+  bool only_track_mutant_coverage_;
 
   // True if and only if a comment showing the type of each mutated AST node
   // should be emitted. This is useful for debugging.
-  const bool show_ast_node_types_;
+  bool show_ast_node_types_;
 };
 
 }  // namespace dredd

--- a/src/libdredd/include/libdredd/options.h
+++ b/src/libdredd/include/libdredd/options.h
@@ -1,0 +1,64 @@
+// Copyright 2024 The Dredd Project Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LIBDREDD_OPTIONS_H
+#define LIBDREDD_OPTIONS_H
+
+namespace dredd {
+
+class Options {
+ public:
+  Options(bool optimise_mutations, bool dump_asts,
+          bool only_track_mutant_coverage, bool show_ast_node_types)
+      : optimise_mutations_(optimise_mutations),
+        dump_asts_(dump_asts),
+        only_track_mutant_coverage_(only_track_mutant_coverage),
+        show_ast_node_types_(show_ast_node_types) {}
+
+  Options() : Options(true, false, false, false) {}
+
+  [[nodiscard]] bool GetOptimiseMutations() const {
+    return optimise_mutations_;
+  }
+
+  [[nodiscard]] bool GetOnlyTrackMutantCoverage() const {
+    return only_track_mutant_coverage_;
+  }
+
+  [[nodiscard]] bool GetDumpAsts() const { return dump_asts_; }
+
+  [[nodiscard]] bool GetShowAstNodeTypes() const {
+    return show_ast_node_types_;
+  }
+
+ private:
+  // True if and only if Dredd's optimisations are enabled.
+  const bool optimise_mutations_;
+
+  // True if and only if the AST being consumed should be dumped; useful for
+  // debugging.
+  const bool dump_asts_;
+
+  // True if and only if instrumentation should track whether mutants are
+  // reached, rather than allowing mutants to be enabled.
+  const bool only_track_mutant_coverage_;
+
+  // True if and only if a comment showing the type of each mutated AST node
+  // should be emitted. This is useful for debugging.
+  const bool show_ast_node_types_;
+};
+
+}  // namespace dredd
+
+#endif  // LIBDREDD_OPTIONS_H

--- a/src/libdredd/include_private/include/libdredd/mutate_ast_consumer.h
+++ b/src/libdredd/include_private/include/libdredd/mutate_ast_consumer.h
@@ -28,6 +28,7 @@
 #include "clang/Rewrite/Core/Rewriter.h"
 #include "libdredd/mutate_visitor.h"
 #include "libdredd/mutation_tree_node.h"
+#include "libdredd/options.h"
 #include "libdredd/protobufs/dredd_protobufs.h"
 
 namespace dredd {
@@ -35,15 +36,11 @@ namespace dredd {
 class MutateAstConsumer : public clang::ASTConsumer {
  public:
   MutateAstConsumer(const clang::CompilerInstance& compiler_instance,
-                    bool optimise_mutations, bool dump_ast,
-                    bool only_track_mutant_coverage, int& mutation_id,
+                    const Options& options, int& mutation_id,
                     std::optional<protobufs::MutationInfo>& mutation_info)
       : compiler_instance_(&compiler_instance),
-        optimise_mutations_(optimise_mutations),
-        dump_ast_(dump_ast),
-        only_track_mutant_coverage_(only_track_mutant_coverage),
-        visitor_(std::make_unique<MutateVisitor>(compiler_instance,
-                                                 optimise_mutations)),
+        options_(&options),
+        visitor_(std::make_unique<MutateVisitor>(compiler_instance, options)),
         mutation_id_(&mutation_id),
         mutation_info_(&mutation_info) {}
 
@@ -78,14 +75,7 @@ class MutateAstConsumer : public clang::ASTConsumer {
 
   const clang::CompilerInstance* compiler_instance_;
 
-  // True if and only if Dredd's optimisations are enabled.
-  bool optimise_mutations_;
-
-  // True if and only if the AST being consumed should be dumped; useful for
-  // debugging.
-  bool dump_ast_;
-
-  bool only_track_mutant_coverage_;
+  const Options* options_;
 
   std::unique_ptr<MutateVisitor> visitor_;
 

--- a/src/libdredd/include_private/include/libdredd/mutate_visitor.h
+++ b/src/libdredd/include_private/include/libdredd/mutate_visitor.h
@@ -38,13 +38,14 @@
 #include "clang/Frontend/CompilerInstance.h"
 #include "libdredd/mutation.h"
 #include "libdredd/mutation_tree_node.h"
+#include "libdredd/options.h"
 
 namespace dredd {
 
 class MutateVisitor : public clang::RecursiveASTVisitor<MutateVisitor> {
  public:
   MutateVisitor(const clang::CompilerInstance& compiler_instance,
-                bool optimise_mutations);
+                const Options& options);
 
   bool TraverseDecl(clang::Decl* decl);
 
@@ -248,7 +249,7 @@ class MutateVisitor : public clang::RecursiveASTVisitor<MutateVisitor> {
       const clang::Expr& expr);
 
   const clang::CompilerInstance* compiler_instance_;
-  bool optimise_mutations_;
+  const Options* options_;
 
   // The begin location of a special function that can be written to indicate
   // where the Dredd prelude should be inserted. This is useful to cater for

--- a/src/libdredd/src/mutate_ast_consumer.cc
+++ b/src/libdredd/src/mutate_ast_consumer.cc
@@ -70,7 +70,7 @@ void MutateAstConsumer::HandleTranslationUnit(clang::ASTContext& ast_context) {
     return;
   }
 
-  if (dump_ast_) {
+  if (options_->GetDumpAsts()) {
     llvm::errs() << "AST:\n";
     ast_context.getTranslationUnitDecl()->dump();
     llvm::errs() << "\n";
@@ -350,7 +350,7 @@ std::string MutateAstConsumer::GetMutantTrackingDreddPreludeCpp(
 std::string MutateAstConsumer::GetDreddPreludeCpp(
     int initial_mutation_id) const {
   return kDreddPreludeStartComment +
-         (only_track_mutant_coverage_
+         (options_->GetOnlyTrackMutantCoverage()
               ? GetMutantTrackingDreddPreludeCpp(initial_mutation_id)
               : GetRegularDreddPreludeCpp(initial_mutation_id));
 }
@@ -449,7 +449,7 @@ std::string MutateAstConsumer::GetMutantTrackingDreddPreludeC(
 
 std::string MutateAstConsumer::GetDreddPreludeC(int initial_mutation_id) const {
   return kDreddPreludeStartComment +
-         (only_track_mutant_coverage_
+         (options_->GetOnlyTrackMutantCoverage()
               ? GetMutantTrackingDreddPreludeC(initial_mutation_id)
               : GetRegularDreddPreludeC(initial_mutation_id));
 }
@@ -478,9 +478,8 @@ void MutateAstConsumer::ApplyMutations(
   for (const auto& mutation : dredd_mutation_tree_node.GetMutations()) {
     const int mutation_id_old = *mutation_id_;
     const auto mutation_group = mutation->Apply(
-        context, compiler_instance_->getPreprocessor(), optimise_mutations_,
-        only_track_mutant_coverage_, initial_mutation_id, *mutation_id_,
-        rewriter_, dredd_declarations);
+        context, compiler_instance_->getPreprocessor(), *options_,
+        initial_mutation_id, *mutation_id_, rewriter_, dredd_declarations);
     if (build_tree && *mutation_id_ > mutation_id_old) {
       // Only add the result of applying the mutation if it had an effect.
       *protobufs_mutation_tree_node.add_mutation_groups() = mutation_group;

--- a/src/libdredd/src/mutation_remove_stmt.cc
+++ b/src/libdredd/src/mutation_remove_stmt.cc
@@ -99,7 +99,7 @@ protobufs::MutationGroup MutationRemoveStmt::Apply(
   // |mutation_id|, into a file-local mutation id.
   const int local_mutation_id = mutation_id - first_mutation_id_in_file;
 
-  std::string ast_node_type_comment = "";
+  std::string ast_node_type_comment;
   if (options.GetShowAstNodeTypes()) {
     ast_node_type_comment =
         "/*" + std::string(stmt_->getStmtClassName()) + "*/";

--- a/src/libdreddtest/src/mutation_remove_stmt_test.cc
+++ b/src/libdreddtest/src/mutation_remove_stmt_test.cc
@@ -49,8 +49,8 @@ void TestRemoval(const std::string& original, const std::string& expected,
   int mutation_id = 0;
   std::unordered_set<std::string> dredd_declarations;
   mutation_supplier(ast_unit->getPreprocessor(), ast_unit->getASTContext())
-      .Apply(ast_unit->getASTContext(), ast_unit->getPreprocessor(), true,
-             false, 0, mutation_id, rewriter, dredd_declarations);
+      .Apply(ast_unit->getASTContext(), ast_unit->getPreprocessor(), Options(),
+             0, mutation_id, rewriter, dredd_declarations);
   ASSERT_EQ(1, mutation_id);
   ASSERT_EQ(0, dredd_declarations.size());
   const clang::RewriteBuffer* rewrite_buffer = rewriter.getRewriteBufferFor(

--- a/src/libdreddtest/src/mutation_replace_binary_operator_test.cc
+++ b/src/libdreddtest/src/mutation_replace_binary_operator_test.cc
@@ -61,8 +61,8 @@ void TestReplacement(const std::string& original, const std::string& expected,
   int mutation_id = 0;
   std::unordered_set<std::string> dredd_declarations;
   mutation.Apply(ast_unit->getASTContext(), ast_unit->getPreprocessor(),
-                 optimise_mutations, false, 0, mutation_id, rewriter,
-                 dredd_declarations);
+                 Options(optimise_mutations, false, false, false), 0,
+                 mutation_id, rewriter, dredd_declarations);
   ASSERT_EQ(num_replacements, mutation_id);
   ASSERT_EQ(1, dredd_declarations.size());
   ASSERT_EQ(expected_dredd_declaration, *dredd_declarations.begin());

--- a/src/libdreddtest/src/mutation_replace_expr_test.cc
+++ b/src/libdreddtest/src/mutation_replace_expr_test.cc
@@ -64,8 +64,8 @@ void TestReplacement(const std::string& original, const std::string& expected,
                            ast_unit->getLangOpts());
   int mutation_id = 0;
   std::unordered_set<std::string> dredd_declarations;
-  mutation.Apply(ast_unit->getASTContext(), ast_unit->getPreprocessor(), true,
-                 false, 0, mutation_id, rewriter, dredd_declarations);
+  mutation.Apply(ast_unit->getASTContext(), ast_unit->getPreprocessor(),
+                 Options(), 0, mutation_id, rewriter, dredd_declarations);
   ASSERT_EQ(num_replacements, mutation_id);
   ASSERT_EQ(1, dredd_declarations.size());
   ASSERT_EQ(expected_dredd_declaration, *dredd_declarations.begin());

--- a/src/libdreddtest/src/mutation_replace_unary_operator_test.cc
+++ b/src/libdreddtest/src/mutation_replace_unary_operator_test.cc
@@ -62,8 +62,8 @@ void TestReplacement(const std::string& original, const std::string& expected,
   int mutation_id = 0;
   std::unordered_set<std::string> dredd_declarations;
   mutation.Apply(ast_unit->getASTContext(), ast_unit->getPreprocessor(),
-                 optimise_mutations, false, 0, mutation_id, rewriter,
-                 dredd_declarations);
+                 Options(optimise_mutations, false, false, false), 0,
+                 mutation_id, rewriter, dredd_declarations);
   ASSERT_EQ(num_replacements, mutation_id);
   ASSERT_EQ(1, dredd_declarations.size());
   ASSERT_EQ(expected_dredd_declaration, *dredd_declarations.begin());


### PR DESCRIPTION
Represents the values of various Dredd command line switches in a class, and adds another switch to allow AST node types to be output as comments in the mutated code, which is useful for debugging.