### PR TITLE
Insert prelude at start of source file by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,8 +382,8 @@ this feature in your project's build configuration.
 
 The mutations that Dredd applies rely on a number of function definitions that must be present at a suitable point in each file that Dredd mutates.
 These are referred to as the Dredd *prelude*.
-Dredd uses a heuristic to determine where to place its prelude.
-Sometimes this heuristic may not find an appropriate place, e.g. because of limitations or bugs in Clang's libTooling (see [this issue](https://github.com/mc-imperial/dredd/issues/322) for example).
+Dredd inserts prelude at the beginning of source files that may produce mutants.
+Sometimes this heuristic may not be appropriate, e.g. because a feature test macro must be defined before including any header files (see [this issue](https://github.com/mc-imperial/dredd/issues/215) for example).
 
 If you face a problem where Dredd-mutated code does not compile due to the Dredd prelude being injected in a bad place, you can declare a function prototype with void return type and no arguments called `__dredd_prelude_start` somewhere in your source file.
 Dredd will then insert its prelude right before this function prototype (regardless of whether this is a sensible place to insert the prelude).

--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ this feature in your project's build configuration.
 
 The mutations that Dredd applies rely on a number of function definitions that must be present at a suitable point in each file that Dredd mutates.
 These are referred to as the Dredd *prelude*.
-Dredd inserts prelude at the beginning of source files that may produce mutants.
+Dredd inserts its prelude at the beginning of each mutated source file.
 Sometimes this heuristic may not be appropriate, e.g. because a feature test macro must be defined before including any header files (see [this issue](https://github.com/mc-imperial/dredd/issues/215) for example).
 
 If you face a problem where Dredd-mutated code does not compile due to the Dredd prelude being injected in a bad place, you can declare a function prototype with void return type and no arguments called `__dredd_prelude_start` somewhere in your source file.

--- a/src/libdredd/include_private/include/libdredd/mutate_visitor.h
+++ b/src/libdredd/include_private/include/libdredd/mutate_visitor.h
@@ -125,11 +125,6 @@ class MutateVisitor : public clang::RecursiveASTVisitor<MutateVisitor> {
     return dredd_prelude_start_location_.value();
   }
 
-  [[nodiscard]] clang::SourceLocation
-  GetStartLocationOfFirstFunctionInSourceFile() const {
-    return start_location_of_first_function_in_source_file_;
-  }
-
   // Yields the static assertions, whose expression need to be
   // rewritten.
   [[nodiscard]] const std::vector<const clang::StaticAssertDecl*>&
@@ -209,10 +204,6 @@ class MutateVisitor : public clang::RecursiveASTVisitor<MutateVisitor> {
   // this special case, so that it can be ignored.
   bool IsConversionOfEnumToConstructor(const clang::Expr& expr) const;
 
-  // It is safe to put Dredd's prelude before the first function we encounter in
-  // a file as Dredd only makes source code modifications inside functions.
-  void UpdateStartLocationOfFirstFunctionInSourceFile();
-
   // Adds details of a mutation that can be applied, and performs associated
   // bookkeeping.
   void AddMutation(std::unique_ptr<Mutation> mutation);
@@ -265,12 +256,6 @@ class MutateVisitor : public clang::RecursiveASTVisitor<MutateVisitor> {
   // cases where the heuristic that Dredd uses to insert its prelude would lead
   // to compilation problems.
   std::optional<clang::SourceLocation> dredd_prelude_start_location_;
-
-  // Records the start location of the very first function definition in the
-  // source file. Dredd's prelude will be placed before this if it is a valid
-  // source location, unless a special Dredd prelude starting function has been
-  // declared.
-  clang::SourceLocation start_location_of_first_function_in_source_file_;
 
   // Tracks the nest of declarations currently being traversed. Any new Dredd
   // functions will be put before the start of the current nest, which avoids

--- a/src/libdredd/src/mutate_ast_consumer.cc
+++ b/src/libdredd/src/mutate_ast_consumer.cc
@@ -168,10 +168,13 @@ void MutateAstConsumer::HandleTranslationUnit(clang::ASTContext& ast_context) {
             .getLimitedValue());
   }
 
+  auto& source_manager = ast_context.getSourceManager();
+  const clang::SourceLocation start_of_source_file =
+      source_manager.translateLineCol(source_manager.getMainFileID(), 1, 1);
   const clang::SourceLocation dredd_prelude_start_location =
       visitor_->HasDreddPreludeStartLocation()
           ? visitor_->GetDreddPreludeStartLocation()
-          : visitor_->GetStartLocationOfFirstFunctionInSourceFile();
+          : start_of_source_file;
   assert(dredd_prelude_start_location.isValid() &&
          "There is at least one mutation, therefore there must be at least one "
          "function.");

--- a/test/single_file/add_type_aliases.c.noopt.expected
+++ b/test/single_file/add_type_aliases.c.noopt.expected
@@ -1,6 +1,3 @@
-#include <inttypes.h>
-#include <stddef.h>
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -161,6 +158,9 @@ static int __dredd_replace_binary_operator_Add_arg1_int_arg2_int(int arg1, int a
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return arg2;
   return arg1 + arg2;
 }
+
+#include <inttypes.h>
+#include <stddef.h>
 
 int main() {
   unsigned a;

--- a/test/single_file/add_type_aliases.cc.noopt.expected
+++ b/test/single_file/add_type_aliases.cc.noopt.expected
@@ -1,6 +1,3 @@
-#include <cinttypes>
-#include <cstddef>
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -163,6 +160,9 @@ static int __dredd_replace_binary_operator_Add_arg1_int_arg2_int(int arg1, int a
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return arg2;
   return arg1 + arg2;
 }
+
+#include <cinttypes>
+#include <cstddef>
 
 int main() {
   unsigned a;

--- a/test/single_file/adl.cc.expected
+++ b/test/single_file/adl.cc.expected
@@ -1,14 +1,3 @@
-namespace bar {
-  void foo(int x);
-
-  enum {B = 1};
-
-  struct C {
-    operator int();
-    friend void baz(int x);
-  };
-}
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -58,6 +47,17 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
     __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return (enabled_bitset[local_mutation_id / 64] & (static_cast<uint64_t>(1) << (local_mutation_id % 64))) != 0;
+}
+
+namespace bar {
+  void foo(int x);
+
+  enum {B = 1};
+
+  struct C {
+    operator int();
+    friend void baz(int x);
+  };
 }
 
 void func() {

--- a/test/single_file/adl.cc.noopt.expected
+++ b/test/single_file/adl.cc.noopt.expected
@@ -1,14 +1,3 @@
-namespace bar {
-  void foo(int x);
-
-  enum {B = 1};
-
-  struct C {
-    operator int();
-    friend void baz(int x);
-  };
-}
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -58,6 +47,17 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
     __dredd_some_mutation_enabled = some_mutation_enabled;
   }
   return (enabled_bitset[local_mutation_id / 64] & (static_cast<uint64_t>(1) << (local_mutation_id % 64))) != 0;
+}
+
+namespace bar {
+  void foo(int x);
+
+  enum {B = 1};
+
+  struct C {
+    operator int();
+    friend void baz(int x);
+  };
 }
 
 void func() {

--- a/test/single_file/bitfield.c.expected
+++ b/test/single_file/bitfield.c.expected
@@ -1,8 +1,3 @@
-struct S {
-  int a : 3;
-  int b : 3;
-};
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -69,6 +64,11 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
   return arg;
 }
+
+struct S {
+  int a : 3;
+  int b : 3;
+};
 
 void foo() {
   struct S myS;

--- a/test/single_file/bitfield.c.noopt.expected
+++ b/test/single_file/bitfield.c.noopt.expected
@@ -1,8 +1,3 @@
-struct S {
-  int a : 3;
-  int b : 3;
-};
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -70,6 +65,11 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
   return arg;
 }
+
+struct S {
+  int a : 3;
+  int b : 3;
+};
 
 void foo() {
   struct S myS;

--- a/test/single_file/bitfield.cc.expected
+++ b/test/single_file/bitfield.cc.expected
@@ -1,8 +1,3 @@
-struct S {
-  int a : 3;
-  int b : 3;
-};
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -71,6 +66,11 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
   return arg;
 }
+
+struct S {
+  int a : 3;
+  int b : 3;
+};
 
 void foo() {
   S myS;

--- a/test/single_file/bitfield.cc.noopt.expected
+++ b/test/single_file/bitfield.cc.noopt.expected
@@ -1,8 +1,3 @@
-struct S {
-  int a : 3;
-  int b : 3;
-};
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -83,6 +78,11 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
   return arg;
 }
+
+struct S {
+  int a : 3;
+  int b : 3;
+};
 
 void foo() {
   S myS;

--- a/test/single_file/bitfield_reference_passing.cc.expected
+++ b/test/single_file/bitfield_reference_passing.cc.expected
@@ -1,9 +1,3 @@
-template<typename T> void bloop(T& x) { }
-
-struct foo {
-  int b : 2;
-};
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -54,6 +48,12 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   }
   return (enabled_bitset[local_mutation_id / 64] & (static_cast<uint64_t>(1) << (local_mutation_id % 64))) != 0;
 }
+
+template<typename T> void bloop(T& x) { }
+
+struct foo {
+  int b : 2;
+};
 
 int main() {
   const foo d = foo();

--- a/test/single_file/bitfield_reference_passing.cc.noopt.expected
+++ b/test/single_file/bitfield_reference_passing.cc.noopt.expected
@@ -1,9 +1,3 @@
-template<typename T> void bloop(T& x) { }
-
-struct foo {
-  int b : 2;
-};
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -54,6 +48,12 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   }
   return (enabled_bitset[local_mutation_id / 64] & (static_cast<uint64_t>(1) << (local_mutation_id % 64))) != 0;
 }
+
+template<typename T> void bloop(T& x) { }
+
+struct foo {
+  int b : 2;
+};
 
 int main() {
   const foo d = foo();

--- a/test/single_file/boolean_not_insertion_optimisation.c.expected
+++ b/test/single_file/boolean_not_insertion_optimisation.c.expected
@@ -1,5 +1,3 @@
-#include <stdbool.h>
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -80,6 +78,8 @@ static int __dredd_replace_binary_operator_LAnd_arg1_int_arg2_int_rhs_zero_lhs_o
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return 1;
   return arg;
 }
+#include <stdbool.h>
+
 int main() {
   int x = __dredd_replace_expr_int_zero(__dredd_replace_binary_operator_LAnd_arg1_int_arg2_int_rhs_zero_lhs_one_outer(__dredd_replace_binary_operator_LAnd_arg1_int_arg2_int_rhs_zero_lhs_one_lhs(__dredd_replace_expr_int_one(1, 0), 5) && __dredd_replace_binary_operator_LAnd_arg1_int_arg2_int_rhs_zero_lhs_one_rhs(__dredd_replace_expr_int_zero(0, 3), 5), 5), 8);
 }

--- a/test/single_file/boolean_not_insertion_optimisation.c.noopt.expected
+++ b/test/single_file/boolean_not_insertion_optimisation.c.noopt.expected
@@ -1,5 +1,3 @@
-#include <stdbool.h>
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -76,6 +74,8 @@ static int __dredd_replace_binary_operator_LAnd_arg1_int_arg2_int_lhs(int arg, i
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return 1;
   return arg;
 }
+#include <stdbool.h>
+
 int main() {
   int x = __dredd_replace_expr_int(__dredd_replace_binary_operator_LAnd_arg1_int_arg2_int_outer(__dredd_replace_binary_operator_LAnd_arg1_int_arg2_int_lhs(__dredd_replace_expr_int(1, 0), 12) && __dredd_replace_binary_operator_LAnd_arg1_int_arg2_int_rhs(__dredd_replace_expr_int(0, 6), 12), 12), 15);
 }

--- a/test/single_file/comment.cc.expected
+++ b/test/single_file/comment.cc.expected
@@ -1,5 +1,3 @@
-void g();
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -56,6 +54,8 @@ static bool __dredd_replace_expr_bool_true(bool arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return false;
   return arg;
 }
+
+void g();
 
 void f()
 {

--- a/test/single_file/comment.cc.noopt.expected
+++ b/test/single_file/comment.cc.noopt.expected
@@ -1,5 +1,3 @@
-void g();
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -58,6 +56,8 @@ static bool __dredd_replace_expr_bool(bool arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return false;
   return arg;
 }
+
+void g();
 
 void f()
 {

--- a/test/single_file/comment_at_start_of_file.cc.expected
+++ b/test/single_file/comment_at_start_of_file.cc.expected
@@ -1,5 +1,3 @@
-// Hello
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -60,6 +58,8 @@ static int __dredd_replace_expr_int_constant(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 4)) return -1;
   return arg;
 }
+
+// Hello
 
 int main() {
   if (!__dredd_enabled_mutation(5)) { return __dredd_replace_expr_int_constant(42, 0); }

--- a/test/single_file/comment_at_start_of_file.cc.noopt.expected
+++ b/test/single_file/comment_at_start_of_file.cc.noopt.expected
@@ -1,5 +1,3 @@
-// Hello
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -61,6 +59,8 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
   return arg;
 }
+
+// Hello
 
 int main() {
   if (!__dredd_enabled_mutation(6)) { return __dredd_replace_expr_int(42, 0); }

--- a/test/single_file/const_expr_function.cc.expected
+++ b/test/single_file/const_expr_function.cc.expected
@@ -1,5 +1,3 @@
-constexpr int Max(int a, int b) { return a > b ? a : b; }
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -60,6 +58,8 @@ static int __dredd_replace_expr_int_constant(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 4)) return -1;
   return arg;
 }
+
+constexpr int Max(int a, int b) { return a > b ? a : b; }
 
 int main() {
   if (!__dredd_enabled_mutation(10)) { Max(__dredd_replace_expr_int_constant(5, 0),__dredd_replace_expr_int_constant(4, 5)); }

--- a/test/single_file/const_expr_function.cc.noopt.expected
+++ b/test/single_file/const_expr_function.cc.noopt.expected
@@ -1,5 +1,3 @@
-constexpr int Max(int a, int b) { return a > b ? a : b; }
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -72,6 +70,8 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
   return arg;
 }
+
+constexpr int Max(int a, int b) { return a > b ? a : b; }
 
 int main() {
   if (!__dredd_enabled_mutation(18)) { __dredd_replace_expr_int([&]() -> int { return Max(__dredd_replace_expr_int(5, 0),__dredd_replace_expr_int(4, 6)); }, 12); }

--- a/test/single_file/const_expr_function_call.cc.expected
+++ b/test/single_file/const_expr_function_call.cc.expected
@@ -1,5 +1,3 @@
-constexpr int Max(int a, int b) { return a > b ? a : b; }
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -70,6 +68,8 @@ static int __dredd_replace_expr_int_constant(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 4)) return -1;
   return arg;
 }
+
+constexpr int Max(int a, int b) { return a > b ? a : b; }
 
 int foo() {
   if (!__dredd_enabled_mutation(15)) { return __dredd_replace_expr_int_constant([&]() -> int { return Max(__dredd_replace_expr_int_constant(5, 0),__dredd_replace_expr_int_constant(4, 5)); }, 10); }

--- a/test/single_file/const_expr_function_call.cc.noopt.expected
+++ b/test/single_file/const_expr_function_call.cc.noopt.expected
@@ -1,5 +1,3 @@
-constexpr int Max(int a, int b) { return a > b ? a : b; }
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -72,6 +70,8 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
   return arg;
 }
+
+constexpr int Max(int a, int b) { return a > b ? a : b; }
 
 int foo() {
   if (!__dredd_enabled_mutation(18)) { return __dredd_replace_expr_int([&]() -> int { return Max(__dredd_replace_expr_int(5, 0),__dredd_replace_expr_int(4, 6)); }, 12); }

--- a/test/single_file/constexpr_if1.cc.expected
+++ b/test/single_file/constexpr_if1.cc.expected
@@ -1,5 +1,3 @@
-#include <iostream>
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -50,6 +48,8 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   }
   return (enabled_bitset[local_mutation_id / 64] & (static_cast<uint64_t>(1) << (local_mutation_id % 64))) != 0;
 }
+
+#include <iostream>
 
 template <int a> void foo() {
   if (!__dredd_enabled_mutation(1)) { if constexpr (a) {

--- a/test/single_file/constexpr_if1.cc.noopt.expected
+++ b/test/single_file/constexpr_if1.cc.noopt.expected
@@ -1,5 +1,3 @@
-#include <iostream>
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -50,6 +48,8 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   }
   return (enabled_bitset[local_mutation_id / 64] & (static_cast<uint64_t>(1) << (local_mutation_id % 64))) != 0;
 }
+
+#include <iostream>
 
 template <int a> void foo() {
   if (!__dredd_enabled_mutation(1)) { if constexpr (a) {

--- a/test/single_file/construct_struct_from_enum_constant.cc.expected
+++ b/test/single_file/construct_struct_from_enum_constant.cc.expected
@@ -1,10 +1,3 @@
-struct foo {
-  foo(int) {};
-  operator int();
-};
-
-enum baz { bar };
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -68,6 +61,13 @@ static bool __dredd_replace_expr_bool_false(bool arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 0)) return true;
   return arg;
 }
+
+struct foo {
+  foo(int) {};
+  operator int();
+};
+
+enum baz { bar };
 
 int main() { 
   if (!__dredd_enabled_mutation(3)) { __dredd_replace_expr_bool_false(0, 0) ? foo(__dredd_replace_expr_int_zero(0, 1)) : baz::bar; }

--- a/test/single_file/construct_struct_from_enum_constant.cc.noopt.expected
+++ b/test/single_file/construct_struct_from_enum_constant.cc.noopt.expected
@@ -1,10 +1,3 @@
-struct foo {
-  foo(int) {};
-  operator int();
-};
-
-enum baz { bar };
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -74,6 +67,13 @@ static bool __dredd_replace_expr_bool(bool arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return false;
   return arg;
 }
+
+struct foo {
+  foo(int) {};
+  operator int();
+};
+
+enum baz { bar };
 
 int main() { 
   if (!__dredd_enabled_mutation(15)) { __dredd_replace_expr_bool(__dredd_replace_expr_int(0, 0), 6) ? foo(__dredd_replace_expr_int(0, 9)) : baz::bar; }

--- a/test/single_file/define_at_start_of_file.c.expected
+++ b/test/single_file/define_at_start_of_file.c.expected
@@ -1,6 +1,3 @@
-#define API
-API int func1();
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -57,5 +54,8 @@ static int __dredd_replace_expr_int_one(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return -1;
   return arg;
 }
+
+#define API
+API int func1();
 
 int main() { int a = __dredd_replace_expr_int_one(1, 0); }

--- a/test/single_file/define_at_start_of_file.c.noopt.expected
+++ b/test/single_file/define_at_start_of_file.c.noopt.expected
@@ -1,6 +1,3 @@
-#define API
-API int func1();
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -60,5 +57,8 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
   return arg;
 }
+
+#define API
+API int func1();
 
 int main() { int a = __dredd_replace_expr_int(1, 0); }

--- a/test/single_file/define_in_first_decl.c.expected
+++ b/test/single_file/define_in_first_decl.c.expected
@@ -1,5 +1,3 @@
-#define TYPE int
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -75,6 +73,8 @@ static int __dredd_replace_binary_operator_Add_arg1_int_arg2_int_lhs_one(int arg
   if (__dredd_enabled_mutation(local_mutation_id + 3)) return arg2;
   return arg1 + arg2;
 }
+
+#define TYPE int
 
 TYPE foo() {
   if (!__dredd_enabled_mutation(17)) { return __dredd_replace_expr_int_constant(__dredd_replace_binary_operator_Add_arg1_int_arg2_int_lhs_one(__dredd_replace_expr_int_one(1, 0) , __dredd_replace_expr_int_constant(2, 3), 8), 12); }

--- a/test/single_file/define_in_first_decl.c.noopt.expected
+++ b/test/single_file/define_in_first_decl.c.noopt.expected
@@ -1,5 +1,3 @@
-#define TYPE int
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -70,6 +68,8 @@ static int __dredd_replace_binary_operator_Add_arg1_int_arg2_int(int arg1, int a
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return arg2;
   return arg1 + arg2;
 }
+
+#define TYPE int
 
 TYPE foo() {
   if (!__dredd_enabled_mutation(24)) { return __dredd_replace_expr_int(__dredd_replace_binary_operator_Add_arg1_int_arg2_int(__dredd_replace_expr_int(1, 0) , __dredd_replace_expr_int(2, 6), 12), 18); }

--- a/test/single_file/define_in_first_decl.cc.expected
+++ b/test/single_file/define_in_first_decl.cc.expected
@@ -1,5 +1,3 @@
-#define TYPE int
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -77,6 +75,8 @@ static int __dredd_replace_binary_operator_Add_arg1_int_arg2_int_lhs_one(int arg
   if (__dredd_enabled_mutation(local_mutation_id + 3)) return arg2;
   return arg1 + arg2;
 }
+
+#define TYPE int
 
 TYPE foo() {
   if (!__dredd_enabled_mutation(17)) { return __dredd_replace_expr_int_constant(__dredd_replace_binary_operator_Add_arg1_int_arg2_int_lhs_one(__dredd_replace_expr_int_one(1, 0) , __dredd_replace_expr_int_constant(2, 3), 8), 12); }

--- a/test/single_file/define_in_first_decl.cc.noopt.expected
+++ b/test/single_file/define_in_first_decl.cc.noopt.expected
@@ -1,5 +1,3 @@
-#define TYPE int
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -72,6 +70,8 @@ static int __dredd_replace_binary_operator_Add_arg1_int_arg2_int(int arg1, int a
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return arg2;
   return arg1 + arg2;
 }
+
+#define TYPE int
 
 TYPE foo() {
   if (!__dredd_enabled_mutation(24)) { return __dredd_replace_expr_int(__dredd_replace_binary_operator_Add_arg1_int_arg2_int(__dredd_replace_expr_int(1, 0) , __dredd_replace_expr_int(2, 6), 12), 18); }

--- a/test/single_file/enum.c.noopt.expected
+++ b/test/single_file/enum.c.noopt.expected
@@ -1,8 +1,3 @@
-enum A {
-  X,
-  Y
-};
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -62,6 +57,11 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
   return arg;
 }
+
+enum A {
+  X,
+  Y
+};
 
 void foo() {
   enum A myA = __dredd_replace_expr_int(X, 0);

--- a/test/single_file/expr_macro.c.expected
+++ b/test/single_file/expr_macro.c.expected
@@ -1,7 +1,3 @@
-#define E (1, 2, 3)
-
-void foo(int, int, int);
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -50,6 +46,10 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   }
   return enabled_bitset[local_mutation_id / 64] & ((uint64_t) 1 << (local_mutation_id % 64));
 }
+
+#define E (1, 2, 3)
+
+void foo(int, int, int);
 
 int main() {
   if (!__dredd_enabled_mutation(0)) { foo E; }

--- a/test/single_file/expr_macro.c.noopt.expected
+++ b/test/single_file/expr_macro.c.noopt.expected
@@ -1,7 +1,3 @@
-#define E (1, 2, 3)
-
-void foo(int, int, int);
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -50,6 +46,10 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   }
   return enabled_bitset[local_mutation_id / 64] & ((uint64_t) 1 << (local_mutation_id % 64));
 }
+
+#define E (1, 2, 3)
+
+void foo(int, int, int);
 
 int main() {
   if (!__dredd_enabled_mutation(0)) { foo E; }

--- a/test/single_file/expr_macro.cc.expected
+++ b/test/single_file/expr_macro.cc.expected
@@ -1,7 +1,3 @@
-#define E (1, 2, 3)
-
-void foo(int, int, int);
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -52,6 +48,10 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   }
   return (enabled_bitset[local_mutation_id / 64] & (static_cast<uint64_t>(1) << (local_mutation_id % 64))) != 0;
 }
+
+#define E (1, 2, 3)
+
+void foo(int, int, int);
 
 int main() {
   if (!__dredd_enabled_mutation(0)) { foo E; }

--- a/test/single_file/expr_macro.cc.noopt.expected
+++ b/test/single_file/expr_macro.cc.noopt.expected
@@ -1,7 +1,3 @@
-#define E (1, 2, 3)
-
-void foo(int, int, int);
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -52,6 +48,10 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   }
   return (enabled_bitset[local_mutation_id / 64] & (static_cast<uint64_t>(1) << (local_mutation_id % 64))) != 0;
 }
+
+#define E (1, 2, 3)
+
+void foo(int, int, int);
 
 int main() {
   if (!__dredd_enabled_mutation(0)) { foo E; }

--- a/test/single_file/initializer_list.cc.expected
+++ b/test/single_file/initializer_list.cc.expected
@@ -1,12 +1,3 @@
-#include <cstddef>
-
-struct A {
-  size_t x;
-  size_t y;
-};
-
-void foo(A arg);
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -64,6 +55,15 @@ static int __dredd_replace_expr_int_zero(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 1)) return -1;
   return arg;
 }
+
+#include <cstddef>
+
+struct A {
+  size_t x;
+  size_t y;
+};
+
+void foo(A arg);
 
 void bar() {
   if (!__dredd_enabled_mutation(4)) { foo({static_cast<unsigned long>(__dredd_replace_expr_int_zero(0, 0)), static_cast<unsigned long>(__dredd_replace_expr_int_zero(0, 2))}); }

--- a/test/single_file/initializer_list.cc.noopt.expected
+++ b/test/single_file/initializer_list.cc.noopt.expected
@@ -1,12 +1,3 @@
-#include <cstddef>
-
-struct A {
-  size_t x;
-  size_t y;
-};
-
-void foo(A arg);
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -68,6 +59,15 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
   return arg;
 }
+
+#include <cstddef>
+
+struct A {
+  size_t x;
+  size_t y;
+};
+
+void foo(A arg);
 
 void bar() {
   if (!__dredd_enabled_mutation(12)) { foo({static_cast<unsigned long>(__dredd_replace_expr_int(0, 0)), static_cast<unsigned long>(__dredd_replace_expr_int(0, 6))}); }

--- a/test/single_file/initializer_list_long_to_short.cc.expected
+++ b/test/single_file/initializer_list_long_to_short.cc.expected
@@ -1,10 +1,3 @@
-#include <initializer_list>
-
-class foo {
-public:
-  foo(std::initializer_list<short>) {}
-};
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -65,6 +58,13 @@ static long __dredd_replace_expr_long_constant(long arg, int local_mutation_id) 
   if (__dredd_enabled_mutation(local_mutation_id + 4)) return -1;
   return arg;
 }
+
+#include <initializer_list>
+
+class foo {
+public:
+  foo(std::initializer_list<short>) {}
+};
 
 int main() { 
     if (!__dredd_enabled_mutation(5)) { foo{static_cast<short>(__dredd_replace_expr_long_constant((long) 2, 0))}; } 

--- a/test/single_file/initializer_list_long_to_short.cc.noopt.expected
+++ b/test/single_file/initializer_list_long_to_short.cc.noopt.expected
@@ -1,10 +1,3 @@
-#include <initializer_list>
-
-class foo {
-public:
-  foo(std::initializer_list<short>) {}
-};
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -77,6 +70,13 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
   return arg;
 }
+
+#include <initializer_list>
+
+class foo {
+public:
+  foo(std::initializer_list<short>) {}
+};
 
 int main() { 
     if (!__dredd_enabled_mutation(18)) { foo{static_cast<short>(__dredd_replace_expr_long((long) __dredd_replace_expr_long(__dredd_replace_expr_int(2, 0), 6), 12))}; } 

--- a/test/single_file/initializer_list_narrower.cc.expected
+++ b/test/single_file/initializer_list_narrower.cc.expected
@@ -1,10 +1,3 @@
-#include <initializer_list>
-
-class foo {
-public:
-  foo(std::initializer_list<unsigned int>) {}
-};
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -65,6 +58,13 @@ static int __dredd_replace_expr_int_constant(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 4)) return -1;
   return arg;
 }
+
+#include <initializer_list>
+
+class foo {
+public:
+  foo(std::initializer_list<unsigned int>) {}
+};
 
 int main() { 
     if (!__dredd_enabled_mutation(10)) { foo{static_cast<unsigned int>(__dredd_replace_expr_int_constant(+__dredd_replace_expr_int_constant(2, 0), 5))}; } 

--- a/test/single_file/initializer_list_narrower.cc.noopt.expected
+++ b/test/single_file/initializer_list_narrower.cc.noopt.expected
@@ -1,10 +1,3 @@
-#include <initializer_list>
-
-class foo {
-public:
-  foo(std::initializer_list<unsigned int>) {}
-};
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -66,6 +59,13 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
   return arg;
 }
+
+#include <initializer_list>
+
+class foo {
+public:
+  foo(std::initializer_list<unsigned int>) {}
+};
 
 int main() { 
     if (!__dredd_enabled_mutation(12)) { foo{static_cast<unsigned int>(__dredd_replace_expr_int(+__dredd_replace_expr_int(2, 0), 6))}; } 

--- a/test/single_file/initializer_list_narrower_nested.cc.expected
+++ b/test/single_file/initializer_list_narrower_nested.cc.expected
@@ -1,8 +1,3 @@
-struct foo {
-  short x;
-  short y;
-};
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -71,6 +66,11 @@ static int __dredd_replace_expr_int_constant(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 4)) return -1;
   return arg;
 }
+
+struct foo {
+  short x;
+  short y;
+};
 
 void baz() {
   foo bar[] = {{static_cast<short>(__dredd_replace_expr_int_one(1, 0)), static_cast<short>(__dredd_replace_expr_int_constant(2, 3))}};

--- a/test/single_file/initializer_list_narrower_nested.cc.noopt.expected
+++ b/test/single_file/initializer_list_narrower_nested.cc.noopt.expected
@@ -1,8 +1,3 @@
-struct foo {
-  short x;
-  short y;
-};
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -64,6 +59,11 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
   return arg;
 }
+
+struct foo {
+  short x;
+  short y;
+};
 
 void baz() {
   foo bar[] = {{static_cast<short>(__dredd_replace_expr_int(1, 0)), static_cast<short>(__dredd_replace_expr_int(2, 6))}};

--- a/test/single_file/initializer_list_parenthesis.cc.expected
+++ b/test/single_file/initializer_list_parenthesis.cc.expected
@@ -1,9 +1,3 @@
-struct foo {
-  short x;
-  short y;
-  short z;
-};
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -72,6 +66,12 @@ static int __dredd_replace_expr_int_constant(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 4)) return -1;
   return arg;
 }
+
+struct foo {
+  short x;
+  short y;
+  short z;
+};
 
 void baz() {
   foo bar = {static_cast<short>(__dredd_replace_expr_int_one(1, 0)), (static_cast<short>(__dredd_replace_expr_int_constant(2, 3))), (((static_cast<short>(__dredd_replace_expr_int_constant(3, 8)))))};

--- a/test/single_file/initializer_list_parenthesis.cc.noopt.expected
+++ b/test/single_file/initializer_list_parenthesis.cc.noopt.expected
@@ -1,9 +1,3 @@
-struct foo {
-  short x;
-  short y;
-  short z;
-};
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -65,6 +59,12 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
   return arg;
 }
+
+struct foo {
+  short x;
+  short y;
+  short z;
+};
 
 void baz() {
   foo bar = {static_cast<short>(__dredd_replace_expr_int(1, 0)), static_cast<short>(__dredd_replace_expr_int((static_cast<short>(__dredd_replace_expr_int(2, 6))), 12)), static_cast<short>(__dredd_replace_expr_int((static_cast<short>(__dredd_replace_expr_int((static_cast<short>(__dredd_replace_expr_int((static_cast<short>(__dredd_replace_expr_int(3, 18))), 24))), 30))), 36))};

--- a/test/single_file/initializer_list_with_templates.cc.expected
+++ b/test/single_file/initializer_list_with_templates.cc.expected
@@ -1,9 +1,3 @@
-#include <memory>
-class a {
-public:
-  a(int);
-  virtual void b();
-};
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -72,6 +66,12 @@ static int __dredd_replace_expr_int_constant(int arg, int local_mutation_id) {
   return arg;
 }
 
+#include <memory>
+class a {
+public:
+  a(int);
+  virtual void b();
+};
 template <typename> class c : a {
   using a::a;
   void b() {

--- a/test/single_file/initializer_list_with_templates.cc.noopt.expected
+++ b/test/single_file/initializer_list_with_templates.cc.noopt.expected
@@ -1,9 +1,3 @@
-#include <memory>
-class a {
-public:
-  a(int);
-  virtual void b();
-};
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -66,6 +60,12 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   return arg;
 }
 
+#include <memory>
+class a {
+public:
+  a(int);
+  virtual void b();
+};
 template <typename> class c : a {
   using a::a;
   void b() {

--- a/test/single_file/misc004.cc
+++ b/test/single_file/misc004.cc
@@ -2,6 +2,8 @@
 #  error test.h must be #included before system headers
 #endif
 
+void __dredd_prelude_start();
+
 int main() {
     int x = 1 + 2;
 }

--- a/test/single_file/misc004.cc.expected
+++ b/test/single_file/misc004.cc.expected
@@ -80,6 +80,8 @@ static int __dredd_replace_binary_operator_Add_arg1_int_arg2_int_lhs_one(int arg
   return arg1 + arg2;
 }
 
+void __dredd_prelude_start();
+
 int main() {
     int x = __dredd_replace_expr_int_constant(__dredd_replace_binary_operator_Add_arg1_int_arg2_int_lhs_one(__dredd_replace_expr_int_one(1, 0) , __dredd_replace_expr_int_constant(2, 3), 8), 12);
 }

--- a/test/single_file/misc004.cc.noopt.expected
+++ b/test/single_file/misc004.cc.noopt.expected
@@ -75,6 +75,8 @@ static int __dredd_replace_binary_operator_Add_arg1_int_arg2_int(int arg1, int a
   return arg1 + arg2;
 }
 
+void __dredd_prelude_start();
+
 int main() {
     int x = __dredd_replace_expr_int(__dredd_replace_binary_operator_Add_arg1_int_arg2_int(__dredd_replace_expr_int(1, 0) , __dredd_replace_expr_int(2, 6), 12), 18);
 }

--- a/test/single_file/new_expr_array_size.cc.expected
+++ b/test/single_file/new_expr_array_size.cc.expected
@@ -1,8 +1,3 @@
-class foo {
-public:
-  foo(int x) {}
-};
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -63,6 +58,11 @@ static int __dredd_replace_expr_int_constant(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 4)) return -1;
   return arg;
 }
+
+class foo {
+public:
+  foo(int x) {}
+};
 
 int main() { 
   if (!__dredd_enabled_mutation(10)) { new foo[2]{__dredd_replace_expr_int_constant(4, 0), __dredd_replace_expr_int_constant(5, 5)}; } 

--- a/test/single_file/new_expr_array_size.cc.noopt.expected
+++ b/test/single_file/new_expr_array_size.cc.noopt.expected
@@ -1,8 +1,3 @@
-class foo {
-public:
-  foo(int x) {}
-};
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -64,6 +59,11 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
   return arg;
 }
+
+class foo {
+public:
+  foo(int x) {}
+};
 
 int main() { 
   if (!__dredd_enabled_mutation(12)) { new foo[2]{__dredd_replace_expr_int(4, 0), __dredd_replace_expr_int(5, 6)}; } 

--- a/test/single_file/noreturn.cc.expected
+++ b/test/single_file/noreturn.cc.expected
@@ -1,6 +1,3 @@
-#include <cstdlib>
-#include <iostream>
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -51,6 +48,9 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   }
   return (enabled_bitset[local_mutation_id / 64] & (static_cast<uint64_t>(1) << (local_mutation_id % 64))) != 0;
 }
+
+#include <cstdlib>
+#include <iostream>
 
 [[noreturn]] static int foo() {
   if (!__dredd_enabled_mutation(0)) { std::cout << "Aborting\n"; }

--- a/test/single_file/noreturn.cc.noopt.expected
+++ b/test/single_file/noreturn.cc.noopt.expected
@@ -1,6 +1,3 @@
-#include <cstdlib>
-#include <iostream>
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -51,6 +48,9 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   }
   return (enabled_bitset[local_mutation_id / 64] & (static_cast<uint64_t>(1) << (local_mutation_id % 64))) != 0;
 }
+
+#include <cstdlib>
+#include <iostream>
 
 [[noreturn]] static int foo() {
   if (!__dredd_enabled_mutation(0)) { std::cout << "Aborting\n"; }

--- a/test/single_file/printing.c.expected
+++ b/test/single_file/printing.c.expected
@@ -1,5 +1,3 @@
-#include <stdio.h>
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -48,6 +46,8 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   }
   return enabled_bitset[local_mutation_id / 64] & ((uint64_t) 1 << (local_mutation_id % 64));
 }
+
+#include <stdio.h>
 
 int main() {
   if (!__dredd_enabled_mutation(0)) { printf("%s\n", "A\n"); }

--- a/test/single_file/printing.c.noopt.expected
+++ b/test/single_file/printing.c.noopt.expected
@@ -1,5 +1,3 @@
-#include <stdio.h>
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -59,6 +57,8 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
   return arg;
 }
+
+#include <stdio.h>
 
 int main() {
   if (!__dredd_enabled_mutation(6)) { __dredd_replace_expr_int(printf("%s\n", "A\n"), 0); }

--- a/test/single_file/printing.cc.expected
+++ b/test/single_file/printing.cc.expected
@@ -1,5 +1,3 @@
-#include <iostream>
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -50,6 +48,8 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   }
   return (enabled_bitset[local_mutation_id / 64] & (static_cast<uint64_t>(1) << (local_mutation_id % 64))) != 0;
 }
+
+#include <iostream>
 
 int main() {
   if (!__dredd_enabled_mutation(0)) { std::cout << "A\n"; }

--- a/test/single_file/printing.cc.noopt.expected
+++ b/test/single_file/printing.cc.noopt.expected
@@ -1,5 +1,3 @@
-#include <iostream>
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -50,6 +48,8 @@ static bool __dredd_enabled_mutation(int local_mutation_id) {
   }
   return (enabled_bitset[local_mutation_id / 64] & (static_cast<uint64_t>(1) << (local_mutation_id % 64))) != 0;
 }
+
+#include <iostream>
 
 int main() {
   if (!__dredd_enabled_mutation(0)) { std::cout << "A\n"; }

--- a/test/single_file/sizeof_template2.cc.expected
+++ b/test/single_file/sizeof_template2.cc.expected
@@ -1,5 +1,3 @@
-bool f(int);
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -69,6 +67,8 @@ static bool __dredd_replace_expr_bool(std::function<bool()> arg, int local_mutat
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return false;
   return arg();
 }
+
+bool f(int);
 
 template <typename a> struct b {
   bool c() { if (!__dredd_enabled_mutation(9)) { return __dredd_replace_expr_bool([&]() -> bool { return static_cast<bool>(f(__dredd_replace_expr_int(sizeof(a), 0))); }, 6); } }

--- a/test/single_file/sizeof_template2.cc.noopt.expected
+++ b/test/single_file/sizeof_template2.cc.noopt.expected
@@ -1,5 +1,3 @@
-bool f(int);
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -78,6 +76,8 @@ static bool __dredd_replace_expr_bool(std::function<bool()> arg, int local_mutat
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return false;
   return arg();
 }
+
+bool f(int);
 
 template <typename a> struct b {
   bool c() { if (!__dredd_enabled_mutation(13)) { return __dredd_replace_expr_bool([&]() -> bool { return static_cast<bool>(f(__dredd_replace_expr_int(__dredd_replace_expr_unsigned_long(sizeof(a), 0), 4))); }, 10); } }

--- a/test/single_file/space_needed_after_macro.c.expected
+++ b/test/single_file/space_needed_after_macro.c.expected
@@ -1,5 +1,3 @@
-#define BEGIN x = 
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -59,6 +57,8 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
   return arg;
 }
+
+#define BEGIN x = 
 
 int main() {
   int x, y;

--- a/test/single_file/space_needed_after_macro.c.noopt.expected
+++ b/test/single_file/space_needed_after_macro.c.noopt.expected
@@ -1,5 +1,3 @@
-#define BEGIN x = 
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -66,6 +64,8 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
   return arg;
 }
+
+#define BEGIN x = 
 
 int main() {
   int x, y;

--- a/test/single_file/space_needed_after_macro2.c.expected
+++ b/test/single_file/space_needed_after_macro2.c.expected
@@ -1,5 +1,3 @@
-#define BEGIN_ x = 
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -59,6 +57,8 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
   return arg;
 }
+
+#define BEGIN_ x = 
 
 int main() {
   int x, y;

--- a/test/single_file/space_needed_after_macro2.c.noopt.expected
+++ b/test/single_file/space_needed_after_macro2.c.noopt.expected
@@ -1,5 +1,3 @@
-#define BEGIN_ x = 
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -66,6 +64,8 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
   return arg;
 }
+
+#define BEGIN_ x = 
 
 int main() {
   int x, y;

--- a/test/single_file/switch_cases1.c.expected
+++ b/test/single_file/switch_cases1.c.expected
@@ -1,5 +1,3 @@
-#include <stdio.h>
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -76,6 +74,8 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
   return arg;
 }
+
+#include <stdio.h>
 
 int main() {
   int x = __dredd_replace_expr_int_constant(10, 0);

--- a/test/single_file/switch_cases1.c.noopt.expected
+++ b/test/single_file/switch_cases1.c.noopt.expected
@@ -1,5 +1,3 @@
-#include <stdio.h>
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -66,6 +64,8 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
   return arg;
 }
+
+#include <stdio.h>
 
 int main() {
   int x = __dredd_replace_expr_int(10, 0);

--- a/test/single_file/switch_cases2.c.expected
+++ b/test/single_file/switch_cases2.c.expected
@@ -1,5 +1,3 @@
-#include <stdio.h>
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -76,6 +74,8 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
   return arg;
 }
+
+#include <stdio.h>
 
 int main() {
   int x = __dredd_replace_expr_int_constant(10, 0);

--- a/test/single_file/switch_cases2.c.noopt.expected
+++ b/test/single_file/switch_cases2.c.noopt.expected
@@ -1,5 +1,3 @@
-#include <stdio.h>
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -66,6 +64,8 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
   return arg;
 }
+
+#include <stdio.h>
 
 int main() {
   int x = __dredd_replace_expr_int(10, 0);

--- a/test/single_file/template_instantiation_const_expr.cc.expected
+++ b/test/single_file/template_instantiation_const_expr.cc.expected
@@ -1,6 +1,3 @@
-template<typename T, int N>
-class bar {};
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -61,6 +58,9 @@ static int __dredd_replace_expr_int_constant(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 4)) return -1;
   return arg;
 }
+
+template<typename T, int N>
+class bar {};
 
 void foo() {
   const int count = __dredd_replace_expr_int_constant(42, 0);

--- a/test/single_file/template_instantiation_const_expr.cc.noopt.expected
+++ b/test/single_file/template_instantiation_const_expr.cc.noopt.expected
@@ -1,6 +1,3 @@
-template<typename T, int N>
-class bar {};
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -62,6 +59,9 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
   return arg;
 }
+
+template<typename T, int N>
+class bar {};
 
 void foo() {
   const int count = __dredd_replace_expr_int(42, 0);

--- a/test/single_file/template_instantiation_nested_const_expr.cc.expected
+++ b/test/single_file/template_instantiation_nested_const_expr.cc.expected
@@ -1,6 +1,3 @@
-template<typename T, int N>
-class bar {};
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -61,6 +58,9 @@ static int __dredd_replace_expr_int_constant(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 4)) return -1;
   return arg;
 }
+
+template<typename T, int N>
+class bar {};
 
 void foo() {
   const int count = __dredd_replace_expr_int_constant(42, 0);

--- a/test/single_file/template_instantiation_nested_const_expr.cc.noopt.expected
+++ b/test/single_file/template_instantiation_nested_const_expr.cc.noopt.expected
@@ -1,6 +1,3 @@
-template<typename T, int N>
-class bar {};
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -62,6 +59,9 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
   return arg;
 }
+
+template<typename T, int N>
+class bar {};
 
 void foo() {
   const int count = __dredd_replace_expr_int(42, 0);

--- a/test/single_file/typedef.c.noopt.expected
+++ b/test/single_file/typedef.c.noopt.expected
@@ -1,7 +1,3 @@
-typedef struct S {
-  int x;
-} SomeS;
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -72,6 +68,10 @@ static int __dredd_replace_binary_operator_Add_arg1_int_arg2_int(int arg1, int a
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return arg2;
   return arg1 + arg2;
 }
+
+typedef struct S {
+  int x;
+} SomeS;
 
 void foo() {
   if (!__dredd_enabled_mutation(24)) { __dredd_replace_expr_int(__dredd_replace_binary_operator_Add_arg1_int_arg2_int(__dredd_replace_expr_int(1, 0) , __dredd_replace_expr_int(2, 6), 12), 18); }

--- a/test/single_file/typedef.cc.noopt.expected
+++ b/test/single_file/typedef.cc.noopt.expected
@@ -1,7 +1,3 @@
-typedef struct S {
-  int x;
-} SomeS;
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -74,6 +70,10 @@ static int __dredd_replace_binary_operator_Add_arg1_int_arg2_int(int arg1, int a
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return arg2;
   return arg1 + arg2;
 }
+
+typedef struct S {
+  int x;
+} SomeS;
 
 void foo() {
   if (!__dredd_enabled_mutation(24)) { __dredd_replace_expr_int(__dredd_replace_binary_operator_Add_arg1_int_arg2_int(__dredd_replace_expr_int(1, 0) , __dredd_replace_expr_int(2, 6), 12), 18); }

--- a/test/single_file/unary_logical_not.c.expected
+++ b/test/single_file/unary_logical_not.c.expected
@@ -1,5 +1,3 @@
-#include <stdbool.h>
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -80,6 +78,8 @@ static bool __dredd_replace_expr_bool(bool arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return 0;
   return arg;
 }
+
+#include <stdbool.h>
 
 int main() {
   bool y = __dredd_replace_expr_bool_true(true, 0);

--- a/test/single_file/unary_logical_not.c.noopt.expected
+++ b/test/single_file/unary_logical_not.c.noopt.expected
@@ -1,5 +1,3 @@
-#include <stdbool.h>
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -75,6 +73,8 @@ static bool __dredd_replace_expr_bool(bool arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 2)) return 0;
   return arg;
 }
+
+#include <stdbool.h>
 
 int main() {
   bool y = __dredd_replace_expr_bool(__dredd_replace_expr_int(true, 0), 6);

--- a/test/single_file/user_defined_literals.cc.expected
+++ b/test/single_file/user_defined_literals.cc.expected
@@ -1,6 +1,3 @@
-#include <cstdint>
-
-// Number wraps integer, enforcing explicit casting
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -84,6 +81,9 @@ static int __dredd_replace_expr_int_zero(int arg, int local_mutation_id) {
   return arg;
 }
 
+#include <cstdint>
+
+// Number wraps integer, enforcing explicit casting
 struct Number {
     
     uint32_t value = {};

--- a/test/single_file/user_defined_literals.cc.noopt.expected
+++ b/test/single_file/user_defined_literals.cc.noopt.expected
@@ -1,6 +1,3 @@
-#include <cstdint>
-
-// Number wraps integer, enforcing explicit casting
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -88,6 +85,9 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   return arg;
 }
 
+#include <cstdint>
+
+// Number wraps integer, enforcing explicit casting
 struct Number {
     
     uint32_t value = {};

--- a/test/single_file/using.cc.noopt.expected
+++ b/test/single_file/using.cc.noopt.expected
@@ -1,5 +1,3 @@
-using blah = int;
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -72,6 +70,8 @@ static int __dredd_replace_binary_operator_Add_arg1_int_arg2_int(int arg1, int a
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return arg2;
   return arg1 + arg2;
 }
+
+using blah = int;
 
 void foo() {
   if (!__dredd_enabled_mutation(24)) { __dredd_replace_expr_int(__dredd_replace_binary_operator_Add_arg1_int_arg2_int(__dredd_replace_expr_int(1, 0) , __dredd_replace_expr_int(2, 6), 12), 18); }

--- a/test/single_file/vector_returns_temporary.cc.expected
+++ b/test/single_file/vector_returns_temporary.cc.expected
@@ -1,5 +1,3 @@
-#include <vector>
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -74,6 +72,8 @@ static unsigned int __dredd_replace_expr_unsigned_int(std::function<unsigned int
   if (__dredd_enabled_mutation(local_mutation_id + 3)) return 1;
   return arg();
 }
+
+#include <vector>
 
 std::vector<unsigned int> bar() {
     std::vector<unsigned int> res(__dredd_replace_expr_unsigned_long_constant(4, 0));

--- a/test/single_file/vector_returns_temporary.cc.noopt.expected
+++ b/test/single_file/vector_returns_temporary.cc.noopt.expected
@@ -1,5 +1,3 @@
-#include <vector>
-
 // DREDD PRELUDE START
 // If this has been inserted at an inappropriate place in a source file,
 // declare a placeholder function with the following signature to
@@ -79,6 +77,8 @@ static int __dredd_replace_expr_int(int arg, int local_mutation_id) {
   if (__dredd_enabled_mutation(local_mutation_id + 5)) return -1;
   return arg;
 }
+
+#include <vector>
 
 std::vector<unsigned int> bar() {
     std::vector<unsigned int> res(__dredd_replace_expr_unsigned_long(__dredd_replace_expr_int(4, 0), 6));


### PR DESCRIPTION
Dredd previously inserted the prelude before the first function to avoid
placing it before feature test macros or headers that must precede other
headers. However, this heuristic often fails in files with class methods
using the `override` modifier, which is common. We now insert the
prelude at the start of the file. In rare cases where the prelude must
follow feature test macros or specific headers, manual insertion of
`void __dredd_prelude_start();` will be required.

Fixes #333 .