### PR TITLE
Show pointer values when printing AST node types

### DIFF
--- a/src/libdredd/src/mutation_remove_stmt.cc
+++ b/src/libdredd/src/mutation_remove_stmt.cc
@@ -15,6 +15,7 @@
 #include "libdredd/mutation_remove_stmt.h"
 
 #include <cassert>
+#include <sstream>
 #include <string>
 #include <unordered_set>
 
@@ -101,8 +102,10 @@ protobufs::MutationGroup MutationRemoveStmt::Apply(
 
   std::string ast_node_type_comment;
   if (options.GetShowAstNodeTypes()) {
-    ast_node_type_comment =
-        "/*" + std::string(stmt_->getStmtClassName()) + "*/";
+    std::stringstream stringstream;
+    stringstream << stmt_;
+    ast_node_type_comment = "/*" + std::string(stmt_->getStmtClassName()) +
+                            " " + stringstream.str() + "*/";
   }
 
   if (options.GetOnlyTrackMutantCoverage()) {

--- a/src/libdredd/src/mutation_replace_binary_operator.cc
+++ b/src/libdredd/src/mutation_replace_binary_operator.cc
@@ -665,8 +665,10 @@ void MutationReplaceBinaryOperator::ReplaceOperator(
   // RHS operands.
   std::string lhs_prefix = new_function_name;
   if (show_ast_node_types) {
-    lhs_prefix +=
-        "/*" + std::string(binary_operator_->getStmtClassName()) + "*/";
+    std::stringstream stringstream;
+    stringstream << binary_operator_;
+    lhs_prefix += "/*" + std::string(binary_operator_->getStmtClassName()) +
+                  " " + stringstream.str() + "*/";
   }
   lhs_prefix += "(";
   std::string lhs_suffix;

--- a/src/libdredd/src/mutation_replace_expr.cc
+++ b/src/libdredd/src/mutation_replace_expr.cc
@@ -551,7 +551,10 @@ void MutationReplaceExpr::ReplaceExprWithFunctionCall(
   std::string prefix = new_function_name;
 
   if (show_ast_node_types) {
-    prefix += "/*" + std::string(expr_->getStmtClassName()) + "*/";
+    std::stringstream stringstream;
+    stringstream << expr_;
+    prefix += "/*" + std::string(expr_->getStmtClassName()) + " " +
+              stringstream.str() + "*/";
   }
 
   prefix += "(";

--- a/src/libdredd/src/mutation_replace_unary_operator.cc
+++ b/src/libdredd/src/mutation_replace_unary_operator.cc
@@ -419,7 +419,10 @@ protobufs::MutationGroup MutationReplaceUnaryOperator::Apply(
   // These record the text that should be inserted before and after the operand.
   std::string prefix = new_function_name;
   if (options.GetShowAstNodeTypes()) {
-    prefix += "/*" + std::string(unary_operator_->getStmtClassName()) + "*/";
+    std::stringstream stringstream;
+    stringstream << unary_operator_;
+    prefix += "/*" + std::string(unary_operator_->getStmtClassName()) + " " +
+              stringstream.str() + "*/";
   }
   prefix += "(";
   std::string suffix;


### PR DESCRIPTION
Having the raw pointer values available for AST nodes in inline comments makes it easier to match these comments to dumped AST nodes.